### PR TITLE
stability: Add Safe Mode preset for critical freeze/reboot scenarios (Refs #40)

### DIFF
--- a/Whisky/Views/Bottle/PerformanceConfigSection.swift
+++ b/Whisky/Views/Bottle/PerformanceConfigSection.swift
@@ -25,6 +25,14 @@ struct PerformanceConfigSection: View {
 
     var body: some View {
         Section("config.title.performance", isExpanded: $isExpanded) {
+            Toggle(isOn: $bottle.settings.stabilitySafeMode) {
+                VStack(alignment: .leading) {
+                    Text("Stability Safe Mode")
+                    Text("Applies conservative settings to mitigate hard freezes/reboots (Refs #40).")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
             Picker("config.performancePreset", selection: $bottle.settings.performancePreset) {
                 ForEach(PerformancePreset.allCases, id: \.self) { preset in
                     Text(preset.description()).tag(preset)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottlePerformanceConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottlePerformanceConfig.swift
@@ -46,6 +46,7 @@ public struct BottlePerformanceConfig: Codable, Equatable {
     var forceD3D11: Bool = false // Force D3D11 instead of D3D12 for compatibility
     var disableShaderOptimizations: Bool = false // For debugging FPS issues
     var vcRedistInstalled: Bool = false // Track if VC++ runtime is installed
+    var stabilitySafeMode: Bool = false // Conservative settings for crash/freeze mitigation
 
     public init() {}
 
@@ -59,5 +60,6 @@ public struct BottlePerformanceConfig: Codable, Equatable {
         self.disableShaderOptimizations = try container
             .decodeIfPresent(Bool.self, forKey: .disableShaderOptimizations) ?? false
         self.vcRedistInstalled = try container.decodeIfPresent(Bool.self, forKey: .vcRedistInstalled) ?? false
+        self.stabilitySafeMode = try container.decodeIfPresent(Bool.self, forKey: .stabilitySafeMode) ?? false
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
@@ -255,4 +255,32 @@ final class EnvironmentVariablesTests: XCTestCase {
         XCTAssertEqual(env["DXVK_SHADER_COMPILE_THREADS"], "1")
         XCTAssertEqual(env["__GL_SHADER_DISK_CACHE"], "0")
     }
+
+    // MARK: - Stability Safe Mode
+
+    func testEnvironmentVariablesWithStabilitySafeModeOverrides() {
+        var settings = BottleSettings()
+        settings.stabilitySafeMode = true
+        settings.dxrEnabled = true
+        settings.forceD3D11 = false
+        settings.enhancedSync = .msync
+        settings.metalValidation = true
+
+        var env: [String: String] = [:]
+        settings.environmentVariables(wineEnv: &env)
+
+        // Safe Mode forces D3D11 and disables DXR and validation.
+        XCTAssertEqual(env["D3DM_FORCE_D3D11"], "1")
+        XCTAssertEqual(env["D3DM_FEATURE_LEVEL_12_0"], "0")
+        XCTAssertEqual(env["D3DM_SUPPORT_DXR"], "0")
+        XCTAssertEqual(env["D3DM_VALIDATION"], "0")
+        XCTAssertEqual(env["MTL_DEBUG_LAYER"], "0")
+
+        // Safe Mode prefers ESYNC baseline and disables MSYNC to avoid conflicting modes.
+        XCTAssertEqual(env["WINEESYNC"], "1")
+        XCTAssertNil(env["WINEMSYNC"])
+
+        // Safe Mode disables fsync.
+        XCTAssertEqual(env["WINEFSYNC"], "0")
+    }
 }


### PR DESCRIPTION
Refs #40\n\n### Summary\nAdds an opt-in **Stability Safe Mode** toggle that applies conservative environment overrides intended to mitigate hard freezes, reboots, and kernel panics on macOS 15.x.\n\n### Behavior\nWhen enabled, Safe Mode forces:\n- D3D11 (D3DM_FORCE_D3D11=1, D3DM_FEATURE_LEVEL_12_0=0)\n- ESYNC baseline and disables MSYNC\n- FSYNC disabled (WINEFSYNC=0)\n- DXR disabled (D3DM_SUPPORT_DXR=0)\n- Validation layers disabled (D3DM_VALIDATION=0, MTL_DEBUG_LAYER=0)\n\n### Implementation\n- New BottleSettings flag backed by BottlePerformanceConfig\n- EnvironmentVariablesTests updated to validate overrides\n\n### Testing\n- swiftformat --lint .\n- swift test --package-path WhiskyKit\n- xcodebuild -project Whisky.xcodeproj -scheme Whisky -configuration Debug build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO\n\n### Reviewer checklist\n- Confirm default behavior unchanged when Safe Mode is off\n- Confirm enabling Safe Mode overrides conflicting settings (DXR, MSYNC, etc.)\n