### PR TITLE
fix: Make WhiskyWine install atomic and error-reporting (Refs #40)

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Documentation.docc/GettingStarted.md
+++ b/WhiskyKit/Sources/WhiskyKit/Documentation.docc/GettingStarted.md
@@ -41,7 +41,7 @@ import WhiskyKit
 if !WhiskyWineInstaller.isWhiskyWineInstalled() {
     // Download and install WhiskyWine
     let tarballURL = // ... download WhiskyWine tarball
-    WhiskyWineInstaller.install(from: tarballURL)
+    try await WhiskyWineInstaller.install(from: tarballURL)
 }
 
 // Check for updates

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -1,0 +1,57 @@
+//
+//  WhiskyWineInstallerTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import SemanticVersion
+@testable import WhiskyKit
+import XCTest
+
+final class WhiskyWineInstallerTests: XCTestCase {
+    func testLocateExtractedLibrariesFolderFindsVersionFileParent() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent("whisky-installer-test-\(UUID().uuidString)")
+        let libraries = root.appendingPathComponent("SomeRoot").appendingPathComponent("Libraries")
+        try fileManager.createDirectory(at: libraries, withIntermediateDirectories: true)
+
+        // Create a valid WhiskyWineVersion.plist in Libraries/
+        let version = WhiskyWineVersion(version: SemanticVersion(2, 5, 0))
+        let data = try PropertyListEncoder().encode(version)
+        let versionPlist = libraries.appendingPathComponent("WhiskyWineVersion").appendingPathExtension("plist")
+        try data.write(to: versionPlist)
+
+        defer { try? fileManager.removeItem(at: root) }
+
+        let found = WhiskyWineInstaller.locateExtractedLibrariesFolder(in: root)
+        XCTAssertEqual(found?.standardizedFileURL.path, libraries.standardizedFileURL.path)
+    }
+
+    func testDecodeWhiskyWineVersionDecodesValidPlist() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent("whisky-installer-test-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let version = WhiskyWineVersion(version: SemanticVersion(2, 5, 0))
+        let data = try PropertyListEncoder().encode(version)
+        let plist = root.appendingPathComponent("WhiskyWineVersion").appendingPathExtension("plist")
+        try data.write(to: plist)
+
+        let decoded = try WhiskyWineInstaller.decodeWhiskyWineVersion(from: plist)
+        XCTAssertEqual(decoded, SemanticVersion(2, 5, 0))
+    }
+}


### PR DESCRIPTION
Refs #40\n\n### Summary\nHardens WhiskyWine installation so a failed install doesn’t leave the app in a partial/corrupt state (a likely contributor to upstream reports like whisky-app/whisky#1275).\n\n### Changes\n- WhiskyWineInstaller.install(from:) is now async throws\n- Install extracts into a staging directory, validates expected structure, then atomically swaps Libraries/\n- UI now shows install failures with Retry/Quit instead of silently continuing\n- Adds unit tests for locating the extracted Libraries folder and decoding the version plist\n- Updates DocC Getting Started snippet to use try await\n\n### Testing\n- swiftformat --lint .\n- swift test --package-path WhiskyKit\n- xcodebuild -project Whisky.xcodeproj -scheme Whisky -configuration Debug build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO\n\n### Reviewer checklist\n- Verify failed installs show an error + Retry works\n- Verify successful installs result in a valid WhiskyWine version and Wine/bin/wine64 present\n- Confirm we no longer delete the entire application support folder during install\n