### PR TITLE
refactor: Address Copilot code review feedback from PR #25

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '16.2'
       
       - name: Show Swift version
         run: swift --version

--- a/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
@@ -178,12 +178,18 @@ final class EnvironmentVariablesTests: XCTestCase {
     func testEnvironmentVariablesWithPerformancePreset() {
         var settings = BottleSettings()
         settings.performancePreset = .performance
+        settings.sequoiaCompatMode = false  // Disable to test performance preset in isolation
 
         var env: [String: String] = [:]
         settings.environmentVariables(wineEnv: &env)
 
+        // Performance preset - prioritize FPS over visual quality
         XCTAssertEqual(env["D3DM_FAST_SHADER_COMPILE"], "1")
         XCTAssertEqual(env["D3DM_VALIDATION"], "0")
+        XCTAssertEqual(env["MTL_DEBUG_LAYER"], "0")
+        XCTAssertEqual(env["DXVK_ASYNC"], "1")
+        XCTAssertEqual(env["DXVK_SHADER_OPT_LEVEL"], "0")
+        XCTAssertEqual(env["MTL_ENABLE_METAL_EVENTS"], "0")
     }
 
     func testEnvironmentVariablesWithQualityPreset() {
@@ -206,10 +212,13 @@ final class EnvironmentVariablesTests: XCTestCase {
         var env: [String: String] = [:]
         settings.environmentVariables(wineEnv: &env)
 
+        // Unity preset - il2cpp and threading optimizations
         XCTAssertEqual(env["MONO_THREADS_SUSPEND"], "1")
         XCTAssertEqual(env["WINE_LARGE_ADDRESS_AWARE"], "65536")
         XCTAssertEqual(env["D3DM_FORCE_D3D11"], "1")
         XCTAssertEqual(env["WINE_HEAP_REUSE"], "0")
+        XCTAssertEqual(env["WINE_DISABLE_NTDLL_THREAD_REGS"], "1")
+        XCTAssertEqual(env["WINEPRELOADRESERVE"], "1")
     }
 
     // MARK: - D3D11 and Shader Cache

--- a/WhiskyKit/Tests/WhiskyKitTests/WineTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WineTests.swift
@@ -149,9 +149,8 @@ final class WineTests: XCTestCase {
         let testURL = URL(fileURLWithPath: "/Applications/Test App.exe")
         let escaped = testURL.esc
 
-        // The escaped string should handle spaces and special characters properly
+        // Verify the exact expected escaped output
         XCTAssertFalse(escaped.isEmpty)
-        XCTAssertTrue(escaped.contains("\\ "), "Spaces should be escaped")
         XCTAssertEqual(escaped, "/Applications/Test\\ App.exe")
     }
 


### PR DESCRIPTION
## Summary

This PR addresses the remaining Copilot code review feedback from PR #25 (review ID `3629310941`).

## Changes

### 1. `.github/workflows/Test.yml`
- Changed Xcode version from `latest-stable` to specific `'16.2'` for reproducible builds

### 2. `EnvironmentVariablesTests.swift`
- **Performance preset test**: Added `sequoiaCompatMode = false` to test preset behavior in isolation, plus additional assertions for all env vars (DXVK_ASYNC, DXVK_SHADER_OPT_LEVEL, MTL_ENABLE_METAL_EVENTS)
- **Unity preset test**: Added missing env var assertions for `WINE_DISABLE_NTDLL_THREAD_REGS` and `WINEPRELOADRESERVE`

### 3. `WineTests.swift`
- Removed redundant `contains` assertion in `testURLEscapeExtension` (line 154 was redundant when line 155 already verifies the exact value)

## Testing

All 53 tests pass locally:
```
Test Suite 'WhiskyKitPackageTests.xctest' passed at 2026-01-05 23:32:44.908.
  Executed 53 tests, with 0 failures (0 unexpected) in 0.007 (0.009) seconds
```

## Related

- Addresses feedback from: https://github.com/frankea/Whisky/pull/25#pullrequestreview-3629310941
- Original issue: #8 (now closed)