### PR TITLE
fix: Correct Dependabot Swift config comments and remove ineffective ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,9 @@ updates:
       - "dependencies"
     open-pull-requests-limit: 5
     
-  # Maintain dependencies for Swift Package Manager (WhiskyKit)
+  # Maintain dependencies for WhiskyKit's standalone Swift package (WhiskyKit/Package.swift only)
+  # Note: Main Whisky project dependencies (Sparkle, etc.) are in Xcode project-based SPM
+  # which Dependabot doesn't support - only standalone Package.swift files are tracked
   - package-ecosystem: "swift"
     directory: "/WhiskyKit"
     schedule:
@@ -24,7 +26,3 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
-    ignore:
-      # Ignore patch versions for Sparkle to avoid noise
-      - dependency-name: "Sparkle"
-        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
## Summary

Follow-up fix to PR #23 addressing two configuration issues identified by code review:

## Issues Fixed

### 1. Misleading Comment
The comment stated "Maintain dependencies for Swift Package Manager (WhiskyKit)" which implied all Swift dependencies would be tracked. In reality, Dependabot only tracks standalone `Package.swift` files, not Xcode project-based SPM.

**Before:**
```yaml
# Maintain dependencies for Swift Package Manager (WhiskyKit)
```

**After:**
```yaml
# Maintain dependencies for WhiskyKit's standalone Swift package (WhiskyKit/Package.swift only)
# Note: Main Whisky project dependencies (Sparkle, etc.) are in Xcode project-based SPM
# which Dependabot doesn't support - only standalone Package.swift files are tracked
```

### 2. Ineffective Ignore Rule
The Sparkle ignore rule was pointless because:
- Sparkle is defined in `Whisky.xcodeproj` (Xcode project-based SPM)
- Dependabot only reads `WhiskyKit/Package.swift`
- WhiskyKit's Package.swift only contains `SemanticVersion` as a dependency

**Removed:**
```yaml
ignore:
  - dependency-name: "Sparkle"
    update-types: ["version-update:semver-patch"]
```

## Testing

- No functional changes, only documentation/cleanup
- CI should pass