### PR TITLE
[Security] Pin Sparkle to semantic version and fix typo in Rosetta2

### DIFF
--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -1020,8 +1020,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
-				branch = 2.x;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.6.0;
 			};
 		};
 		6E5967682A9A421800D64F70 /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {

--- a/Whisky.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Whisky.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "10089079d78380f130f96af5e7c1cfaca419c05af09feef934de813f8b0c2041",
   "pins" : [
     {
       "identity" : "progress.swift",
@@ -23,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "branch" : "2.x",
-        "revision" : "8de8db001ea3c781f5e2b1c9abe851209dd8c08a"
+        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
+        "version" : "2.8.1"
       }
     },
     {
@@ -46,5 +47,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/WhiskyKit/Sources/WhiskyKit/Utils/Rosetta2.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Utils/Rosetta2.swift
@@ -34,7 +34,7 @@ public class Rosetta2 {
         process.arguments = ["--install-rosetta", "--agree-to-license"]
         process.standardOutput = fileHandle
         process.standardError = fileHandle
-        fileHandle.writeApplicaitonInfo()
+        fileHandle.writeApplicationInfo()
         fileHandle.writeInfo(for: process)
 
         return try await withCheckedThrowingContinuation { continuation in


### PR DESCRIPTION
## Summary

This PR addresses Issue #6 by pinning the Sparkle dependency to a specific semantic version instead of floating on the `2.x` branch.

## Changes

### Security Fix: Sparkle Version Pinning
- Changed Sparkle dependency from branch-based (`2.x`) to semantic versioning (`upToNextMajorVersion` from `2.6.0`)
- This ensures reproducible builds and prevents supply chain attacks via the auto-update framework

### Bug Fix: Typo in Rosetta2.swift
- Fixed typo: `writeApplicaitonInfo` → `writeApplicationInfo`
- This was a pre-existing bug that prevented compilation if `writeApplicaitonInfo` was actually called

## Testing
- ✅ Local build succeeds
- ✅ Sparkle now resolves to version 2.8.1 (latest stable 2.x release)

## Related Issues
- Closes #6

## Acceptance Criteria from Issue
- [x] Sparkle pinned to specific semantic version
- [x] Build succeeds with pinned version
- [ ] Auto-update functionality tested (manual testing recommended)
- [x] Package.resolved reflects exact version (2.8.1)