### PR TITLE
fix: add missing English translations for localization fallback (Refs #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AVX toggle and Sequoia compatibility mode are now always visible (no longer gated by OS version)
 
 ### Fixed
+- Fixed localization fallback showing raw keys to non-English users (Refs #49)
 - Corrected Dependabot Swift configuration
 - Capped Wine process logs and pruned old logs to prevent excessive disk usage (Issue #46)
 - Surface bottle creation failures with diagnostic information (Issue #61)

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -1,21561 +1,21785 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "(%@)" : {
-
+  "sourceLanguage": "en",
+  "strings": {
+    "(%@)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%@)"
+          }
+        }
+      }
     },
-    "%llds" : {
-
+    "%llds": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%llds"
+          }
+        }
+      }
     },
-    "accessibility.toast.dismiss" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Click to dismiss"
+    "accessibility.toast.dismiss": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Click to dismiss"
           }
         }
       }
     },
-    "accessibility.toast.error" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
+    "accessibility.toast.error": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         }
       }
     },
-    "accessibility.toast.info" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Information"
+    "accessibility.toast.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Information"
           }
         }
       }
     },
-    "accessibility.toast.success" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Success"
+    "accessibility.toast.success": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Success"
           }
         }
       }
     },
-    "alert.info" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فشل في الفتح"
+    "alert.info": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل في الفتح"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nepodařilo se otevřít"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nepodařilo se otevřít"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kunne ikke åbne"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kunne ikke åbne"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öffnen fehlgeschlagen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnen fehlgeschlagen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to open"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to open"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo abrir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo abrir"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avaaminen epäonnistui"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaaminen epäonnistui"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de l'ouverture"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de l'ouverture"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile aprire"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile aprire"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "起動に失敗しました。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "起動に失敗しました。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "열기 실패"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "열기 실패"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Openen mislukt"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Openen mislukt"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie można otworzyć"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie można otworzyć"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao abrir"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao abrir"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao abrir"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao abrir"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu s-a putut deschide"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nu s-a putut deschide"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось открыть"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось открыть"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Açılamadı"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Açılamadı"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося відкрити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося відкрити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể mở"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể mở"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开失败"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开失败"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟失敗"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟失敗"
           }
         }
       }
     },
-    "alert.message" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فشل في فتح البرنامج!"
+    "alert.message": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل في فتح البرنامج!"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nepodařilo se otevřít program!"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nepodařilo se otevřít program!"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programmet kunne ikke åbnes!"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programmet kunne ikke åbnes!"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öffnen des Programms fehlgeschlagen!"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnen des Programms fehlgeschlagen!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to open program!"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to open program!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Error al abrir el programa!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Error al abrir el programa!"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ohjelman käynnistäminen epäonnistui!"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ohjelman käynnistäminen epäonnistui!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d'ouvrir le programme !"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'ouvrir le programme !"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile aprire il programma!"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile aprire il programma!"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プログラムの起動に失敗しました！"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プログラムの起動に失敗しました！"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프로그램을 여는 데 실패했습니다!"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로그램을 여는 데 실패했습니다!"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kan het programma niet openen!"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kan het programma niet openen!"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się otworzyć programu!"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się otworzyć programu!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao abrir o programa!"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao abrir o programa!"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao abrir o programa!"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao abrir o programa!"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programul nu a putut fi deschis!"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programul nu a putut fi deschis!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось запустить программу!"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось запустить программу!"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Program açılamadı!"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program açılamadı!"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося відкрити програму!"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося відкрити програму!"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể mở chương trình này!"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể mở chương trình này!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法打开软件！"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法打开软件！"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法開啟程式！"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法開啟程式！"
           }
         }
       }
     },
-    "Auto-Enable DXVK for Launchers" : {
-
+    "Auto-Enable DXVK for Launchers": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Enable DXVK for Launchers"
+          }
+        }
+      }
     },
-    "Automatic" : {
-
+    "Automatic": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic"
+          }
+        }
+      }
     },
-    "Automatic: Detects launcher from executable path\nManual: Use explicitly selected launcher type" : {
-
+    "Automatic: Detects launcher from executable path\nManual: Use explicitly selected launcher type": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic: Detects launcher from executable path\nManual: Use explicitly selected launcher type"
+          }
+        }
+      }
     },
-    "Automatically enables DXVK when launcher requires it (e.g., Rockstar Games Launcher)" : {
-
+    "Automatically enables DXVK when launcher requires it (e.g., Rockstar Games Launcher)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically enables DXVK when launcher requires it (e.g., Rockstar Games Launcher)"
+          }
+        }
+      }
     },
-    "button.cDrive" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فتح القرص C"
+    "button.cDrive": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح القرص C"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otevřít disk C:"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otevřít disk C:"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åbn C: Drev"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn C: Drev"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "C: Laufwerk öffnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "C: Laufwerk öffnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open C: Drive"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open C: Drive"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Unidad C:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Unidad C:"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avaa C: Levy"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa C: Levy"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir le Lecteur C:"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir le Lecteur C:"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri unità C:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri unità C:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "C: ドライブを開く"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "C: ドライブを開く"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "C: 드라이브 열기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "C: 드라이브 열기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open C: schijf"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open C: schijf"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otwórz dysk C:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz dysk C:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir disco C:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir disco C:"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir C: Drive"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir C: Drive"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deschide C: Drive"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deschide C: Drive"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть Диск C:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть Диск C:"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "C: Sürücüsünü Aç"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "C: Sürücüsünü Aç"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відкрити диск C:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити диск C:"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở ổ C:"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở ổ C:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开 C: 盘"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 C: 盘"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟 C: 槽"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟 C: 槽"
           }
         }
       }
     },
-    "button.cancel" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "button.cancel": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         }
       }
     },
-    "button.createBottle" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إنشاء قارورة"
+    "button.createBottle": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إنشاء قارورة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vytvořit láhev"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vytvořit láhev"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opret Bottle"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opret Bottle"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle erstellen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle erstellen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create Bottle"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Bottle"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear Botella"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear Botella"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luo pullo"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luo pullo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer une Bouteille"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer une Bouteille"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea bottiglia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea bottiglia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle を作成"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle を作成"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle 생성"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle 생성"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maak fles"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maak fles"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utwórz butelkę"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utwórz butelkę"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar Bottle"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar Bottle"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar uma Bottle"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar uma Bottle"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creează o Sticlă"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creează o Sticlă"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создать Бутылку"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать Бутылку"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle Oluştur"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle Oluştur"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Створити пляшку"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створити пляшку"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tạo Bottle"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo Bottle"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建容器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建容器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "建立容器"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建立容器"
           }
         }
       }
     },
-    "button.createShortcut" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إنشاء إختصار"
+    "button.createShortcut": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إنشاء إختصار"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vytvořit zástupce"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vytvořit zástupce"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opret genvej"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opret genvej"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verknüpfung erstellen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verknüpfung erstellen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create Shortcut"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Shortcut"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear atajo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear atajo"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luo pikakomento"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luo pikakomento"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer raccourci"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer raccourci"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea scorciatoia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea scorciatoia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ショートカットを作成"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットを作成"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "바로 가기 만들기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "바로 가기 만들기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maak snelkoppeling"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maak snelkoppeling"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utwórz skrót"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utwórz skrót"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar Atalho"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar Atalho"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar Atalho"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar Atalho"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creează o Scurtătură"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creează o Scurtătură"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создать ярлык"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать ярлык"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kısayol Oluştur"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kısayol Oluştur"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Створити ярлик"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створити ярлик"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tạo Phím tắt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo Phím tắt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建快捷方式"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建快捷方式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "建立捷徑"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建立捷徑"
           }
         }
       }
     },
-    "button.exportBottle" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تصدير كأرشيف..."
+    "button.exportBottle": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصدير كأرشيف..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportovat jako archiv..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportovat jako archiv..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eksporter som arkiv..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eksporter som arkiv..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Als Archiv exportieren..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als Archiv exportieren..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export as Archive..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export as Archive..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar como archivo..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar como archivo..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vie arkistona..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vie arkistona..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exporter en tant qu'archive..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter en tant qu'archive..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esporta come archivio..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esporta come archivio..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アーカイブとしてエクスポート..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アーカイブとしてエクスポート..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "아카이브로 내보내기..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아카이브로 내보내기..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exporteer als archief..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporteer als archief..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eksportuj jako archiwum..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eksportuj jako archiwum..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar como Arquivo..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar como Arquivo..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar como Arquivo..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar como Arquivo..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportă ca Arhivă..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportă ca Arhivă..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Экспортировать как архив..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Экспортировать как архив..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arşiv olarak dışa aktarın..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arşiv olarak dışa aktarın..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Експортувати як архів..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Експортувати як архів..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xuất ra tệp nén..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xuất ra tệp nén..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "导出为存档..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出为存档..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "匯出為封存檔⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯出為封存檔⋯"
           }
         }
       }
     },
-    "button.moveBottle" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نقل..."
+    "button.moveBottle": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقل..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přesunout..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přesunout..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flyt..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flyt..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verschieben..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verschieben..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Move..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mover..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Siirrä..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siirrä..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Déplacer..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déplacer..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sposta..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sposta..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移動..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移動..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이동..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이동..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verplaats..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verplaats..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przenieś..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przenieś..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mover..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mover..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mutare..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mutare..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переместить..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переместить..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taşı..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taşı..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перемістити..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемістити..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Di chuyển..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Di chuyển..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移动..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移动..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移動⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移動⋯"
           }
         }
       }
     },
-    "button.ok" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حسناً"
+    "button.ok": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حسناً"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Okay"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Okay"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ok"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ok"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ОК"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ОК"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tamam"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamam"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Гаразд"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Гаразд"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "确定"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "確定"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確定"
           }
         }
       }
     },
-    "bottle.creation.failed.title" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle Creation Failed"
+    "bottle.creation.failed.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle Creation Failed"
           }
         }
       }
     },
-    "bottle.creation.failed.copyDiagnostics" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Diagnostics"
+    "bottle.creation.failed.copyDiagnostics": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Diagnostics"
           }
         }
       }
     },
-    "button.pin" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تثبيت"
+    "button.pin": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Připnout"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Připnout"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fastgør"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fastgør"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anpinnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anpinnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anclar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anclar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kiinnitä"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiinnitä"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Épingler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épingler"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fissa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fissa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ピン留め"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ピン留め"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "고정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고정"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przypnij"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przypnij"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fixar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fixar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fixează"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixează"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закрепить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрепить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sabitle"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sabitle"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закріпити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закріпити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ghim"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghim"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "置顶"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "置顶"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "釘選"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "釘選"
           }
         }
       }
     },
-    "button.refresh" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحديث"
+    "button.refresh": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحديث"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obnovit"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obnovit"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opfrisk"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opfrisk"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualisieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refresh"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Päivitä"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Päivitä"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rafraîchir"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rafraîchir"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiorna"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiorna"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再読み込み"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再読み込み"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "새로 고침"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로 고침"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vernieuw"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vernieuw"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odśwież"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odśwież"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reîmprospătează"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reîmprospătează"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обновить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yenile"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yenile"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Оновити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оновити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Làm cho khỏe lại"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Làm cho khỏe lại"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刷新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新整理"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新整理"
           }
         }
       }
     },
-    "button.removeAlert" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إزالة..."
+    "button.removeAlert": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odstranit..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odstranit..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Löschen..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrar..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovi..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "削除..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "삭제..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijder..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijder..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elimină..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimină..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaldır..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaldır..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gỡ..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gỡ..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除⋯"
           }
         }
       }
     },
-    "button.removeAlert.cancel" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إلغاء"
+    "button.removeAlert.cancel": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zrušit"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zrušit"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuller"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuller"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Peru"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peru"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuleren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuleren"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anuluj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuluj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anulează"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anulează"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İptal"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İptal"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скасувати"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скасувати"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Huỷ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huỷ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "button.removeAlert.checkbox" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حذف الملفات من القرص"
+    "button.removeAlert.checkbox": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف الملفات من القرص"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odstranit soubory z disku"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odstranit soubory z disku"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slet filer fra disk"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slet filer fra disk"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dateien von der Festplatte löschen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien von der Festplatte löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete files from disk"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete files from disk"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrar archivos del disco"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar archivos del disco"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista tiedostoja levyltä"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista tiedostoja levyltä"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer les fichiers du disque"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer les fichiers du disque"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elimina i file dal disco"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina i file dal disco"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ディスクからも削除"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディスクからも削除"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "디스크에서 파일 삭제"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "디스크에서 파일 삭제"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijder bestanden van harde schijf"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijder bestanden van harde schijf"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń pliki z dysku"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń pliki z dysku"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apagar arquivos do disco"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apagar arquivos do disco"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar ficheiros do disco"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar ficheiros do disco"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Șterge fișierele de pe disc"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Șterge fișierele de pe disc"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить файлы с диска"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить файлы с диска"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dosyaları diskten sil"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosyaları diskten sil"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити файли з диска"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити файли з диска"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xoá tệp từ ổ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xoá tệp từ ổ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从磁盘中删除文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从磁盘中删除文件"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "從硬碟上刪除檔案"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從硬碟上刪除檔案"
           }
         }
       }
     },
-    "button.removeAlert.delete" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إزالة"
+    "button.removeAlert.delete": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odebrat"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odebrat"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Löschen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "削除"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "삭제"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijderen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijderen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elimină"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimină"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaldır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaldır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gỡ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gỡ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
           }
         }
       }
     },
-    "button.removeAlert.info" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هل أنت متأكد أنك تريد إزالة هذه القارورة؟ هذا الإجراء دائم."
+    "button.removeAlert.info": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هل أنت متأكد أنك تريد إزالة هذه القارورة؟ هذا الإجراء دائم."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opravdu chcete ostranit tento balíček? Tato akce je nenavrátitelná."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opravdu chcete ostranit tento balíček? Tato akce je nenavrátitelná."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Er du sikker på, at du vil fjerne denne flaske? Denne handling er permanent."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Er du sikker på, at du vil fjerne denne flaske? Denne handling er permanent."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sind Sie sicher, dass Sie diese Bottle löschen möchten? Dies kann nicht rückgängig gemacht werden."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sind Sie sicher, dass Sie diese Bottle löschen möchten? Dies kann nicht rückgängig gemacht werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure you want to remove this bottle? This action is permanent."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure you want to remove this bottle? This action is permanent."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Estás seguro de que quieres eliminar esta botella? Esta acción es permanente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Estás seguro de que quieres eliminar esta botella? Esta acción es permanente."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oletko varma, että haluat poistaa tämän pullon? Tämä toiminto on pysyvä."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oletko varma, että haluat poistaa tämän pullon? Tämä toiminto on pysyvä."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Êtes-vous sûr de vouloir supprimer cette bouteille ? Vous ne pouvez pas annuler cette action."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Êtes-vous sûr de vouloir supprimer cette bouteille ? Vous ne pouvez pas annuler cette action."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sei sicuro di voler eliminare questa bottiglia? L'azione è irreversibile."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sei sicuro di voler eliminare questa bottiglia? L'azione è irreversibile."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "この Bottle を削除してもよろしいですか？ この操作は取り消せません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Bottle を削除してもよろしいですか？ この操作は取り消せません。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "정말로 이 Bottle을 삭제하시겠습니까? 이 행동은 되돌릴 수 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정말로 이 Bottle을 삭제하시겠습니까? 이 행동은 되돌릴 수 없습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weet u zeker dat u deze fles wilt verwijderen? Deze actie is permanent."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weet u zeker dat u deze fles wilt verwijderen? Deze actie is permanent."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czy na pewno chcesz usunąć tę butelkę? Ta akcja jest nieodwracalna."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czy na pewno chcesz usunąć tę butelkę? Ta akcja jest nieodwracalna."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tem certeza que deseja remover esta bottle? Esta ação é permanente."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tem certeza que deseja remover esta bottle? Esta ação é permanente."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tem certeza de que deseja apagar esta Bottle? Esta acção é permanente."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tem certeza de que deseja apagar esta Bottle? Esta acção é permanente."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sunteți sigur că doriți să eliminați această sticlă? Această acțiune este definitivă."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sunteți sigur că doriți să eliminați această sticlă? Această acțiune este definitivă."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вы уверены, что хотите удалить эту бутылку? Это действие необратимо."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы уверены, что хотите удалить эту бутылку? Это действие необратимо."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu Bottle'ı kaldırmak istediğinize emin misiniz? Bu hareket kalıcıdır."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu Bottle'ı kaldırmak istediğinize emin misiniz? Bu hareket kalıcıdır."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ви впевнені, що хочете видалити цю пляшку? Цю дію не можна скасувати."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ви впевнені, що хочете видалити цю пляшку? Цю дію не можна скасувати."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bạn có chắc chắn rằng mình muốn gỡ chai này? Hành động này không thể đảo ngược."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn có chắc chắn rằng mình muốn gỡ chai này? Hành động này không thể đảo ngược."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你确定要删除这个容器吗？这将是不可逆的。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你确定要删除这个容器吗？这将是不可逆的。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你確定要移除此容器嗎？此動作將不可還原。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你確定要移除此容器嗎？此動作將不可還原。"
           }
         }
       }
     },
-    "button.removeAlert.msg" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove %@؟"
+    "button.removeAlert.msg": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove %@؟"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odebrat %@?"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odebrat %@?"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern %@?"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern %@?"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ löschen?"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ löschen?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove %@?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove %@?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Borrar %@?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Borrar %@?"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista %@?"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista %@?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer %@ ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer %@ ?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vuoi rimuovere %@?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuoi rimuovere %@?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ を削除しますか？"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を削除しますか？"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@을(를) 삭제하시겠습니까?"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@을(를) 삭제하시겠습니까?"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijder %@?"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijder %@?"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usunąć %@?"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usunąć %@?"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover %@?"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover %@?"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover %@?"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover %@?"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elimină %@?"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimină %@?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить %@?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить %@?"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ öğesini kaldır?"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ öğesini kaldır?"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити %@?"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити %@?"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gỡ %@?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gỡ %@?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除 %@？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除 %@？"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除 %@？"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除 %@？"
           }
         }
       }
     },
-    "button.rename" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة التسمية..."
+    "button.rename": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة التسمية..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přejmenovat..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přejmenovat..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Omdøb..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omdøb..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umbenennen..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbenennen..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rename..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renombrar..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nimeä uudelleen..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nimeä uudelleen..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renommer..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rinomina..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "名前の変更..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前の変更..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이름 변경..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름 변경..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hernoem..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hernoem..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zmień nazwę..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zmień nazwę..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renomear..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renomear..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redenumire..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redenumire..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переименовать..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переименовать..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yeniden Adlandır..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeniden Adlandır..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перейменувати..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейменувати..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đổi tên..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đổi tên..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新命名..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新命名..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新命名⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新命名⋯"
           }
         }
       }
     },
-    "button.run" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تشغيل..."
+    "button.run": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spustit..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spustit..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kør program..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kør program..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starten..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Run..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ejecutar..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Käynnistä..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käynnistä..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exécuter..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécuter..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avvia..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvia..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "実行..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "실행..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uruchom..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uruchom..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executar..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executar..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executare..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executare..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выполнить..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполнить..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Çalıştır..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalıştır..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запустити..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустити..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chạy..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạy..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "執行⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行⋯"
           }
         }
       }
     },
-    "button.showInFinder" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إظهار في Finder"
+    "button.showInFinder": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إظهار في Finder"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zobrazit ve Finderu"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zobrazit ve Finderu"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vis i Finder"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vis i Finder"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Im Finder anzeigen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Finder anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show in Finder"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show in Finder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar en Finder"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar en Finder"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Näytä Finderissa"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näytä Finderissa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher dans Finder"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher dans Finder"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra in Finder"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra in Finder"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finder で表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder で表示"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finder에서 보기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder에서 보기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toon in Finder"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toon in Finder"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokaż w Finderze"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokaż w Finderze"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar no Finder"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar no Finder"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir no Finder"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir no Finder"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arată în Finder"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arată în Finder"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показать в Finder"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать в Finder"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finder'da Göster"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder'da Göster"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показати у Finder"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показати у Finder"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở trong Finder"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở trong Finder"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在访达中显示"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在访达中显示"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Finder 中顯示"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Finder 中顯示"
           }
         }
       }
     },
-    "button.terminal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الوحدة الطرفية..."
+    "button.terminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوحدة الطرفية..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ターミナル..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Терминал..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Терминал..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "终端..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "終端機⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終端機⋯"
           }
         }
       }
     },
-    "button.unpin" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إزالة تثبيت"
+    "button.unpin": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة تثبيت"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odepnout"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odepnout"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frigør"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frigør"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lösen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lösen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unpin"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unpin"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desanclar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desanclar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista kiinnitys"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista kiinnitys"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désépingler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désépingler"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stacca"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stacca"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ピン留めを解除"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ピン留めを解除"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "고정 해제"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고정 해제"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lospinnen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lospinnen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odepnij"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odepnij"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desafixar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desafixar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desafixar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desafixar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anulează fixarea"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anulează fixarea"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открепить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открепить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sabitlemeyi kaldır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sabitlemeyi kaldır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відкріпити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкріпити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bỏ ghim"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bỏ ghim"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消置顶"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消置顶"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消釘選"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消釘選"
           }
         }
       }
     },
-    "button.winetricks" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+    "button.winetricks": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetrickit..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetrickit..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetrick..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetrick..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks⋯"
           }
         }
       }
     },
-    "check.updates" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التحقق من وجود تحديثات..."
+    "check.updates": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحقق من وجود تحديثات..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vyhledat aktualizace..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vyhledat aktualizace..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tjek for Opdateringer..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tjek for Opdateringer..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach Updates suchen..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Updates suchen..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check for Updates..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar actualizaciones..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tarkista päivitykset..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarkista päivitykset..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des Mises à Jour..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des Mises à Jour..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controlla aggiornamenti..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controlla aggiornamenti..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アップデートを確認..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "업데이트 확인..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 확인..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controleer op updates..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controleer op updates..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprawdź dostępność aktualizacji..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprawdź dostępność aktualizacji..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Procurar por Atualizações..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Procurar por Atualizações..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificar Actualizações..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar Actualizações..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifică Actualizări..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifică Actualizări..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверить наличие обновлений..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить наличие обновлений..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Güncellemeleri Kontrol Et..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güncellemeleri Kontrol Et..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перевірити наявність оновлень..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перевірити наявність оновлень..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kiểm tra Cập nhật..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểm tra Cập nhật..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查更新..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "檢查更新⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查更新⋯"
           }
         }
       }
     },
-    "config.avx" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "دعم AVX للإعلان"
+    "config.avx": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دعم AVX للإعلان"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "da": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AVX-Unterstützung anzeigen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AVX-Unterstützung anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Advertise AVX Support"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertise AVX Support"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anunciar soporte AVX"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anunciar soporte AVX"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AVX サポートを通知する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AVX サポートを通知する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "ro": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "查看 AVX 支持"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看 AVX 支持"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Advertise AVX Support"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Advertise AVX Support"
           }
         }
       }
     },
-    "config.avx.warning" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وقد يؤثر ذلك سلباً على الأداء"
+    "config.avx.warning": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وقد يؤثر ذلك سلباً على الأداء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "da": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kann die Leistung negativ beeinflussen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kann die Leistung negativ beeinflussen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "May negatively impact performance"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "May negatively impact performance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puede afectar negativamente el rendimiento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puede afectar negativamente el rendimiento"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パフォーマンスが低下する可能性があります"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パフォーマンスが低下する可能性があります"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "ro": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Может негативно повлиять на производительность"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Может негативно повлиять на производительность"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "可能会对性能产生负面影响"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可能会对性能产生负面影响"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "May negatively impact performance"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "May negatively impact performance"
           }
         }
       }
     },
-    "config.buildVersion" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نسخة الإصدار"
+    "config.buildVersion": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخة الإصدار"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Build verze"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build verze"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Build-version"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build-version"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Build-Version"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build-Version"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Build Version"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build Version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión de Compilación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión de Compilación"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ohjelmistoversio"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ohjelmistoversio"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version de Build"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version de Build"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione build"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione build"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ビルド番号"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビルド番号"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "빌드 버전"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빌드 버전"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Build-versie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build-versie"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obecna wersja: "
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obecna wersja: "
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão da Compilação"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão da Compilação"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão da compilação"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão da compilação"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versiunea"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versiunea"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версия сборки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версия сборки"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yapı Sürümü"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yapı Sürümü"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версія складання"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версія складання"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phiên bản"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phiên bản"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "构建版本"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "构建版本"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "組建版本"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "組建版本"
           }
         }
       }
     },
-    "config.controlPanel" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فتح لوحة التحكم"
+    "config.controlPanel": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح لوحة التحكم"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otevřít Ovládací Panel"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otevřít Ovládací Panel"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åbn Kontrolpanel"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn Kontrolpanel"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systemsteuerung öffnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemsteuerung öffnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Control Panel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Control Panel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Panel de Control"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Panel de Control"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avaa ohjauspaneeli"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa ohjauspaneeli"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir le Panneau de Configuration"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir le Panneau de Configuration"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri Pannello di controllo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Pannello di controllo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コントロール パネルを開く"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コントロール パネルを開く"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제어판 열기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제어판 열기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open configuratiescherm"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open configuratiescherm"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otwórz Panel Sterowania"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz Panel Sterowania"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Painel de Controle"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Painel de Controle"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Painel de Controlo"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Painel de Controlo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deschide Panoul de Control"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deschide Panoul de Control"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть Панель управления"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть Панель управления"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontrol Panelini Aç"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontrol Panelini Aç"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відкрити Панель Керування"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити Панель Керування"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở Control Panel"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở Control Panel"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开控制面板"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开控制面板"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟控制台"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟控制台"
           }
         }
       }
     },
-    "config.dpi" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحجيم DPI"
+    "config.dpi": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحجيم DPI"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI škálování"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI škálování"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI Skalering"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI Skalering"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI-Skalierung"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI-Skalierung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI Scaling"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI Scaling"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escala de DPI"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala de DPI"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI skaalaus"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI skaalaus"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mise à l'échelle du PPP"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à l'échelle du PPP"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scaling di DPI"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scaling di DPI"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI スケーリング"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI スケーリング"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI 스케일링"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI 스케일링"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI Schalen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI Schalen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skalowanie DPI"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skalowanie DPI"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escala de DPI"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala de DPI"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escala de DPI"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala de DPI"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scalare DPI"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scalare DPI"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Масштабирование DPI"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштабирование DPI"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI Ölçeklendirme"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI Ölçeklendirme"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Масштабування DPI"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштабування DPI"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI 缩放"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI 缩放"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI 縮放"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI 縮放"
           }
         }
       }
     },
-    "config.dxr" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تتبع أشعة DirectX"
+    "config.dxr": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تتبع أشعة DirectX"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "da": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DirectX Raytracing"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DirectX Raytracing"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DirectX Raytracing"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DirectX Raytracing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trazado de rayos de DirectX"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trazado de rayos de DirectX"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DirectX レイトレーシング"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DirectX レイトレーシング"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "ro": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DirectX 光线追踪"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DirectX 光线追踪"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DirectX Raytracing"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "DirectX Raytracing"
           }
         }
       }
     },
-    "config.dxr.info" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تمكين دعم تتبع الأشعة في عناوين DirectX 12 "
+    "config.dxr.info": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمكين دعم تتبع الأشعة في عناوين DirectX 12 "
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "da": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktiviert Raytracing-Unterstützung in DirectX 12 Titeln "
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviert Raytracing-Unterstützung in DirectX 12 Titeln "
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite el trazado de rayos en los títulos con DirectX 12 "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite el trazado de rayos en los títulos con DirectX 12 "
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "fi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DirectX 12 のタイトルでレイトレーシングを有効にする "
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DirectX 12 のタイトルでレイトレーシングを有効にする "
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "pt-PT": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "ro": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Включает поддержку raytracing в DirectX 12 заголовках "
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включает поддержку raytracing в DirectX 12 заголовках "
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在DirectX 12 游戏中启用光线追踪 "
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在DirectX 12 游戏中启用光线追踪 "
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enables raytracing support in DirectX 12 titles "
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enables raytracing support in DirectX 12 titles "
           }
         }
       }
     },
-    "config.dxvk" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+    "config.dxvk": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK を使用する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK を使用する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         }
       }
     },
-    "config.dxvk.async" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+    "config.dxvk.async": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Asíncrono"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Asíncrono"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK asincrono"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK asincrono"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asynchroniczny DXVK"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asynchroniczny DXVK"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Async DXVK"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Async DXVK"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Асинхронный DXVK"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Асинхронный DXVK"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Асинхронний DXVK"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Асинхронний DXVK"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Async"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Async"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "异步 DXVK"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "异步 DXVK"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "非同步 DXVK"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非同步 DXVK"
           }
         }
       }
     },
-    "config.dxvkHud" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+    "config.dxvkHud": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar Info & Stats de DXVK"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar Info & Stats de DXVK"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HUD DXVK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD DXVK"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HUD DXVK"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD DXVK"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HUD DXVK"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD DXVK"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HUD DXVK"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD DXVK"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK Arayüzü"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK Arayüzü"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HUD DXVK"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD DXVK"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK HUD"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK HUD"
           }
         }
       }
     },
-    "config.dxvkHud.fps" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+    "config.dxvkHud.fps": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CPS"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CPS"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IPS"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPS"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS のみ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS のみ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS (kl./s)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS (kl./s)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Только FPS"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Только FPS"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Кадр/с"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кадр/с"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FPS"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FPS"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "幀數"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "幀數"
           }
         }
       }
     },
-    "config.dxvkHud.full" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "كامل"
+    "config.dxvkHud.full": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كامل"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Full"
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Full"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fuld"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuld"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voll"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voll"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Full"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completa"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Koko"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koko"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Détaillé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détaillé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完全"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전체"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Volledig"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volledig"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pełny"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pełny"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completa"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completa"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completo"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Complet"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Complet"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Полный"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Полный"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tam"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tam"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Повний"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повний"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đầy đủ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đầy đủ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "全部"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "全開"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全開"
           }
         }
       }
     },
-    "config.dxvkHud.off" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تعطيل"
+    "config.dxvkHud.off": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعطيل"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vypnuto"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vypnuto"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fra"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fra"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aus"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Off"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apagado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apagado"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pois"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pois"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactivé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spento"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spento"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オフ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "끄기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "끄기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uit"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uit"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyłączony"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyłączony"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desativada"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativada"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desligado"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desligado"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dezactivat"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dezactivat"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выключен"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выключен"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kapalı"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapalı"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вимкнено"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимкнено"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tắt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tắt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "關閉"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉"
           }
         }
       }
     },
-    "config.dxvkHud.partial" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جزئي"
+    "config.dxvkHud.partial": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جزئي"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Částečný"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Částečný"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delvis"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delvis"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teilweise"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teilweise"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partial"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partial"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parcial"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcial"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Osittainen"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Osittainen"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partiel"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partiel"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parziale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parziale"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一部"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一部"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "일부"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일부"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gedeeltelijk"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gedeeltelijk"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Częściowy"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Częściowy"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parcial"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcial"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parcial"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcial"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parțial"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parțial"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Частичный"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Частичный"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kısmi"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kısmi"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Частковий"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Частковий"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Một phần"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Một phần"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "部分"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "部份"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部份"
           }
         }
       }
     },
-    "config.enhancedSync" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مزامنة محسنة"
+    "config.enhancedSync": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مزامنة محسنة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enhanced Sync"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enhanced Sync"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enhanced Sync"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enhanced Sync"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbessertes Sync"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbessertes Sync"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enhanced Sync"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enhanced Sync"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronización mejorada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización mejorada"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parannettu Synkronointi"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parannettu Synkronointi"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Avancée"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Avancée"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enhanced Sync"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enhanced Sync"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enhanced Sync"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enhanced Sync"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "향상된 동기 처리"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "향상된 동기 처리"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enhanced Sync"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enhanced Sync"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rodzaj synchronizacji"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rodzaj synchronizacji"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enhanced Sync"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enhanced Sync"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronização melhorada"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronização melhorada"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enhanced Sync"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enhanced Sync"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Улучшенная синхронизация"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Улучшенная синхронизация"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enhanced Sync"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enhanced Sync"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Розширена синхронізація"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розширена синхронізація"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync nâng cao"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync nâng cao"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "增强同步"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "增强同步"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "增強同步"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "增強同步"
           }
         }
       }
     },
-    "config.enhancedSync.esync" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+    "config.enhancedSync.esync": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ESync"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESync"
           }
         }
       }
     },
-    "config.enhancedSync.msync" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+    "config.enhancedSync.msync": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MSync"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MSync"
           }
         }
       }
     },
-    "config.enhancedSync.none" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا شَيْء"
+    "config.enhancedSync.none": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا شَيْء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Žádný"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Žádný"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keiner"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keiner"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "None"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ninguna"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei mitään"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ei mitään"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuno"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuno"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "なし"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "なし"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "끄기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "끄기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brak"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niciunul"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niciunul"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не задана"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не задана"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hiçbiri"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiçbiri"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Немає"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không có"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無"
           }
         }
       }
     },
-    "config.forceD3D11" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Force DirectX 11"
+    "config.forceD3D11": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Force DirectX 11"
           }
         }
       }
     },
-    "config.forceD3D11.info" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use D3D11 mode for better compatibility with older games"
+    "config.forceD3D11.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use D3D11 mode for better compatibility with older games"
           }
         }
       }
     },
-    "config.inspect" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعداد..."
+    "config.inspect": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعداد..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurovat..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurovat..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurer..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurer..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurieren..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurieren..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configure..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configure..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurar..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguroi..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguroi..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurer..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurer..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configura..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configura..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구성..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구성..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configureer..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configureer..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguruj..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguruj..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurar..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurar..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurează..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurează..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настроить..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настроить..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigüre et..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigüre et..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Налаштувати..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштувати..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "配置..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定⋯"
           }
         }
       }
     },
-    "config.installVcRedist" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install VC++ Runtime"
+    "config.installVcRedist": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install VC++ Runtime"
           }
         }
       }
     },
-    "config.installVcRedist.info" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Required for Unity games (fixes il2cpp errors)"
+    "config.installVcRedist.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Required for Unity games (fixes il2cpp errors)"
           }
         }
       }
     },
-    "config.metalHud" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+    "config.metalHud": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HUD Metal"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD Metal"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hud Metal"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hud Metal"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HUD Metal"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD Metal"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal HUD"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal HUD"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal 抬頭顯示"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal 抬頭顯示"
           }
         }
       }
     },
-    "config.metalTrace" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal Trace"
+    "config.metalTrace": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Trace"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trasa Metal"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trasa Metal"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal Trace"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Trace"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal Trace"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Trace"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal Trace"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Trace"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal Trace"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Trace"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal Jäljitin"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Jäljitin"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnostic de Metal"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostic de Metal"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tracciatura Metal"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tracciatura Metal"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal トレース"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal トレース"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal Trace"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Trace"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal tracering"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal tracering"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Śledź Metal"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Śledź Metal"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Registros Metal"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros Metal"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnóstico Metal"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico Metal"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trace Metal"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trace Metal"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Трассировка Metal"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Трассировка Metal"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal İzleme"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal İzleme"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal Trace"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Trace"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal Trace"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Trace"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal 性能分析"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal 性能分析"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal 追蹤"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal 追蹤"
           }
         }
       }
     },
-    "config.metalTrace.info" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يسمح لك بالتقاط عبء عمل الـGPU في Xcode"
+    "config.metalTrace.info": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يسمح لك بالتقاط عبء عمل الـGPU في Xcode"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umožňuje ti zachytit zatížení GPU v Xcode"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umožňuje ti zachytit zatížení GPU v Xcode"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giver dig mulighed for at fange GPU-workload i Xcode"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giver dig mulighed for at fange GPU-workload i Xcode"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erlaubt es dir, den GPU-Workload in Xcode aufzunehmen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlaubt es dir, den GPU-Workload in Xcode aufzunehmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allows you to capture GPU workload in Xcode"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allows you to capture GPU workload in Xcode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite capturar la carga de trabajo de la GPU en Xcode"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite capturar la carga de trabajo de la GPU en Xcode"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mahdollistaa GPU työn nappaamisen Xcodessa"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mahdollistaa GPU työn nappaamisen Xcodessa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permet de capturer la charge de travail GPU dans Xcode"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permet de capturer la charge de travail GPU dans Xcode"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permette di catturare il carico di lavoro della GPU in Xcode"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permette di catturare il carico di lavoro della GPU in Xcode"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xcode で GPU ワークロードをキャプチャできるようにします"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xcode で GPU ワークロードをキャプチャできるようにします"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xcode에서 GPU 워크로드를 기록할 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xcode에서 GPU 워크로드를 기록할 수 있습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maakt GPU werklast captures mogelijk"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maakt GPU werklast captures mogelijk"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umożliwia przechwytywanie obciążenia GPU w Xcode"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umożliwia przechwytywanie obciążenia GPU w Xcode"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite capturar a carga de trabalho da GPU no Xcode"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite capturar a carga de trabalho da GPU no Xcode"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite capturar a carga de trabalho da GPU no Xcode"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite capturar a carga de trabalho da GPU no Xcode"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permite captarea sarcinii de lucru GPU în Xcode"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite captarea sarcinii de lucru GPU în Xcode"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Позволяет отслеживать рабочую нагрузку видеокарты через Xcode"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Позволяет отслеживать рабочую нагрузку видеокарты через Xcode"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xcode'da GPU iş yükünü yakalamak için kullanılır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xcode'da GPU iş yükünü yakalamak için kullanılır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дозволяє вам відстежувати навантаження GPU в Xcode"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дозволяє вам відстежувати навантаження GPU в Xcode"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cho phép lấy thông tin GPU trong Xcode"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cho phép lấy thông tin GPU trong Xcode"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "允许你在 Xcode 中抓取 GPU 工作负载"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许你在 Xcode 中抓取 GPU 工作负载"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "允許在 Xcode 中擷取 GPU 工作負載"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允許在 Xcode 中擷取 GPU 工作負載"
           }
         }
       }
     },
-    "config.notAvailable" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا يوجد"
+    "config.notAvailable": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يوجد"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "N/A"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "N/A"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ikke tilgængelig"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ikke tilgængelig"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Angabe"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Angabe"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "N/A"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "N/A"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No disponible"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei saatavilla"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ei saatavilla"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "N/A"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "N/A"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "N/D"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "N/D"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "存在しません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存在しません"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사용 불가"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 불가"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "N.v.t."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "N.v.t."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie dotyczy"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie dotyczy"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indisponível"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indisponível"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "N/D"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "N/D"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "N/A"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "N/A"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Недоступно"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недоступно"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mevcut değil"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mevcut değil"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Н/Д"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Н/Д"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không có sẵn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có sẵn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不适用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不适用"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不適用"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不適用"
           }
         }
       }
     },
-    "config.performancePreset" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Performance Preset"
+    "config.performancePreset": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Performance Preset"
           }
         }
       }
     },
-    "config.preset.balanced.desc" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default settings for most games"
+    "config.preset.balanced.desc": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default settings for most games"
           }
         }
       }
     },
-    "config.preset.performance.desc" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prioritizes FPS over visual quality. Good for FPS drops."
+    "config.preset.performance.desc": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prioritizes FPS over visual quality. Good for FPS drops."
           }
         }
       }
     },
-    "config.preset.quality.desc" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prioritizes visual quality over performance."
+    "config.preset.quality.desc": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prioritizes visual quality over performance."
           }
         }
       }
     },
-    "config.preset.unity.desc" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Optimized for Unity/IL2CPP games (Genshin, etc.)"
+    "config.preset.unity.desc": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optimized for Unity/IL2CPP games (Genshin, etc.)"
           }
         }
       }
     },
-    "config.regedit" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فتح محرر التسجيل"
+    "config.regedit": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح محرر التسجيل"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otevřít editor databáze registrů"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otevřít editor databáze registrů"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åbn Registry Editor"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn Registry Editor"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Registry-Editor öffnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registry-Editor öffnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Registry Editor"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Registry Editor"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Editor de Registro"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Editor de Registro"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avaa rekisterin muokkain"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa rekisterin muokkain"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir l'Éditeur de Registre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir l'Éditeur de Registre"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri editor del Registro"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri editor del Registro"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "レジストリ エディターを開く"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レジストリ エディターを開く"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "레지스트리 편집기 열기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레지스트리 편집기 열기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Register Editor"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Register Editor"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otwórz edytor rejestru"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz edytor rejestru"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Editor do Registro"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Editor do Registro"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Editor de Registo"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Editor de Registo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deschide Editorul de Registre"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deschide Editorul de Registre"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть Редактор реестра"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть Редактор реестра"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kayıt Düzenleyicisi'ni Aç"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kayıt Düzenleyicisi'ni Aç"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відкрити Редактор Реєстру"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити Редактор Реєстру"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở Registry Editor"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở Registry Editor"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开注册表编辑器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开注册表编辑器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟註冊表編輯器"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟註冊表編輯器"
           }
         }
       }
     },
-    "config.repairPrefix" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Repair Wine Prefix"
+    "config.repairPrefix": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repair Wine Prefix"
           }
         }
       }
     },
-    "config.repairPrefix.failed" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Repair Failed"
+    "config.repairPrefix.failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repair Failed"
           }
         }
       }
     },
-    "config.repairPrefix.help" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reinitializes the Wine prefix to fix missing user directories"
+    "config.repairPrefix.help": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reinitializes the Wine prefix to fix missing user directories"
           }
         }
       }
     },
-    "config.repairPrefix.success" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Repair Successful"
+    "config.repairPrefix.success": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repair Successful"
           }
         }
       }
     },
-    "config.repairPrefix.successMessage" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The Wine prefix has been repaired successfully."
+    "config.repairPrefix.successMessage": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Wine prefix has been repaired successfully."
           }
         }
       }
     },
-    "config.repairPrefix.validationFailed" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prefix validation failed after repair"
+    "config.repairPrefix.validationFailed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prefix validation failed after repair"
           }
         }
       }
     },
-    "config.retinaMode" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وضع Retina"
+    "config.retinaMode": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وضع Retina"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Režim Retina"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Režim Retina"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retina Tilstand"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retina Tilstand"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retina-Modus"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retina-Modus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retina Mode"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retina Mode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo Retina"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo Retina"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retina-tila"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retina-tila"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mode Retina"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode Retina"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modalità Retina"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità Retina"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retina モード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retina モード"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retina 모드"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retina 모드"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retina Modus"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retina Modus"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tryb Retina"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryb Retina"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo Retina"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo Retina"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo Retina"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo Retina"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mod Retina"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mod Retina"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Режим Retina"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Режим Retina"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retina Modu"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retina Modu"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Режим Retina"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Режим Retina"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chế độ Retina"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chế độ Retina"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retina 模式"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retina 模式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retina 模式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retina 模式"
           }
         }
       }
     },
-    "config.sequoiaCompat" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sequoia Compatibility Mode"
+    "config.sequoiaCompat": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sequoia Compatibility Mode"
           }
         }
       }
     },
-    "config.sequoiaCompat.info" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Applies fixes for Steam and graphics issues on macOS 15.x"
+    "config.sequoiaCompat.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applies fixes for Steam and graphics issues on macOS 15.x"
           }
         }
       }
     },
-    "config.shaderCache" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shader Cache"
+    "config.shaderCache": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shader Cache"
           }
         }
       }
     },
-    "config.shaderCache.info" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cache compiled shaders for faster loading"
+    "config.shaderCache.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cache compiled shaders for faster loading"
           }
         }
       }
     },
-    "config.title.dxvk" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+    "config.title.dxvk": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DXVK"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DXVK"
           }
         }
       }
     },
-    "config.title.metal" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+    "config.title.metal": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal"
           }
         }
       }
     },
-    "config.title.performance" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Performance"
+    "config.title.performance": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Performance"
           }
         }
       }
     },
-    "config.title.wine" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+    "config.title.wine": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine"
           }
         }
       }
     },
-    "config.vcRedistInstalled" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VC++ Runtime Installed"
+    "config.vcRedistInstalled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VC++ Runtime Installed"
           }
         }
       }
     },
-    "config.winecfg" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فتح تكوين Wine"
+    "config.winecfg": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح تكوين Wine"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otevřít konfiguraci Wine"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otevřít konfiguraci Wine"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åben Wine Konfiguration"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åben Wine Konfiguration"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öffne die Wine-Konfiguration"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne die Wine-Konfiguration"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Wine Configuration"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Wine Configuration"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir configuración de Wine"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir configuración de Wine"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avaa Wine konfiguraatio"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa Wine konfiguraatio"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir la configuration de Wine"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir la configuration de Wine"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri configurazione Wine"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri configurazione Wine"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine 設定を開く"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine 設定を開く"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine 설정 열기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine 설정 열기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Wine Configuratie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Wine Configuratie"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otwórz konfigurację Wine"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz konfigurację Wine"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Configuração do Wine"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Configuração do Wine"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Configuração do Wine"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Configuração do Wine"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deschide Configurarea Wine"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deschide Configurarea Wine"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть конфигурацию Wine"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть конфигурацию Wine"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine Yapılandırmasını Aç"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine Yapılandırmasını Aç"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відкрити налаштування Wine"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити налаштування Wine"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở cài đặt Wine"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở cài đặt Wine"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开 Wine 配置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 Wine 配置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟Wine設定"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟Wine設定"
           }
         }
       }
     },
-    "config.winVersion" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إصدار Windows"
+    "config.winVersion": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إصدار Windows"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verze Windows"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verze Windows"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows-version"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows-version"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows Version"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows Version"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows Version"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows Version"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión de Windows"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión de Windows"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows versio"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows versio"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version de Windows"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version de Windows"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione di Windows"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione di Windows"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows のバージョン"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows のバージョン"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows 버전"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows 버전"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows-versie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows-versie"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wersja Windows"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wersja Windows"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão do Windows"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão do Windows"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão do Windows"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão do Windows"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versiune Windows"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versiune Windows"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версия Windows"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версия Windows"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows Sürümü"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows Sürümü"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версія Windows"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версія Windows"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phiên bản Windows"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phiên bản Windows"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows 版本"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows 版本"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows 版本"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows 版本"
           }
         }
       }
     },
-    "configDpi.dpi" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+    "configDpi.dpi": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PPP"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PPP"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI"
           }
         }
       }
     },
-    "configDpi.preview" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "سيبدو النص هكذا:"
+    "configDpi.preview": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سيبدو النص هكذا:"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text bude vypadat takto:"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text bude vypadat takto:"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teksten vil se sådan ud:"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teksten vil se sådan ud:"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Text wird wie folgt aussehen:"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Text wird wie folgt aussehen:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text will look like this:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text will look like this:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se verá así:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se verá así:"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teksti tulee näyttämään tältä:"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teksti tulee näyttämään tältä:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le texte ressemblera à ça :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le texte ressemblera à ça :"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il testo apparirà così:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il testo apparirà così:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "テキストはこのように見えます:"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストはこのように見えます:"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "텍스트는 다음과 같이 표시될 것입니다:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "텍스트는 다음과 같이 표시될 것입니다:"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tekst ziet er als volgt uit:"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tekst ziet er als volgt uit:"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tekst będzie wyglądał tak:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tekst będzie wyglądał tak:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O texto ficará assim:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O texto ficará assim:"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O texto ficará assim:"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O texto ficará assim:"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Textul va arăta astfel:"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Textul va arăta astfel:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Текст будет выглядеть так:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Текст будет выглядеть так:"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metin bu şekilde gözükecek:"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metin bu şekilde gözükecek:"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Текст виглядатиме так:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Текст виглядатиме так:"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chữ sẽ trông như thế này:"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ sẽ trông như thế này:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文字外观示例："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字外观示例："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文本外觀範例："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文本外觀範例："
           }
         }
       }
     },
-    "configDpi.previewText" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الثعالب البني السريع يقفز فوق الكلب الكسول."
+    "configDpi.previewText": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الثعالب البني السريع يقفز فوق الكلب الكسول."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Příliš žluťoučký kůň úpěl ďábelské ódy."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Příliš žluťoučký kůň úpěl ďábelské ódy."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen Walther spillede på xylofon."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen Walther spillede på xylofon."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The quick brown fox jumps over the lazy dog."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The quick brown fox jumps over the lazy dog."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El zorro rápido y marrón saltó sobre el perro perezoso."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El zorro rápido y marrón saltó sobre el perro perezoso."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Albert osti fagotin ja töräytti puhkuvan melodian."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Albert osti fagotin ja töräytti puhkuvan melodian."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voix ambiguë d'un cœur qui, au zéphyr, préfère les jattes de kiwis."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voix ambiguë d'un cœur qui, au zéphyr, préfère les jattes de kiwis."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ma la volpe, col suo balzo, ha raggiunto il quieto Fido."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ma la volpe, col suo balzo, ha raggiunto il quieto Fido."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "色は匂へど　散りぬるを　我が世誰ぞ　常ならむ　有為の奥山　今日越えて　浅き夢見じ　酔ひもせず。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "色は匂へど　散りぬるを　我が世誰ぞ　常ならむ　有為の奥山　今日越えて　浅き夢見じ　酔ひもせず。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다람쥐 헌 쳇바퀴에 타고파."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다람쥐 헌 쳇바퀴에 타고파."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pa’s wijze lynx bezag vroom het fikse aquaduct."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pa’s wijze lynx bezag vroom het fikse aquaduct."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Szybki brązowy lis przeskorzył przez leniwego psa."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szybki brązowy lis przeskorzył przez leniwego psa."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A rápida raposa marrom pula sobre o cachorro preguiçoso."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A rápida raposa marrom pula sobre o cachorro preguiçoso."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A raposa castanha ágil salta por cima do cão preguiçoso."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A raposa castanha ágil salta por cima do cão preguiçoso."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The quick brown fox jumps over the lazy dog."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The quick brown fox jumps over the lazy dog."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Съешь же ещё этих мягких французских булок, да выпей чаю."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Съешь же ещё этих мягких французских булок, да выпей чаю."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pijamalı hasta yağız şoföre çabucak güvendi."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pijamalı hasta yağız şoföre çabucak güvendi."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жебракують філософи при ґанку церкви в Гадячі, ще й шатро їхнє п’яне знаємо."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Жебракують філософи при ґанку церкви в Гадячі, ще й шатро їхнє п’яне знаємо."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chú cáo nâu nhanh nhẹn nhảy qua chú chó lười biếng."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chú cáo nâu nhanh nhẹn nhảy qua chú chó lười biếng."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中国智造，慧及全球"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中国智造，慧及全球"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "敏捷的棕色狐狸跳過了懶狗。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "敏捷的棕色狐狸跳過了懶狗。"
           }
         }
       }
     },
-    "configDpi.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعدادات DPI"
+    "configDpi.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعدادات DPI"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení DPI"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nastavení DPI"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI Indstillinger"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI Indstillinger"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI-Einstellungen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI-Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes DPI"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes DPI"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI asetukset"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI asetukset"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres du PPP"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramètres du PPP"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni DPI"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni DPI"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI 設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI 設定"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI 설정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI 설정"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI-instellingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI-instellingen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ustawienia DPI"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienia DPI"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurações de DPI"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurações de DPI"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurações de DPI"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurações de DPI"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setări DPI"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setări DPI"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройка DPI"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройка DPI"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI Ayarları"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI Ayarları"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Налаштування DPI"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування DPI"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt DPI"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt DPI"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI 设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI 设置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DPI 設定"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DPI 設定"
           }
         }
       }
     },
-    "Configuration Warnings" : {
-
+    "Configuration Warnings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration Warnings"
+          }
+        }
+      }
     },
-    "Copy to Clipboard" : {
-
+    "Copy to Clipboard": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy to Clipboard"
+          }
+        }
+      }
     },
-    "create.browse" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تصفح"
+    "create.browse": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصفح"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Procházet"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Procházet"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gennemse"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gennemse"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durchsuchen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durchsuchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browse"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Explorar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explorar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selaa"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selaa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Explorer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explorer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esplora"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esplora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "変更..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "탐색"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탐색"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoek"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zoek"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przeglądaj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przeglądaj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Procurar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Procurar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Explorar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explorar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caută"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caută"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обзор"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обзор"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gözat"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gözat"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Огляд"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Огляд"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duyệt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duyệt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "浏览"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "瀏覽"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "瀏覽"
           }
         }
       }
     },
-    "create.cancel" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إلغاء"
+    "create.cancel": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zrušit"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zrušit"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuller"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuller"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Peru"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peru"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuleren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuleren"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anuluj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuluj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anulează"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anulează"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İptal"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İptal"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скасувати"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скасувати"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Huỷ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huỷ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "create.create" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إنشاء"
+    "create.create": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إنشاء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vytořit"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vytořit"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opret"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opret"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luo"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作成"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "생성"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생성"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aanmaken"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aanmaken"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utwórz"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utwórz"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creează"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creează"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создать"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oluştur"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oluştur"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Створити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tạo"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "建立"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建立"
           }
         }
       }
     },
-    "create.name" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اسم القارورة:"
+    "create.name": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسم القارورة:"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Název láhve:"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Název láhve:"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle navn:"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle navn:"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle-Name:"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle-Name:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle name:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle name:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nombre de la botella:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre de la botella:"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pullon nimi:"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pullon nimi:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nom de la bouteille :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom de la bouteille :"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome bottiglia:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome bottiglia:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle 名:"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle 名:"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle 이름:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle 이름:"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fles naam:"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fles naam:"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nazwa butelki:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nazwa butelki:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome da Bottle:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome da Bottle:"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome da Bottle:"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome da Bottle:"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Numele sticlei:"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numele sticlei:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Название бутылки:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Название бутылки:"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle Adı:"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle Adı:"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Назва пляшки:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назва пляшки:"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tên Bottle:"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tên Bottle:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "容器名称："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "容器名称："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "容器名稱："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "容器名稱："
           }
         }
       }
     },
-    "create.path" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مسار القارورة:"
+    "create.path": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسار القارورة:"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cesta k lahvi:"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cesta k lahvi:"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle sti:"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle sti:"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle-Pfad:"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle-Pfad:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle path:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle path:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ubicación de la botella:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ubicación de la botella:"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pullon polku:"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pullon polku:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chemin de la bouteille :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin de la bouteille :"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Percorso della bottiglia:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Percorso della bottiglia:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle の場所:"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle の場所:"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle 경로:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle 경로:"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fles pad:"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fles pad:"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ścieżka butelki:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ścieżka butelki:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caminho da Bottle:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caminho da Bottle:"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caminho do Bottle:"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caminho do Bottle:"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Locația sticlei:"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locația sticlei:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Путь к бутылке:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Путь к бутылке:"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle Dosya Yolu:"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle Dosya Yolu:"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Шлях до пляшки:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шлях до пляшки:"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đường dẫn bottle:"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đường dẫn bottle:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "容器路径："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "容器路径："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "容器路徑："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "容器路徑："
           }
         }
       }
     },
-    "create.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إنشاء قارورة جديدة"
+    "create.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إنشاء قارورة جديدة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vytvořit novou láhev"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vytvořit novou láhev"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opret en ny bottle"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opret en ny bottle"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstelle eine neue Bottle"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstelle eine neue Bottle"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create a new bottle"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create a new bottle"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear una botella nueva"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear una botella nueva"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luo uusi pullo"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luo uusi pullo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer une nouvelle bouteille"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer une nouvelle bouteille"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea una nuova bottiglia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea una nuova bottiglia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新しい Bottle を作成"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しい Bottle を作成"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "새로운 Bottle 생성"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로운 Bottle 생성"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maak een nieuwe fles"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maak een nieuwe fles"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utwórz nową butelkę"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utwórz nową butelkę"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar uma nova Bottle"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar uma nova Bottle"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar uma nova Bottle"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar uma nova Bottle"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creează o sticlă nouă"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creează o sticlă nouă"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создать новую бутылку"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать новую бутылку"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yeni bir Bottle Oluştur"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni bir Bottle Oluştur"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Створити нову пляшку"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створити нову пляшку"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tạo bottle mới"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo bottle mới"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建新的容器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建新的容器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "建立一個新的容器"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建立一個新的容器"
           }
         }
       }
     },
-    "create.win" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إصدار Windows:"
+    "create.win": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إصدار Windows:"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verze Windows:"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verze Windows:"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows-version:"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows-version:"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows Version:"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows Version:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows version:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows version:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión de Windows:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión de Windows:"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows versio:"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows versio:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version de Windows :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version de Windows :"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione di Windows:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione di Windows:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows バージョン:"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows バージョン:"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows 버전:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows 버전:"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows versie:"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows versie:"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wersja Windows:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wersja Windows:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão do Windows:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão do Windows:"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão do Windows:"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão do Windows:"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versiune Windows:"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versiune Windows:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версия Windows:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версия Windows:"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows sürümü:"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows sürümü:"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версія Windows:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версія Windows:"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phiên bản Windows:"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phiên bản Windows:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows 版本："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows 版本："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windows 版本："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows 版本："
           }
         }
       }
     },
-    "Detected:" : {
-
+    "Detected:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detected:"
+          }
+        }
+      }
     },
-    "Detection Mode:" : {
-
+    "Detection Mode:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detection Mode:"
+          }
+        }
+      }
     },
-    "Done" : {
-
+    "Done": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        }
+      }
     },
-    "Enables automatic fixes for Steam, Rockstar, EA App, Epic Games, and other game launchers (frankea/Whisky#41)" : {
-
+    "Enables automatic fixes for Steam, Rockstar, EA App, Epic Games, and other game launchers (frankea/Whisky#41)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enables automatic fixes for Steam, Rockstar, EA App, Epic Games, and other game launchers (frankea/Whisky#41)"
+          }
+        }
+      }
     },
-    "environment.add" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إضافة"
+    "environment.add": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přidat"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přidat"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilføj"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilføj"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinzufügen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzufügen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Añadir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lisää"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lisää"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追加"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "추가"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추가"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toevoegen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toevoegen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dodaj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodaj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adăugați"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adăugați"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ekle"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ekle"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Додати"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Додати"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thêm"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thêm"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新建"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新增"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增"
           }
         }
       }
     },
-    "environment.remove" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إزالة"
+    "environment.remove": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odebrat"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odebrat"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entfernen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "削除"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제거"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제거"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijderen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijderen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminați"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminați"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaldır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaldır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gỡ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gỡ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
           }
         }
       }
     },
-    "Export to File" : {
-
+    "Export to File": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export to File"
+          }
+        }
+      }
     },
-    "Fixes Steam download stalls and connection timeouts" : {
-
+    "Fixes Steam download stalls and connection timeouts": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixes Steam download stalls and connection timeouts"
+          }
+        }
+      }
     },
-    "Forces %@ locale to fix steamwebhelper crashes" : {
-
+    "Forces %@ locale to fix steamwebhelper crashes": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forces %@ locale to fix steamwebhelper crashes"
+          }
+        }
+      }
     },
-    "Generate Diagnostics Report" : {
-
+    "Generate Diagnostics Report": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generate Diagnostics Report"
+          }
+        }
+      }
     },
-    "GPU Spoofing" : {
-
+    "GPU Spoofing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPU Spoofing"
+          }
+        }
+      }
     },
-    "GPU Vendor:" : {
-
+    "GPU Vendor:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPU Vendor:"
+          }
+        }
+      }
     },
-    "help.github" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Github"
+    "help.github": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Github"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Github"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Github"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "깃허브"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "깃허브"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
           }
         }
       }
     },
-    "help.issues" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإبلاغ عن مشكلة"
+    "help.issues": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإبلاغ عن مشكلة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nahlásit problém"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nahlásit problém"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rapporter problem"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rapporter problem"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Problem melden"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problem melden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report Issues"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report Issues"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reportar problemas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reportar problemas"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ilmoita ongelmasta"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ilmoita ongelmasta"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signaler un problème"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signaler un problème"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Segnala problemi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Segnala problemi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "問題を報告"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "問題を報告"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "문제 보고"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문제 보고"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Meld problemen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meld problemen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zgłoś problem"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zgłoś problem"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relatar problemas"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relatar problemas"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reportar problemas"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reportar problemas"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raportați probleme"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raportați probleme"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сообщить о проблеме"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщить о проблеме"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sorun bildir"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sorun bildir"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Повідомити про проблему"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повідомити про проблему"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Báo cáo vấn đề"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Báo cáo vấn đề"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "报告问题"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "报告问题"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回報問題"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回報問題"
           }
         }
       }
     },
-    "help.website" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الموقع الالكتروني"
+    "help.website": {
+      "extractionState": "stale",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الموقع الالكتروني"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Webové stránky"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webové stránky"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hjemmeside"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hjemmeside"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Webseite"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webseite"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitio Web"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitio Web"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verkkosivu"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verkkosivu"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Site Web"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Site Web"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sito web"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sito web"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web サイト"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web サイト"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹 사이트"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹 사이트"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Strona internetowa"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Strona internetowa"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Página web"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página web"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagină Web"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagină Web"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сайт"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сайт"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Web sitesi"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Web sitesi"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Веб-сайт"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Веб-сайт"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trang web"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trang web"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "网站"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网站"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "網站"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網站"
           }
         }
       }
     },
-    "install.cli" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تثبيت Whisky CLI..."
+    "install.cli": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت Whisky CLI..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nainstalovat Whisky CLI..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nainstalovat Whisky CLI..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installer Whisky CLI..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer Whisky CLI..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky CLI installieren..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky CLI installieren..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Install Whisky CLI..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install Whisky CLI..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalar Whisky CLI..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar Whisky CLI..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asenna Whisky CLI..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asenna Whisky CLI..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installer Whisky CLI..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer Whisky CLI..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installa Whisky CLI..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installa Whisky CLI..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky CLI をインストール..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky CLI をインストール..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky CLI 설치..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky CLI 설치..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installeer de Whisky CLI..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installeer de Whisky CLI..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zainstaluj Whisky w formie CLI..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zainstaluj Whisky w formie CLI..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalar o Whisky CLI..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar o Whisky CLI..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalar Whisky CLI..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar Whisky CLI..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalează CLI Whisky..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalează CLI Whisky..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить Whisky CLI..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установить Whisky CLI..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky CLI'i Yükle..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky CLI'i Yükle..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Встановити інтерфейс командного рядка..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Встановити інтерфейс командного рядка..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt Whisky CLI..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt Whisky CLI..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安装 Whisky CLI..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装 Whisky CLI..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安裝Whisky CLI⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安裝Whisky CLI⋯"
           }
         }
       }
     },
-    "kill.bottles" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اقتل جميع القوارير"
+    "kill.bottles": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اقتل جميع القوارير"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ukončit všechny lahve"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukončit všechny lahve"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dræb Alle Bottles"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dræb Alle Bottles"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beende sofort alle Bottles"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beende sofort alle Bottles"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kill All Bottles"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kill All Bottles"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detener todas las Botellas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detener todas las Botellas"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tapa kaikki pullot"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tapa kaikki pullot"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fermer toutes les bouteilles"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermer toutes les bouteilles"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Termina tutte le bottiglie"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termina tutte le bottiglie"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべての Bottle を終了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての Bottle を終了"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모든 Bottle 종료하기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 Bottle 종료하기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop alle flessen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop alle flessen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zakończ wszystkie butelki"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zakończ wszystkie butelki"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Encerrar todas as Bottles"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Encerrar todas as Bottles"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Encerrar todas as Bottles..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Encerrar todas as Bottles..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oprește Toate Sticlele"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oprește Toate Sticlele"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закрыть все бутылки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрыть все бутылки"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tüm Bottle'ları Sonlandır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tüm Bottle'ları Sonlandır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Примусово завершити всі пляшки"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Примусово завершити всі пляшки"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dừng tất cả Bottle"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dừng tất cả Bottle"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止所有容器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止所有容器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "終止所有容器"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終止所有容器"
           }
         }
       }
     },
-    "Launcher Compatibility" : {
-
+    "Launcher Compatibility": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launcher Compatibility"
+          }
+        }
+      }
     },
-    "Launcher compatibility disables the Chromium sandbox (required for Wine). This allows Steam, Epic, EA App, and Rockstar launchers to function, but embedded browser content runs with full process privileges. Only use with trusted launchers from reputable companies." : {
-
+    "Launcher compatibility disables the Chromium sandbox (required for Wine). This allows Steam, Epic, EA App, and Rockstar launchers to function, but embedded browser content runs with full process privileges. Only use with trusted launchers from reputable companies.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launcher compatibility disables the Chromium sandbox (required for Wine). This allows Steam, Epic, EA App, and Rockstar launchers to function, but embedded browser content runs with full process privileges. Only use with trusted launchers from reputable companies."
+          }
+        }
+      }
     },
-    "Launcher Compatibility Mode" : {
-
+    "Launcher Compatibility Mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launcher Compatibility Mode"
+          }
+        }
+      }
     },
-    "Launcher Diagnostics Report" : {
-
+    "Launcher Diagnostics Report": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launcher Diagnostics Report"
+          }
+        }
+      }
     },
-    "Launcher Type:" : {
-
+    "Launcher Type:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launcher Type:"
+          }
+        }
+      }
     },
-    "Locale Override:" : {
-
+    "Locale Override:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locale Override:"
+          }
+        }
+      }
     },
-    "locale.auto" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تلقائي"
+    "locale.auto": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تلقائي"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Automatic"
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Automatic"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisk"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisk"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatic"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automático"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automático"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automaattinen"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automaattinen"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatique"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatique"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatico"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatico"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자동"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatyczne"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatyczne"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automático"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automático"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automático"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automático"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automat"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automat"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автоматический выбор"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматический выбор"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otomatik"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otomatik"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автоматично"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматично"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tự động"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự động"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
           }
         }
       }
     },
-    "locale.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "محلي"
+    "locale.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محلي"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Locale"
+        "cs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Locale"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprog"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprog"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Locale"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locale"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Localización"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Localización"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kieli"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kieli"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Langue"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langue"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lingua"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingua"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "言語"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "언어"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "언어"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taal"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taal"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ustawienie regionalne"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienie regionalne"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Locale"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locale"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Localizare"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Localizare"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Языковой стандарт (локаль)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Языковой стандарт (локаль)"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yerel"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yerel"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Мова"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мова"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Địa điểm"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Địa điểm"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "本地化语言"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地化语言"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語言地區"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語言地區"
           }
         }
       }
     },
-    "main.createFirst" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "قم بإنشاء قارورتك الأولى للبدء"
+    "main.createFirst": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قم بإنشاء قارورتك الأولى للبدء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pro začátek musíte vytvořit svou první láhev"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro začátek musíte vytvořit svou první láhev"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opret din første bottle for at komme igang"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opret din første bottle for at komme igang"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellen Sie Ihre erste Flasche, um loszulegen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen Sie Ihre erste Flasche, um loszulegen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create your first bottle to get started"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create your first bottle to get started"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea tu primera botella para comenzar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea tu primera botella para comenzar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Luo ensimmäinen pullo, jotta voit aloittaa"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luo ensimmäinen pullo, jotta voit aloittaa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créez votre première bouteille pour commencer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créez votre première bouteille pour commencer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea la tua prima bottiglia per iniziare"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea la tua prima bottiglia per iniziare"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最初の Bottle を作りましょう"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最初の Bottle を作りましょう"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "첫 번째 Bottle을 만들어 시작하기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "첫 번째 Bottle을 만들어 시작하기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maak je eerste bottle om te beginnen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maak je eerste bottle om te beginnen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stwórz swoją pierwszą butelkę, aby rozpocząć"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stwórz swoją pierwszą butelkę, aby rozpocząć"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crie sua primeira Bottle para começar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crie sua primeira Bottle para começar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crie a sua primeira bottle para começar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crie a sua primeira bottle para começar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creaţi-vă prima sticlă pentru a începe"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creaţi-vă prima sticlă pentru a începe"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создайте первую бутылку, чтобы начать"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создайте первую бутылку, чтобы начать"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Başlamak için ilk Bottle'ınızı oluşturunuz"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başlamak için ilk Bottle'ınızı oluşturunuz"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Створіть свою першу пляшку, щоб почати"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створіть свою першу пляшку, щоб почати"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tạo bottle đầu tiên của bạn để bắt đầu"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo bottle đầu tiên của bạn để bắt đầu"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从创建第一个容器开始"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从创建第一个容器开始"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "建立你的第一個容器以開始"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建立你的第一個容器以開始"
           }
         }
       }
     },
-    "Manual" : {
-
+    "Manual": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manual"
+          }
+        }
+      }
     },
-    "Manually select the launcher type for this bottle" : {
-
+    "Manually select the launcher type for this bottle": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manually select the launcher type for this bottle"
+          }
+        }
+      }
     },
-    "Network Timeout:" : {
-
+    "Network Timeout:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network Timeout:"
+          }
+        }
+      }
     },
-    "None" : {
-
+    "None": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None"
+          }
+        }
+      }
     },
-    "NVIDIA (recommended) provides best compatibility across launchers" : {
-
+    "NVIDIA (recommended) provides best compatibility across launchers": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NVIDIA (recommended) provides best compatibility across launchers"
+          }
+        }
+      }
     },
-    "open.bottle" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استيراد قارورة"
+    "open.bottle": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استيراد قارورة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importovat láhev"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importovat láhev"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importér Bottle"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importér Bottle"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flasche importieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flasche importieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import Bottle"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Bottle"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importar Botella"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar Botella"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tuo pullo"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuo pullo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importer une bouteille"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer une bouteille"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importa bottiglia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa bottiglia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle をインポート"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle をインポート"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle 불러오기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle 불러오기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importeer Fles"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importeer Fles"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importuj butelkę"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importuj butelkę"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importar Bottle"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar Bottle"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importar Bottle"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar Bottle"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importă Sticlă"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importă Sticlă"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Импортировать бутылку"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Импортировать бутылку"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle'ı İçeri Aktarın"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle'ı İçeri Aktarın"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Імпортувати пляшку"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Імпортувати пляшку"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nhập Bottle"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhập Bottle"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "导入容器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入容器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "导入容器"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入容器"
           }
         }
       }
     },
-    "open.logs" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فتح مجلد السجلات"
+    "open.logs": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح مجلد السجلات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otevřít složku s logy"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otevřít složku s logy"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åbn Logmappe"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn Logmappe"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log-Folder öffnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Log-Folder öffnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Logs Folder"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Logs Folder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir carpeta de registros"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir carpeta de registros"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avaa log kansio"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa log kansio"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir le dossier des journaux"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir le dossier des journaux"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri la cartella dei log"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri la cartella dei log"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログフォルダを開く"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログフォルダを開く"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "로그 폴더 열기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그 폴더 열기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Logs map"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Logs map"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otwórz folder z logami"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz folder z logami"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Pasta dos Logs"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Pasta dos Logs"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Pasta dos Logs"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Pasta dos Logs"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deschide Folder-ul Logs"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deschide Folder-ul Logs"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть папку логов"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть папку логов"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log Klasörünü Aç"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Log Klasörünü Aç"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відкрити теку журналів"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити теку журналів"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở Folder Log"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở Folder Log"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开日志文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开日志文件夹"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟日誌資料夾"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟日誌資料夾"
           }
         }
       }
     },
-    "open.setup" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعداد..."
+    "open.setup": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعداد..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nastavení..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opsætning..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opsætning..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einrichtung..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einrichtung..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setup..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setup..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalar..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asennus..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asennus..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration initiale..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration initiale..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurazione..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurazione..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セットアップ..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットアップ..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설치..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설치..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installatie..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installatie..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguracja..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguracja..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalação..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalação..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurar..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurare..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurare..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установить..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установить..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kur..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kur..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Налаштування..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thiết lập..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thiết lập..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安装..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "配置⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置⋯"
           }
         }
       }
     },
-    "pin.create" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تثبيت"
+    "pin.create": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Připnout"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Připnout"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fastgør"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fastgør"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anpinnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anpinnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anclar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anclar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kiinnitä"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiinnitä"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Épingler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épingler"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fissa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fissa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ピン留めする"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ピン留めする"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "고정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고정"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vastpinnen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vastpinnen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przypnij"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przypnij"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fixar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fixează"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixează"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закрепить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрепить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sabitle"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sabitle"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закріпити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закріпити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ghim"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghim"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "置顶"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "置顶"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "釘選"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "釘選"
           }
         }
       }
     },
-    "pin.error.duplicate.%@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" مثبت بالفعل!"
+    "pin.error.duplicate.%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" مثبت بالفعل!"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" je již připnut!"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" je již připnut!"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" er allerede fastgjort!"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" er allerede fastgjort!"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" ist bereits angepinnt!"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" ist bereits angepinnt!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" is already pinned!"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" is already pinned!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡\"%@\" ya está anclado!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡\"%@\" ya está anclado!"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" on jo kiinnitetty!"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" on jo kiinnitetty!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" est déjà épinglé !"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" est déjà épinglé !"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" è già fissato!"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" è già fissato!"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ はすでにピン留めされています。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はすでにピン留めされています。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\"은(는) 이미 고정되어 있습니다!"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\"은(는) 이미 고정되어 있습니다!"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" is al vastgepind!"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" is al vastgepind!"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" jest już przypięty!"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" jest już przypięty!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" is already pinned!"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" is already pinned!"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" já está fixado!"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" já está fixado!"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" este deja fixat!"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" este deja fixat!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" уже закреплен!"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" уже закреплен!"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" zaten sabitlenmiş!"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" zaten sabitlenmiş!"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" вже закріплено!"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" вже закріплено!"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" đã được ghim!"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" đã được ghim!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" 已被置顶！"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" 已被置顶！"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「%@」已經釘選！"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」已經釘選！"
           }
         }
       }
     },
-    "pin.error.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خطأ في تدبيس البرنامج"
+    "pin.error.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطأ في تدبيس البرنامج"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chyba v připínání programu"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chyba v připínání programu"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fejl ved fastgørelse af program"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fejl ved fastgørelse af program"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler beim Anpinnen des Programms"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler beim Anpinnen des Programms"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error Pinning Program"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error Pinning Program"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error al fijar el programa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al fijar el programa"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Virhe kiinnittäessä ohjelmaa"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Virhe kiinnittäessä ohjelmaa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur en épinglant le programme"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur en épinglant le programme"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Errore creazione scorciatoia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore creazione scorciatoia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ピン留めに失敗しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ピン留めに失敗しました"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프로그램 고정 오류 발생"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로그램 고정 오류 발생"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fout tijdens vastpinnen van het programma"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fout tijdens vastpinnen van het programma"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Błąd podczas przypinania programu"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Błąd podczas przypinania programu"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error Pinning Program"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error Pinning Program"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro ao Fixar Programa"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro ao Fixar Programa"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu s-a Putut Fixa Programul"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nu s-a Putut Fixa Programul"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Произошла ошибка при закреплении программы"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Произошла ошибка при закреплении программы"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programı Sabitleme Hatası"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programı Sabitleme Hatası"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Помилка під час закріплення програми"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помилка під час закріплення програми"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chương trình ghim bị lỗi"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chương trình ghim bị lỗi"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "置顶程序出错"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "置顶程序出错"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "釘選程式時發生錯誤"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "釘選程式時發生錯誤"
           }
         }
       }
     },
-    "pin.help" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تدبيس البرنامج"
+    "pin.help": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تدبيس البرنامج"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Připnout program"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Připnout program"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fastgør program"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fastgør program"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programm anpinnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programm anpinnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin Program"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Program"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anclar programa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anclar programa"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kiinnitä ohjelma"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiinnitä ohjelma"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Épingler le Programme"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épingler le Programme"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi scorciatoia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi scorciatoia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新しくピン留め"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しくピン留め"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프로그램 고정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로그램 고정"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programma vastpinnen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programma vastpinnen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przypnij program"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przypnij program"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin Program"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Program"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fixar Programa"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixar Programa"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fixează Programul"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixează Programul"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закрепление программы"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрепление программы"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programı Sabitle"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programı Sabitle"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закріпити програму"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закріпити програму"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ghim chương trình"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghim chương trình"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "置顶程序"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "置顶程序"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "釘選程式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "釘選程式"
           }
         }
       }
     },
-    "pin.name" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اسم الدبوس:"
+    "pin.name": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسم الدبوس:"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Název připínáčku:"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Název připínáčku:"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Navn på fastgørelse:"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navn på fastgørelse:"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin Name:"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Name:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin name:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin name:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nombre del Anclaje:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del Anclaje:"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kiinnityksen nimi:"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiinnityksen nimi:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nom de l’épingle :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom de l’épingle :"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome della scorciatoia:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome della scorciatoia:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "名前:"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前:"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이름:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름:"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Naam pinnen:"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naam pinnen:"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nazwa przypinki:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nazwa przypinki:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin name:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin name:"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome do Fixo:"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome do Fixo:"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nume pin:"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nume pin:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закреплено:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закреплено:"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sabitleme Adı:"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sabitleme Adı:"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закріпити ім'я:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закріпити ім'я:"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tên của ghim:"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tên của ghim:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "置顶名称"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "置顶名称"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "釘選名稱："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "釘選名稱："
           }
         }
       }
     },
-    "pin.path" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مسار البرنامج:"
+    "pin.path": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسار البرنامج:"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cesta k programu:"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cesta k programu:"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programsti:"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programsti:"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programm Pfad:"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programm Pfad:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Program path:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program path:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruta del programa:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta del programa:"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ohjelman polku:"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ohjelman polku:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emplacement du programme :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emplacement du programme :"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Percorso del programma:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Percorso del programma:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パス:"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パス:"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프로그램 경로:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로그램 경로:"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programma pad:"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programma pad:"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ścieżka programu:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ścieżka programu:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Program path:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program path:"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caminho do programa:"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caminho do programa:"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Locația programului:"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locația programului:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Путь к программе:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Путь к программе:"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Program dosya yolu:"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program dosya yolu:"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Шлях до програми:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шлях до програми:"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đường dẫn chương trình:"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đường dẫn chương trình:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "程序路径"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "程序路径"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "程式路徑："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "程式路徑："
           }
         }
       }
     },
-    "pin.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تدبيس البرنامج"
+    "pin.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تدبيس البرنامج"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Připnout program"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Připnout program"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fastgør program"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fastgør program"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programm anpinnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programm anpinnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin Program"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Program"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anclar programa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anclar programa"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kiinnitä ohjelma"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiinnitä ohjelma"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Épingler le Programme"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épingler le Programme"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi scorciatoia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi scorciatoia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プログラムをピン留め"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プログラムをピン留め"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프로그램 고정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로그램 고정"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programma vastpinnen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programma vastpinnen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przypnij program"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przypnij program"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin Program"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Program"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fixar Programa"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixar Programa"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fixează Programul"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fixează Programul"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закрепить программу"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрепить программу"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programı Sabitle"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programı Sabitle"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закріпити програму"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закріпити програму"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ghim chương trình"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghim chương trình"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "置顶程序"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "置顶程序"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "釘選程式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "釘選程式"
           }
         }
       }
     },
-    "process.table.executable" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "قابل للتنفيذ"
+    "process.table.executable": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قابل للتنفيذ"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spustitelný soubor"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spustitelný soubor"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eksekverbar"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eksekverbar"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausführbare Datei"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausführbare Datei"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executable"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ejecutable"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutable"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suoritettava"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suoritettava"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exécutable"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécutable"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eseguibile"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eseguibile"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プロセスの実行ファイル"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセスの実行ファイル"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "실행 파일"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 파일"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uitvoerbaar bestand"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uitvoerbaar bestand"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plik wykonywalny"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plik wykonywalny"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executável"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executável"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executável"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executável"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executabil"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executabil"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Исполняемый файл"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Исполняемый файл"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Çalıştırılabilir"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalıştırılabilir"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виконуваний файл"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виконуваний файл"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tệp thi hành"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tệp thi hành"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "可执行文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可执行文件"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "可執行"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可執行"
           }
         }
       }
     },
-    "process.table.kill" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إيقاف العملية"
+    "process.table.kill": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف العملية"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zastavit proces"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zastavit proces"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop Processen"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Processen"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prozess beenden"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prozess beenden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop Process"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Process"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detener el proceso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detener el proceso"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sammuta prosessi"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sammuta prosessi"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrêter le processus"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter le processus"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esci dal processo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esci dal processo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したプロセスを停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したプロセスを停止"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프로세스 중지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로세스 중지"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proces stoppen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proces stoppen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zatrzymaj proces"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zatrzymaj proces"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parar Processo"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parar Processo"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parar Processo"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parar Processo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oprește Procesul"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oprește Procesul"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Остановить процесс"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Остановить процесс"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İşlemi Sonlandır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İşlemi Sonlandır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Зупинити Процес"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зупинити Процес"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dừng tiến trình"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dừng tiến trình"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "结束进程"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "结束进程"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止進程"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止進程"
           }
         }
       }
     },
-    "process.table.loading" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جلب العمليات"
+    "process.table.loading": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جلب العمليات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Získávám seznam procesů"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Získávám seznam procesů"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Henter Processer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Henter Processer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lade Prozesse"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lade Prozesse"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fetching Processes"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetching Processes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obteniendo procesos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obteniendo procesos"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haetaan prosesseja"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haetaan prosesseja"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Récupération des processus"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Récupération des processus"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ricerca dei processi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ricerca dei processi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プロセスを読み込み中"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセスを読み込み中"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프로세스 목록을 가져오는 중"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로세스 목록을 가져오는 중"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processen ophalen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processen ophalen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pobieranie procesu"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pobieranie procesu"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtendo Processos"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtendo Processos"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A obter Processos"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A obter Processos"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preluare Procese"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preluare Procese"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Получение списка процессов"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Получение списка процессов"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İşlemler Getiriliyor"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İşlemler Getiriliyor"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отримання процесів"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отримання процесів"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đang lấy những tiến trình"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang lấy những tiến trình"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在获取进程"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在获取进程"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在獲取進程"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在獲取進程"
           }
         }
       }
     },
-    "process.table.pid" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "معرّف العملية"
+    "process.table.pid": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معرّف العملية"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID procesu"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID procesu"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Process ID"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Process ID"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prozess ID"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prozess ID"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Process ID"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Process ID"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID del proceso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID del proceso"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prosessin ID"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prosessin ID"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID du processus"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID du processus"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID processo"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID processo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プロセス ID"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセス ID"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프로세스 ID"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로세스 ID"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proces ID"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proces ID"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Identyfikator procesu"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identyfikator procesu"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID do Processo"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID do Processo"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID do Processo"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID do Processo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID Proces"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID Proces"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID процесса"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID процесса"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İşlem Kimliği"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İşlem Kimliği"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ідентифікатор процесу"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ідентифікатор процесу"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mã ID tiến trình"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mã ID tiến trình"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "进程ID"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "进程ID"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "進程 ID"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "進程 ID"
           }
         }
       }
     },
-    "process.table.refresh" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحديث"
+    "process.table.refresh": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحديث"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obnovit"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obnovit"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opfrisk"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opfrisk"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualisieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refresh"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Päivitä"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Päivitä"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rafraîchir"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rafraîchir"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiorna"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiorna"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プロセスを再読み込み"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセスを再読み込み"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "새로 고침"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로 고침"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vernieuwen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vernieuwen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odśwież"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odśwież"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reîmprospătează"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reîmprospătează"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обновить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yenile"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yenile"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Оновити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оновити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Làm mới"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Làm mới"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刷新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新整理"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新整理"
           }
         }
       }
     },
-    "program.add.blocklist" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إضافة إلى القائمة السوداء"
+    "program.add.blocklist": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة إلى القائمة السوداء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přidat na listinu blokovaných"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přidat na listinu blokovaných"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Føj til blokeringsliste"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Føj til blokeringsliste"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zur Blockliste hinzufügen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zur Blockliste hinzufügen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add to Blocklist"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add to Blocklist"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Añadir a la lista de bloqueo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir a la lista de bloqueo"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lisää estolistaan"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lisää estolistaan"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter à la liste de programmes bloqués"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter à la liste de programmes bloqués"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi alla lista bloccati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi alla lista bloccati"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ブロックリストに追加"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブロックリストに追加"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "차단 목록에 추가"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "차단 목록에 추가"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voeg toe aan blokkeerlijst"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voeg toe aan blokkeerlijst"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dodaj do czarnej listy"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodaj do czarnej listy"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar à lista de bloqueio"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar à lista de bloqueio"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar à Lista de Bloqueio"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar à Lista de Bloqueio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adaugă la Blocklist"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adaugă la Blocklist"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавить в Черный список"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить в Черный список"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Engelleme Listesine Ekle"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Engelleme Listesine Ekle"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Додати до чорного списку"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Додати до чорного списку"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thêm vào danh sách chặn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thêm vào danh sách chặn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加到阻止列表"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加到阻止列表"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新增至黑名單"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增至黑名單"
           }
         }
       }
     },
-    "program.add.selected.blocklist" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إضافة المحدد إلى القائمة السوداء"
+    "program.add.selected.blocklist": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة المحدد إلى القائمة السوداء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přidat označené na listinu blokovaných"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přidat označené na listinu blokovaných"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilføj valgte til blokeringsliste"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilføj valgte til blokeringsliste"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewählte Bottle zur Sperrliste hinzufügen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählte Bottle zur Sperrliste hinzufügen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add Selected to Blocklist"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Selected to Blocklist"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Añadir seleccionado a la lista"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir seleccionado a la lista"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lisää valitut kieltolistalle"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lisää valitut kieltolistalle"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter sélectionnés à la liste de programmes bloqués"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter sélectionnés à la liste de programmes bloqués"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi selezionati alla lista bloccati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi selezionati alla lista bloccati"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したものをブロックリストに追加"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したものをブロックリストに追加"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "선택한 항목을 블랙리스트에 추가"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 항목을 블랙리스트에 추가"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voeg geselecteerde toe aan blokkeerlijst"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voeg geselecteerde toe aan blokkeerlijst"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dodaj wybrane do czarnej listy"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodaj wybrane do czarnej listy"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add Selected to Blocklist"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Selected to Blocklist"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar Selecionados à Lista de Bloqueio"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar Selecionados à Lista de Bloqueio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adăugați cele selectate la Blocklist"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adăugați cele selectate la Blocklist"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавить выделенное в черный список"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить выделенное в черный список"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seçilenleri Engelleme Listesine Ekle"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilenleri Engelleme Listesine Ekle"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Додати вибране до списку блокування"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Додати вибране до списку блокування"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thêm những mục được chọn vào danh sách chặn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thêm những mục được chọn vào danh sách chặn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将所选内容加入黑名单"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将所选内容加入黑名单"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "將選擇項目加入至黑名單"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將選擇項目加入至黑名單"
           }
         }
       }
     },
-    "program.args" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الأوامر"
+    "program.args": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأوامر"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argumenty"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumenty"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argumenter"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumenter"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argumente"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumente"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arguments"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arguments"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argumentos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumentos"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argumentit"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumentit"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arguments"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arguments"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argomenti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argomenti"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "引数"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引数"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "인자"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인자"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argumenten"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumenten"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parametry"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parametry"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argumentos"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumentos"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argumentos"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argumentos"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parametri"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parametri"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Аргументы"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аргументы"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argümanlar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argümanlar"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Аргументи"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аргументи"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thông số"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thông số"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "参数"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参数"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "命令列引數"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令列引數"
           }
         }
       }
     },
-    "program.blocklist" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "القائمة السوداء"
+    "program.blocklist": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "القائمة السوداء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Listina blokovaných"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listina blokovaných"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blokeringsliste"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blokeringsliste"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blockliste"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blockliste"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blocklist"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blocklist"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lista de bloqueo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lista de bloqueo"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estolista"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estolista"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Liste de programmes bloqués"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liste de programmes bloqués"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lista bloccati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lista bloccati"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ブロックリスト"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブロックリスト"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "차단 목록"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "차단 목록"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blokkeerlijst"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blokkeerlijst"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czarna lista"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czarna lista"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lista de bloqueio"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lista de bloqueio"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lista de Bloqueio"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lista de Bloqueio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blocklist"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blocklist"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Черный список"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Черный список"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Karaliste"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Karaliste"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Чорний список"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чорний список"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danh sách chặn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danh sách chặn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "阻止列表"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "阻止列表"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "黑名單"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "黑名單"
           }
         }
       }
     },
-    "program.config" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تهيئة"
+    "program.config": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تهيئة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurace"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurace"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguration"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguration"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguration"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguration"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Config"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Config"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguraatio"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguraatio"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurazione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuratie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuratie"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguracja"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguracja"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuração"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuração"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuração"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuração"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurare"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurare"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayarlar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayarlar"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Налаштування"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "配置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
           }
         }
       }
     },
-    "program.env" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "متغيرات البيئة"
+    "program.env": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متغيرات البيئة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proměnné prostředí"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proměnné prostředí"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Miljøvariabler"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Miljøvariabler"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umgebungsvariablen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umgebungsvariablen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Environment Variables"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment Variables"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Variables de Entorno"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variables de Entorno"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ympäristön muuttujat"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ympäristön muuttujat"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Variables d'environnement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variables d'environnement"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Variabili d'ambiente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variabili d'ambiente"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "環境変数"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "환경 변수"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환경 변수"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Omgevingsvariabelen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omgevingsvariabelen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zmienne środowiskowe"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zmienne środowiskowe"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Variáveis de Ambiente"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variáveis de Ambiente"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Variáveis de Ambiente"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variáveis de Ambiente"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Variabile de Mediu"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variabile de Mediu"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переменные окружения"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переменные окружения"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ortam Değişkenleri"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ortam Değişkenleri"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Змінні середовища"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Змінні середовища"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Biến môi trường"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biến môi trường"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "环境变量"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环境变量"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "環境變數"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境變數"
           }
         }
       }
     },
-    "program.remove.blocklist" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إزالة من القائمة السوداء"
+    "program.remove.blocklist": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة من القائمة السوداء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odstranit z blokovaných"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odstranit z blokovaných"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern fra blokeringsliste"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern fra blokeringsliste"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Von der Blockliste entfernen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von der Blockliste entfernen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove from Blocklist"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove from Blocklist"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar de la lista de bloqueo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar de la lista de bloqueo"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista estolistalta"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista estolistalta"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enlever de la liste de programmes bloqués"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enlever de la liste de programmes bloqués"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovi dalla lista bloccati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi dalla lista bloccati"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ブロックリストから削除"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブロックリストから削除"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "차단 목록에서 삭제"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "차단 목록에서 삭제"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijder van blokkeerlijst"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijder van blokkeerlijst"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń z czarnej listy"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń z czarnej listy"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover da lista de bloqueio"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover da lista de bloqueio"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover da Lista de bloqueio"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover da Lista de bloqueio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminați din Blocklist"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminați din Blocklist"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить из Черного списка"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить из Черного списка"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Karalisteden Kaldır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Karalisteden Kaldır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити з чорного списку"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити з чорного списку"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gỡ khỏi danh sách chặn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gỡ khỏi danh sách chặn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从阻止列表中移除"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从阻止列表中移除"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "從黑名單中移除"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從黑名單中移除"
           }
         }
       }
     },
-    "program.remove.selected.blocklist" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إزالة من القائمة السوداء"
+    "program.remove.selected.blocklist": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة من القائمة السوداء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odstranit vybrané ze seznamu"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odstranit vybrané ze seznamu"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern valgte fra blokeringsliste"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern valgte fra blokeringsliste"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewählte Bottle von Sperrliste entfernen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählte Bottle von Sperrliste entfernen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove Selected from Blocklist"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Selected from Blocklist"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar seleccionados de la lista"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar seleccionados de la lista"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista valitut estolistalta"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista valitut estolistalta"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enlever sélectionnés de la liste de programmes bloqués"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enlever sélectionnés de la liste de programmes bloqués"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovi selezionati dalla bloccati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi selezionati dalla bloccati"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したものをブロックリストから削除"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したものをブロックリストから削除"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "선택한 항목을 블랙리스트에서 제거"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 항목을 블랙리스트에서 제거"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijder geselecteerde uit blokkeerlijst"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijder geselecteerde uit blokkeerlijst"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń wybrane z czarnej listy"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń wybrane z czarnej listy"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove Selected from Blocklist"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Selected from Blocklist"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover Selecionados da Lista de Bloqueio"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover Selecionados da Lista de Bloqueio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminați cele selectate din Blocklist"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminați cele selectate din Blocklist"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Убрать выделенное из черного списка"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Убрать выделенное из черного списка"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seçilenleri Engelleme Listesinden Çıkar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilenleri Engelleme Listesinden Çıkar"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити з чорного списку"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити з чорного списку"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gỡ những mục được chọn khỏi danh sách chặn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gỡ những mục được chọn khỏi danh sách chặn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将所选内容从黑名单中移除"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将所选内容从黑名单中移除"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "將選擇項目移除出黑名單"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將選擇項目移除出黑名單"
           }
         }
       }
     },
-    "program.settings" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإعدادات"
+    "program.settings": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإعدادات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nastavení"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indstillinger"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indstillinger"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asetukset"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asetukset"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramètres"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instellingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instellingen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ustawienia"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienia"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Definições"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definições"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setări"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setări"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayarlar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayarlar"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Налаштування"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
           }
         }
       }
     },
-    "program.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جميع البرامج"
+    "program.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جميع البرامج"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Všechny programy"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Všechny programy"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle programmer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle programmer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Programme"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Programme"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All Programs"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All Programs"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todos los programas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos los programas"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaikki ohjelmat"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaikki ohjelmat"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tous les programmes"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tous les programmes"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tutti i programmi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutti i programmi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべてのプログラム"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのプログラム"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모든 프로그램"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 프로그램"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle programma's"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle programma's"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wszystkie programy"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wszystkie programy"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todos os Programas"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos os Programas"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todos os programas"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos os programas"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toate Programele"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toate Programele"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Все программы"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все программы"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bütün Programlar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bütün Programlar"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Всі програми"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всі програми"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tất cả ứng dụng"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tất cả ứng dụng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所有程序"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有程序"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所有程式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有程式"
           }
         }
       }
     },
-    "rename.bottle.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة تسمية القارورة"
+    "rename.bottle.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تسمية القارورة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přejmenovat lahev"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přejmenovat lahev"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Omdøb bottle"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omdøb bottle"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle umbenennen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle umbenennen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rename bottle"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename bottle"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renombrar botella"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar botella"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uudelleennimeä pullo"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uudelleennimeä pullo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renommer la bouteille"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer la bouteille"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rinomina bottiglia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina bottiglia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle の名前を変更"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle の名前を変更"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle 이름 변경"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle 이름 변경"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle hernoemen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle hernoemen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zmień nazwę butelki"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zmień nazwę butelki"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renomear Bottle"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear Bottle"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renomear a Bottle"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear a Bottle"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redenumiţi sticla"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redenumiţi sticla"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переименовать бутылку"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переименовать бутылку"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle'ı Yeniden Adlandır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle'ı Yeniden Adlandır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перейменувати пляшку"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейменувати пляшку"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đổi tên của Bottle"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đổi tên của Bottle"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新命名容器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新命名容器"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新命名容器"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新命名容器"
           }
         }
       }
     },
-    "rename.name" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اسم جديد:"
+    "rename.name": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسم جديد:"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nové jméno:"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nové jméno:"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nyt navn:"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nyt navn:"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neuer Name:"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer Name:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New name:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New name:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nuevo nombre:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo nombre:"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uusi nimi:"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uusi nimi:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nouveau nom :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouveau nom :"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nuovo nome:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuovo nome:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新しい名前:"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しい名前:"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "새 이름:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 이름:"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nieuwe naam:"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nieuwe naam:"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nowa nazwa:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowa nazwa:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Novo nome:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo nome:"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Novo nome:"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo nome:"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nume nou:"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nume nou:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Новое имя:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новое имя:"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yeni ad:"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni ad:"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нова назва:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нова назва:"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tên mới:"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tên mới:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新名称："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新名称："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新名稱："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新名稱："
           }
         }
       }
     },
-    "rename.pin.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة تسمية الدبوس"
+    "rename.pin.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تسمية الدبوس"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přejmenovat připínáček"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přejmenovat připínáček"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Omdøb fastgørelse"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omdøb fastgørelse"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin umbenennen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin umbenennen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rename pin"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename pin"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renombrar marcador"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar marcador"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uudelleennimeä kiinnike"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uudelleennimeä kiinnike"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renommer l'épingle"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer l'épingle"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rinomina scorciatoia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina scorciatoia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ピン留めの名前を変更"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ピン留めの名前を変更"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이름 변경"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름 변경"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin hernoemen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin hernoemen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zmień nazwę przypięcia"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zmień nazwę przypięcia"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rename pin"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename pin"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renomear pin"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear pin"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redenumire pin"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redenumire pin"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переименовать ярлык"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переименовать ярлык"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sabitlenmiş Programı Adlandır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sabitlenmiş Programı Adlandır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перейменувати прикріплене"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейменувати прикріплене"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đổi tên ghim"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đổi tên ghim"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名固定快捷名称"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名固定快捷名称"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新命名 Pin"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新命名 Pin"
           }
         }
       }
     },
-    "rename.rename" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة التسمية"
+    "rename.rename": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة التسمية"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přejmenovat"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přejmenovat"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Omdøb"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omdøb"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umbenennen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbenennen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rename"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renombrar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uudelleen nimeä"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uudelleen nimeä"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renommer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rinomina"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "変更"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이름 변경"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름 변경"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hernoem"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hernoem"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zmień nazwę"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zmień nazwę"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renomear"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alterar nome"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alterar nome"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redenumiți"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redenumiți"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переименовать"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переименовать"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yeniden Adlandır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeniden Adlandır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перейменувати"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейменувати"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đổi tên"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đổi tên"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新命名"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新命名"
           }
         }
       }
     },
-    "Reports high-end GPU to pass launcher compatibility checks. Fixes EA App black screen and \"GPU not supported\" errors." : {
-
+    "Reports high-end GPU to pass launcher compatibility checks. Fixes EA App black screen and \"GPU not supported\" errors.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reports high-end GPU to pass launcher compatibility checks. Fixes EA App black screen and \"GPU not supported\" errors."
+          }
+        }
+      }
     },
-    "run.bottle" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "القارورة:"
+    "run.bottle": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "القارورة:"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Láhev:"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Láhev:"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle:"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle:"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle:"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Botella:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Botella:"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pullo:"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pullo:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bouteille :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bouteille :"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottiglia:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottiglia:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボトル"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ボトル"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle:"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle:"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle:"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Butelka:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Butelka:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle:"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Garrafa:"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Garrafa:"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sticlă:"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sticlă:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Бутылка:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Бутылка:"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle:"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle:"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пляшка:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пляшка:"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle:"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "容器："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "容器："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "容器："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "容器："
           }
         }
       }
     },
-    "run.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تشغيل \"%@\""
+    "run.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل \"%@\""
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spustit \"%@\""
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spustit \"%@\""
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kør \"%@\""
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kør \"%@\""
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starte \"%@\""
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starte \"%@\""
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Run \"%@\""
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run \"%@\""
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ejecutar \"%@\""
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar \"%@\""
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suorita \"%@\""
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suorita \"%@\""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exécuter «%@»"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécuter «%@»"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esegui \"%@\""
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esegui \"%@\""
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" を実行"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" を実行"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" 실행"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" 실행"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start \"%@\""
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start \"%@\""
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uruchom \"%@\""
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uruchom \"%@\""
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executar \"%@\""
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar \"%@\""
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executar \"%@\""
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar \"%@\""
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rulează \"%@\""
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rulează \"%@\""
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запустить \"%@\""
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустить \"%@\""
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%@\" Çalıştır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" Çalıştır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запустити \"%@\""
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустити \"%@\""
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chạy \"%@\""
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạy \"%@\""
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行 \"%@\""
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行 \"%@\""
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "執行「%@」"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行「%@」"
           }
         }
       }
     },
-    "Security Note" : {
-
+    "Security Note": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Security Note"
+          }
+        }
+      }
     },
-    "settings.general" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عام"
+    "settings.general": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عام"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obecné"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obecné"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generelt"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generelt"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allgemein"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemein"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yleinen"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yleinen"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Général"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Général"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generali"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generali"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "全般"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全般"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "일반"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algemeen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algemeen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ogólne"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ogólne"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geral"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geral"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Основные"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основные"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Genel"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genel"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Основне"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основне"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chung"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chung"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通用"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一般"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
           }
         }
       }
     },
-    "settings.path" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مسار القارورة الإفتراضي:"
+    "settings.path": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسار القارورة الإفتراضي:"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Výchozí cesta láhve:"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Výchozí cesta láhve:"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standard Bottle-sti:"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard Bottle-sti:"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standard Bottle-Pfad:"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard Bottle-Pfad:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default bottle path:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default bottle path:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruta predeterminada de la botella:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta predeterminada de la botella:"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pullon oletuspolku:"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pullon oletuspolku:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chemin par défaut de la bouteille :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin par défaut de la bouteille :"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Percorso bottiglie predefinito:"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Percorso bottiglie predefinito:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle の既定の保存場所:"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle の既定の保存場所:"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기본 Bottle 경로:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 Bottle 경로:"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standaard bottle locatie:"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standaard bottle locatie:"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Domyślna ścieżka butelki:"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domyślna ścieżka butelki:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caminho padrão da bottle:"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caminho padrão da bottle:"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caminho padrão da garrafa:"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caminho padrão da garrafa:"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cale implicită a sticlelor:"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cale implicită a sticlelor:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Путь к бутылке по умолчанию:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Путь к бутылке по умолчанию:"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Varsayılan bottle dosya yolu:"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Varsayılan bottle dosya yolu:"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Стандартний шлях до пляшки:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стандартний шлях до пляшки:"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đường dẫn Bottle mặc định:"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đường dẫn Bottle mặc định:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "默认容器路径："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认容器路径："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "預設容器路徑："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設容器路徑："
           }
         }
       }
     },
-    "settings.toggle.kill.on.terminate" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إنهاء عمليات Wine عند إغلاق Whisky"
+    "settings.toggle.kill.on.terminate": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إنهاء عمليات Wine عند إغلاق Whisky"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ukončit Wine procesy při uzavření Whisky"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukončit Wine procesy při uzavření Whisky"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afslut Wine-processer, når Whisky lukkes"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afslut Wine-processer, når Whisky lukkes"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine-Prozesse beim Schließen von Whisky beenden"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine-Prozesse beim Schließen von Whisky beenden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminate Wine processes when Whisky closes"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminate Wine processes when Whisky closes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminar procesos de Wine cuando Whisky cierre"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminar procesos de Wine cuando Whisky cierre"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sulje Wine-prosessit kun Whisky suljetaan"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sulje Wine-prosessit kun Whisky suljetaan"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminer les processus de Wine à la fermeture de Whisky"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminer les processus de Wine à la fermeture de Whisky"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Termina i processi Wine quando Whisky chiude"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termina i processi Wine quando Whisky chiude"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky の終了時に Wine の全プロセスを停止する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky の終了時に Wine の全プロセスを停止する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky를 종료할 때 Wine 프로세스도 종료"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky를 종료할 때 Wine 프로세스도 종료"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beëindig de Wine processen wanneer Whisky sluit"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beëindig de Wine processen wanneer Whisky sluit"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zakończ proces Wine, gdy Whisky zostanie zamknięte"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zakończ proces Wine, gdy Whisky zostanie zamknięte"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminate Wine processes when Whisky closes"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminate Wine processes when Whisky closes"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Termine processos Wine quando o Whisky fechar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termine processos Wine quando o Whisky fechar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Închide procesele Wine atunci când Whisky se închide"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Închide procesele Wine atunci când Whisky se închide"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закрывать процессы Wine при закрытии Whisky"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрывать процессы Wine при закрытии Whisky"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky kapandığında Wine işlemlerini sonlandır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky kapandığında Wine işlemlerini sonlandır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завершити процеси Wine, коли закривається Whisky"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершити процеси Wine, коли закривається Whisky"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buộc Wine phải tắt khi Whisky tắt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buộc Wine phải tắt khi Whisky tắt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭 Whisky 时结束 Wine 进程"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭 Whisky 时结束 Wine 进程"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky 關閉時終止 Wine 進程"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky 關閉時終止 Wine 進程"
           }
         }
       }
     },
-    "settings.toggle.whisky.updates" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التحقق تلقائيا من تحديثات Whisky"
+    "settings.toggle.whisky.updates": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحقق تلقائيا من تحديثات Whisky"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automaticky kontrolovat Whisky aktualizace"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automaticky kontrolovat Whisky aktualizace"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Søg automatisk efter Whisky-opdateringer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Søg automatisk efter Whisky-opdateringer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch nach Updates für Whisky suchen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch nach Updates für Whisky suchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatically check for Whisky updates"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically check for Whisky updates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar actualizaciones de Whiskey automáticamente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones de Whiskey automáticamente"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automaattisesti tarkista Whisky päivityksien varalta"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automaattisesti tarkista Whisky päivityksien varalta"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher automatiquement les mises à jour de Whisky"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher automatiquement les mises à jour de Whisky"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controlla automaticamente aggiornamenti di Whisky"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controlla automaticamente aggiornamenti di Whisky"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky のアップデートを自動的に確認する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky のアップデートを自動的に確認する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky 업데이트를 자동으로 확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky 업데이트를 자동으로 확인"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch controleren op Whisky updates"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch controleren op Whisky updates"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatycznie sprawdzaj aktualizacje Whisky"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatycznie sprawdzaj aktualizacje Whisky"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatically check for Whisky updates"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically check for Whisky updates"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifique automaticamente para atualizações do Whisky"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifique automaticamente para atualizações do Whisky"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifică automat pentru actualizări Whisky"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifică automat pentru actualizări Whisky"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автоматически проверять на наличие обновлений Whisky"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматически проверять на наличие обновлений Whisky"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky güncellemelerini otomatik olarak kontrol et"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky güncellemelerini otomatik olarak kontrol et"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автоматична перевірка оновлень Whisky"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматична перевірка оновлень Whisky"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tự động kiểm tra bản cập nhật của Whisky"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự động kiểm tra bản cập nhật của Whisky"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动检查Whisky更新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动检查Whisky更新"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動檢查 Whisky 更新"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動檢查 Whisky 更新"
           }
         }
       }
     },
-    "settings.toggle.whiskywine.updates" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التحقق تلقائيا من تحديثات WhiskyWine"
+    "settings.toggle.whiskywine.updates": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحقق تلقائيا من تحديثات WhiskyWine"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automaticky vyhledávat WhiskyWine aktualizace"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automaticky vyhledávat WhiskyWine aktualizace"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Søg automatisk efter WhiskyWine-opdateringer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Søg automatisk efter WhiskyWine-opdateringer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch nach Updates für WhiskyWine suchen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch nach Updates für WhiskyWine suchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatically check for WhiskyWine updates"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically check for WhiskyWine updates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar actualizaciones de WhiskyWine automáticamente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones de WhiskyWine automáticamente"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automaattisesti tarkista WhiskyWine päivityksien varalta"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automaattisesti tarkista WhiskyWine päivityksien varalta"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher automatiquement les mises à jour de WhiskyWine"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher automatiquement les mises à jour de WhiskyWine"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controlla automaticamente aggiornamenti di WhiskyWine"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controlla automaticamente aggiornamenti di WhiskyWine"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine のアップデートを自動的に確認する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine のアップデートを自動的に確認する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine 업데이트를 자동으로 확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine 업데이트를 자동으로 확인"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch controleren op WhiskyWine updates"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch controleren op WhiskyWine updates"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatycznie sprawdzaj dostępność aktualizacji WhiskyWine"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatycznie sprawdzaj dostępność aktualizacji WhiskyWine"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificar automaticamente atualizações do WhiskyWine"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar automaticamente atualizações do WhiskyWine"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Procurar atualizações automaticamente"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Procurar atualizações automaticamente"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifică automat pentru actualizări WhiskyWine"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifică automat pentru actualizări WhiskyWine"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автоматически проверять на наличие обновлений WhiskyWine"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматически проверять на наличие обновлений WhiskyWine"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Güncellemeleri otomatik olarak kontrol et"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güncellemeleri otomatik olarak kontrol et"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автоматично перевіряти оновлення WhiskyWine"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматично перевіряти оновлення WhiskyWine"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tự động kiểm tra bản cập nhật WhiskyWine"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự động kiểm tra bản cập nhật WhiskyWine"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动检查 WhiskyWine 更新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动检查 WhiskyWine 更新"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動檢查 WhiskyWine 更新"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動檢查 WhiskyWine 更新"
           }
         }
       }
     },
-    "settings.updates" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التحديثات"
+    "settings.updates": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحديثات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualizace"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualizace"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opdateringer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opdateringer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualisierungen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisierungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updates"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizaciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Päivitykset"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Päivitykset"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mises à jour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mises à jour"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiornamenti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamenti"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アップデート"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデート"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "업데이트"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updates"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualizacje"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualizacje"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updates"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizações"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizações"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizări"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizări"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обновления"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновления"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Güncellemeler"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güncellemeler"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Оновлення"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оновлення"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Các bản cập nhật"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Các bản cập nhật"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
           }
         }
       }
     },
-    "setup.done" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تم"
+    "setup.done": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hotovo"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hotovo"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Udført"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Udført"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fertig"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completado"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valmis"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valmis"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fatto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fatto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "완료"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완료"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voltooid"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voltooid"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gotowe"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gotowe"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feito"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feito"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Concluído"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concluído"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizat"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizat"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Готово"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitti"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitti"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Готово"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xong"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xong"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完成"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完成"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
           }
         }
       }
     },
-    "setup.install.checking" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جاري التحقق من تثبيت %@..."
+    "setup.install.checking": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جاري التحقق من تثبيت %@..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontrola instalace %@..."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontrola instalace %@..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tjekker %@ Installation..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tjekker %@ Installation..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfen der %@ Installation..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen der %@ Installation..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking %@ installation..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking %@ installation..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobando la instalación %@..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobando la instalación %@..."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tarkistetaan %@ asennusta..."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarkistetaan %@ asennusta..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérification de l'installation de %@..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification de l'installation de %@..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controllo installazione %@..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controllo installazione %@..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ のインストールを確認しています..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ のインストールを確認しています..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 설치를 확인하는 중입니다..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 설치를 확인하는 중입니다..."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De %@ installatie controleren..."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De %@ installatie controleren..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprawdzanie %@ instalacji..."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprawdzanie %@ instalacji..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificando instalação de %@..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificando instalação de %@..."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificando a instalação de %@..."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificando a instalação de %@..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se verifică instalarea %@..."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se verifică instalarea %@..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверка установки %@..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка установки %@..."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ kontrol ediliyor..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kontrol ediliyor..."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перевірка інсталяції %@..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перевірка інсталяції %@..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đang kiểm tra cài đặt %@..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang kiểm tra cài đặt %@..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在检查 %@ 是否安装..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查 %@ 是否安装..."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在檢查 %@ 安裝⋯⋯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在檢查 %@ 安裝⋯⋯"
           }
         }
       }
     },
-    "setup.install.installed" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تم تثبيت %@"
+    "setup.install.installed": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم تثبيت %@"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ nainstalováno"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ nainstalováno"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ installeret"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ installeret"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ installiert"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ installiert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ installed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ installed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ instalado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ instalado"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ asennettu"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ asennettu"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ installé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ installé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ installato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ installato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ がインストールされました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ がインストールされました"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 설치됨"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 설치됨"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ geïnstalleerd"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ geïnstalleerd"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ zainstalowano"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ zainstalowano"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ instalado"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ instalado"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ instalado"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ instalado"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ instalat"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ instalat"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ – установлено"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – установлено"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ yüklendi"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ yüklendi"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ встановлено"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ встановлено"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ đã được cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ đã được cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 已安装"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已安装"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 已安裝"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已安裝"
           }
         }
       }
     },
-    "setup.install.notInstalled" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ لم يتم تثبيته"
+    "setup.install.notInstalled": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ لم يتم تثبيته"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ není nainstalováno"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ není nainstalováno"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ikke installeret"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ikke installeret"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ nicht installiert"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ nicht installiert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ not installed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ not installed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ instalado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ instalado"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ei asennettu"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ei asennettu"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ pas installé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ pas installé"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ non installato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ non installato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ が未インストール"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ が未インストール"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 설치되지 않음"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 설치되지 않음"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ niet geïnstalleerd"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ niet geïnstalleerd"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ nie zainstalowano"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ nie zainstalowano"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ não instalado"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ não instalado"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ não instalado"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ não instalado"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ neinstalat"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ neinstalat"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ – не установлено"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – не установлено"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ yüklü değil"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ yüklü değil"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ не встановлено"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ не встановлено"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ chưa được cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ chưa được cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 未安装"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 未安装"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 未安裝"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 未安裝"
           }
         }
       }
     },
-    "setup.next" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التالي"
+    "setup.next": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التالي"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Další"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Další"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Næste"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Næste"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weiter"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiter"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seuraava"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seuraava"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suivant"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suivant"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avanti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avanti"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "次へ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次へ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다음"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Volgende"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volgende"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dalej"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dalej"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seguinte"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seguinte"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Próximo"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próximo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Următorul"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Următorul"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Далее"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Далее"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sonraki"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sonraki"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Далі"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Далі"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiếp tục"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếp tục"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下一页"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下一页"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下一步"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下一步"
           }
         }
       }
     },
-    "setup.quit" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خروج"
+    "setup.quit": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خروج"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ukončit"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukončit"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afslut"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afslut"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quit"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sulje"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sulje"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quitter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chiudi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiudi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "終了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "종료"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "종료"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afsluiten"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afsluiten"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyjdź"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyjdź"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sair"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sair"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ieșire"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ieșire"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выйти"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выйти"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Çık"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çık"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вийти"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вийти"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thoát"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thoát"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "離開"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "離開"
           }
         }
       }
     },
-    "setup.retry" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة المحاولة"
+    "setup.retry": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة المحاولة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opakovat"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opakovat"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Forsøg igen"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forsøg igen"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erneut versuchen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneut versuchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reintentar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintentar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yritä uudelleen"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yritä uudelleen"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réessayer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réessayer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riprova"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riprova"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再試行"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再試行"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다시 시도"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 시도"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opnieuw Proberen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opnieuw Proberen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spróbuj ponownie"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spróbuj ponownie"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voltar a tentar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voltar a tentar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reîncearcă"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reîncearcă"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Повторить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повторить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tekrar Dene"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tekrar Dene"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Повторити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повторити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thử lại"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thử lại"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重试"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重试"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重試"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重試"
           }
         }
       }
     },
-    "setup.rosetta" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تثبيت Rosetta"
+    "setup.rosetta": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت Rosetta"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalování Rosetta"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalování Rosetta"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installere Rosetta"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installere Rosetta"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installiere Rosetta"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installiere Rosetta"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installing Rosetta"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installing Rosetta"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalando Rosetta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando Rosetta"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asennetaan Rosettaa"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asennetaan Rosettaa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installation de Rosetta"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation de Rosetta"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installazione di Rosetta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installazione di Rosetta"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta をインストール中"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta をインストール中"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta를 설치 중입니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta를 설치 중입니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta installeren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta installeren"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalowanie Rosetta"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalowanie Rosetta"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalando Rosetta"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando Rosetta"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalando Rosetta"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando Rosetta"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se instalează Rosetta"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se instalează Rosetta"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установка Rosetta"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установка Rosetta"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta Yükleniyor"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta Yükleniyor"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Встановлення Rosetta"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Встановлення Rosetta"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đang cài đặt Rosetta"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang cài đặt Rosetta"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在安装 Rosetta"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在安装 Rosetta"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在安裝 Rosetta"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在安裝 Rosetta"
           }
         }
       }
     },
-    "setup.rosetta.fail" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فشل تثبيت Rosetta 2. الرجاء تثبيته يدوياً."
+    "setup.rosetta.fail": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل تثبيت Rosetta 2. الرجاء تثبيته يدوياً."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalace Rosetta 2 se nezdařila. Nainstalujte ji prosím ručně."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalace Rosetta 2 se nezdařila. Nainstalujte ji prosím ručně."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 2-installation mislykkedes. Installer venligst manuelt."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 2-installation mislykkedes. Installer venligst manuelt."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 2 Installation fehlgeschlagen. Bitte installieren es manuell."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 2 Installation fehlgeschlagen. Bitte installieren es manuell."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 2 installation failed. Please install it manually."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 2 installation failed. Please install it manually."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La instalación de Rosetta 2 ha fallado. Por favor, instálala manualmente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La instalación de Rosetta 2 ha fallado. Por favor, instálala manualmente."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 2:n asennus epäonnistui. Asenna se manuaalisesti."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 2:n asennus epäonnistui. Asenna se manuaalisesti."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installation de Rosetta 2 a échoué. Veuillez l'installer manuellement."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation de Rosetta 2 a échoué. Veuillez l'installer manuellement."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installazione di Rosetta 2 fallita. Si prega di installarlo manualmente."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installazione di Rosetta 2 fallita. Si prega di installarlo manualmente."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 2 のインストールに失敗しました。手動でインストールしてください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 2 のインストールに失敗しました。手動でインストールしてください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 2 설치에 실패했습니다. 수동으로 설치해 주세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 2 설치에 실패했습니다. 수동으로 설치해 주세요."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De Rosetta 2 installatie is mislukt. Installeer het handmatig."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De Rosetta 2 installatie is mislukt. Installeer het handmatig."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalacja Rosetta 2 nie powiodła się. Proszę zainstaluj ją manualnie."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalacja Rosetta 2 nie powiodła się. Proszę zainstaluj ją manualnie."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 2 installation failed. Please install it manually."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 2 installation failed. Please install it manually."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A instalação do Rosetta 2 falhou. Por favor instale manualmente."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A instalação do Rosetta 2 falhou. Por favor instale manualmente."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu s-a putut instala Rosetta 2. Vă rugăm să o instalați manual."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nu s-a putut instala Rosetta 2. Vă rugăm să o instalați manual."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установка Rosetta 2 завершилась с ошибкой. Пожалуйста, выполните установку вручную."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установка Rosetta 2 завершилась с ошибкой. Пожалуйста, выполните установку вручную."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 2 kurulumu başarısız oldu. Lütfen manuel olarak yükleyin."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 2 kurulumu başarısız oldu. Lütfen manuel olarak yükleyin."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося встановити Rosetta 2. Будь ласка, встановіть вручну."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося встановити Rosetta 2. Будь ласка, встановіть вручну."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể cài đặt Rosetta 2. Hãy cài đặt nó thủ công."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể cài đặt Rosetta 2. Hãy cài đặt nó thủ công."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 2安装失败。请手动安装。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 2安装失败。请手动安装。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 2 安裝失敗。請手動安裝。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 2 安裝失敗。請手動安裝。"
           }
         }
       }
     },
-    "setup.rosetta.subtitle" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تسمح Rosetta بأكواد x86، مثل Wine، بالعمل على الماك الخاص بك."
+    "setup.rosetta.subtitle": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تسمح Rosetta بأكواد x86، مثل Wine، بالعمل على الماك الخاص بك."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta umožňuje x86 kódu, jakým je Wine, běžet na vašem Macu."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta umožňuje x86 kódu, jakým je Wine, běžet na vašem Macu."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta tillader x86 kode, som Wine, til at køre på din Mac."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta tillader x86 kode, som Wine, til at køre på din Mac."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta erlaubt es, x86 code auf deinem Mac auszuführen, ähnlich wie Wine."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta erlaubt es, x86 code auf deinem Mac auszuführen, ähnlich wie Wine."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta allows x86 code, like Wine, to run on your Mac."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta allows x86 code, like Wine, to run on your Mac."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta permite que programas de arquitectura x86 (Wine por ejemplo) funcionen en tu Mac."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta permite que programas de arquitectura x86 (Wine por ejemplo) funcionen en tu Mac."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta, kuten Wine, mahdollistaa x86 koodin käyttämisen Macilläsi."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta, kuten Wine, mahdollistaa x86 koodin käyttämisen Macilläsi."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta permet au code x86, comme Wine, de s'exécuter sur votre Mac."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta permet au code x86, comme Wine, de s'exécuter sur votre Mac."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta permette al codice x86, come Wine, di funzionare sul tuo Mac."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta permette al codice x86, come Wine, di funzionare sul tuo Mac."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta は、Wine のような x86 バイナリを Mac 上で実行できるようにします。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta は、Wine のような x86 バイナリを Mac 上で実行できるようにします。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta는 Wine과 같은 x86 코드를 당신의 Mac에서 실행할 수 있게 해 줍니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta는 Wine과 같은 x86 코드를 당신의 Mac에서 실행할 수 있게 해 줍니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta laat x86 code, zoals Wine, uitgevoerd worden op je Mac."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta laat x86 code, zoals Wine, uitgevoerd worden op je Mac."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta pozwala kodowi x86, tak jak Wine, na uruchamianie na komputerze Mac."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta pozwala kodowi x86, tak jak Wine, na uruchamianie na komputerze Mac."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta permite código x86, como Wine, a rodar em seu Mac."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta permite código x86, como Wine, a rodar em seu Mac."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta permite que código x86, como o Wine, execute no seu Mac."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta permite que código x86, como o Wine, execute no seu Mac."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta permite codului x86, ca de exemplu Wine, să ruleze pe Mac-ul dvs."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta permite codului x86, ca de exemplu Wine, să ruleze pe Mac-ul dvs."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta позволяет программам x86, таким как Wine, работать на вашем Mac."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta позволяет программам x86, таким как Wine, работать на вашем Mac."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta, Wine gibi, x86 yazılımının Mac bilgisayarınızda çalışmasına izin verir."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta, Wine gibi, x86 yazılımının Mac bilgisayarınızda çalışmasına izin verir."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta дозволяє запускати x86 код (напр. Wine) на вашому Mac."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta дозволяє запускати x86 код (напр. Wine) на вашому Mac."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta cho phép các ứng dụng x86 như Wine chạy trên máy Mac của bạn."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta cho phép các ứng dụng x86 như Wine chạy trên máy Mac của bạn."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 让您的 Mac 可以运行 Wine 等 x86 架构的程序。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 让您的 Mac 可以运行 Wine 等 x86 架构的程序。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rosetta 允許 x86 代碼（如 Wine）在 Mac 上運行。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosetta 允許 x86 代碼（如 Wine）在 Mac 上運行。"
           }
         }
       }
     },
-    "setup.subtitle" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إدارة التبعيات المطلوبة لـWhisky."
+    "setup.subtitle": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إدارة التبعيات المطلوبة لـWhisky."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spravovat požadované závislosti Whisky."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spravovat požadované závislosti Whisky."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Administrer Whisky's nødvendige afhængigheder."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administrer Whisky's nødvendige afhængigheder."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwalte Whiskys erforderliche Abhängigkeiten."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwalte Whiskys erforderliche Abhängigkeiten."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manage Whisky's required dependencies."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Whisky's required dependencies."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Administre las dependencias requeridas de Whisky."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administre las dependencias requeridas de Whisky."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hallitse Whiskyn tarvittavia riippuvuuksia."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hallitse Whiskyn tarvittavia riippuvuuksia."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gérer les dépendances requises de Whisky."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gérer les dépendances requises de Whisky."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gestisci le dipendenze richieste da Whisky."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestisci le dipendenze richieste da Whisky."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky に必要な依存関係を管理します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky に必要な依存関係を管理します。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky의 필수 의존성 관리하기."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky의 필수 의존성 관리하기."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beheer Whisky's vereiste dependencies."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beheer Whisky's vereiste dependencies."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zarządzaj wymaganymi zależnościami Whisky."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zarządzaj wymaganymi zależnościami Whisky."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gerir as dependências necessárias do Whisky."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerir as dependências necessárias do Whisky."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gerencie dependências necessárias do Whisky."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerencie dependências necessárias do Whisky."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gestionează dependențele cerute de Whisky."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestionează dependențele cerute de Whisky."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Управление требуемыми зависимостями Whisky."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Управление требуемыми зависимостями Whisky."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky'nin gerekli yazılımlarını düzenle."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky'nin gerekli yazılımlarını düzenle."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Керування необхідними залежностями Whisky."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Керування необхідними залежностями Whisky."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quản lý những tệp quan trọng của Whisky."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quản lý những tệp quan trọng của Whisky."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "管理 Whisky 所需依赖"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理 Whisky 所需依赖"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "管理Whisky需要的相依性套件"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理Whisky需要的相依性套件"
           }
         }
       }
     },
-    "setup.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعداد التبعيات"
+    "setup.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعداد التبعيات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení závislostí"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nastavení závislostí"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opsætning af afhængigheder"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opsætning af afhængigheder"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abhängigkeitseinstellungen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abhängigkeitseinstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dependencies Setup"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dependencies Setup"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración de dependencias"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración de dependencias"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riippuvuuksien valmistelu"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riippuvuuksien valmistelu"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration des dépendances"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration des dépendances"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurazione delle dipendenze"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurazione delle dipendenze"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "依存関係のセットアップ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依存関係のセットアップ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "의존성 설정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "의존성 설정"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beheer dependencies"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beheer dependencies"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguracja zależności"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguracja zależności"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuração de dependências"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuração de dependências"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuração das Dependências"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuração das Dependências"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurare Dependențe"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurare Dependențe"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установка зависимостей"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установка зависимостей"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gerekli Yazılımların Kurulumu"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerekli Yazılımların Kurulumu"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Встановлення залежностей"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Встановлення залежностей"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt những tệp quan trọng"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt những tệp quan trọng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "依赖项设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依赖项设置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "相依性管理"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相依性管理"
           }
         }
       }
     },
-    "setup.uninstall" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إلغاء التثبيت"
+    "setup.uninstall": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء التثبيت"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odinstalování"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odinstalování"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afinstaller"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afinstaller"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deinstallieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deinstallieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uninstall"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desinstalar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista asennus"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista asennus"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désinstaller"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désinstaller"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disinstalla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disinstalla"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アンインストール"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アンインストール"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제거"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제거"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deïnstalleren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deïnstalleren"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odinstaluj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odinstaluj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desinstalar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dezinstalează"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dezinstalează"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaldır"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaldır"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Видалити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gỡ cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gỡ cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "卸载"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "卸载"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "解除安裝"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解除安裝"
           }
         }
       }
     },
-    "setup.welcome" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مرحبا بكم في Whisky"
+    "setup.welcome": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مرحبا بكم في Whisky"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vítejte ve Whisky"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vítejte ve Whisky"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velkommen til Whisky"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velkommen til Whisky"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Willkommen zu Whisky"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Willkommen zu Whisky"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Welcome to Whisky"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome to Whisky"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bienvenido a Whisky"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bienvenido a Whisky"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tervetuloa käyttämään Whiskyä"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tervetuloa käyttämään Whiskyä"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bienvenue sur Whisky"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bienvenue sur Whisky"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benvenuto su Whisky"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benvenuto su Whisky"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky へようこそ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky へようこそ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky에 오신 것을 환영합니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky에 오신 것을 환영합니다"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Welkom bij Whisky"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welkom bij Whisky"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Witaj w Whisky"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Witaj w Whisky"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bem-vindo ao Whisky"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bem-vindo ao Whisky"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bem-vindo ao Whisky"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bem-vindo ao Whisky"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bine ați venit la Whisky"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bine ați venit la Whisky"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добро пожаловать в Whisky"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добро пожаловать в Whisky"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky'ye Hoşgeldiniz"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky'ye Hoşgeldiniz"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ласкаво просимо до Whisky"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ласкаво просимо до Whisky"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chào mừng đến với Whisky"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chào mừng đến với Whisky"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "欢迎使用 Whisky"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "欢迎使用 Whisky"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "歡迎使用 Whisky"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "歡迎使用 Whisky"
           }
         }
       }
     },
-    "setup.welcome.subtitle" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "دعونا نحصل على الإعداد. لن يستغرق هذا دقيقة."
+    "setup.welcome.subtitle": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دعونا نحصل على الإعداد. لن يستغرق هذا دقيقة."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pojďme to nastavit. Nedube to trvat ani minutu."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pojďme to nastavit. Nedube to trvat ani minutu."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lad os få dig sat op. Dette vil ikke tage et minut."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lad os få dig sat op. Dette vil ikke tage et minut."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lass uns mit der Einrichtung beginnen. Dies dauert keine Minute."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lass uns mit der Einrichtung beginnen. Dies dauert keine Minute."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Let's get you set up. This won't take a minute."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Let's get you set up. This won't take a minute."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vamos a configurar. Solo tomará un minuto."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vamos a configurar. Solo tomará un minuto."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valmistellaan perusominaisuudet. Tämä vie vain hetken."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valmistellaan perusominaisuudet. Tämä vie vain hetken."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mettons-nous en place. Cela ne prendra qu'un instant."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettons-nous en place. Cela ne prendra qu'un instant."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creiamo la tua configurazione. Ci vorrà meno di un minuto."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creiamo la tua configurazione. Ci vorrà meno di un minuto."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セットアップをしましょう。1分以内に終わります。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットアップをしましょう。1分以内に終わります。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정하는 것을 도와드리겠습니다. 얼마 걸리지 않을 거예요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정하는 것을 도와드리겠습니다. 얼마 걸리지 않을 거예요."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laten we ervoor zorgen dat alles klaarstaat. Dit duurt een ogenblik."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laten we ervoor zorgen dat alles klaarstaat. Dit duurt een ogenblik."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przygotujmy się. To nie potrwa długo."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przygotujmy się. To nie potrwa długo."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vamos preparar as coisas para você. Isso não vai demorar."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vamos preparar as coisas para você. Isso não vai demorar."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vamos prepará-lo. Isto não irá demorar um minuto."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vamos prepará-lo. Isto não irá demorar um minuto."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hai să începem! Nu va lua mult."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hai să începem! Nu va lua mult."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Производится первоначальная настройка. Это займёт не больше минуты."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Производится первоначальная настройка. Это займёт не больше минуты."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hadi seni hazırlayalım. Bu çok da uzun sürmeyecek."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hadi seni hazırlayalım. Bu çok da uzun sürmeyecek."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Давайте все налаштуємо, це не займе багато часу."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Давайте все налаштуємо, це не займе багато часу."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cùng giúp bạn thiết lập. Điều này sẽ không mất đến một phút."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cùng giúp bạn thiết lập. Điều này sẽ không mất đến một phút."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "让我们帮您安装好，这不会用很长时间。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "让我们帮您安装好，这不会用很长时间。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "讓我們為你完成設置。此步驟不會花上一分鐘時間。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讓我們為你完成設置。此步驟不會花上一分鐘時間。"
           }
         }
       }
     },
-    "setup.whiskywine.download" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تنزيل WhiskyWine"
+    "setup.whiskywine.download": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنزيل WhiskyWine"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stahování WhiskyWine"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stahování WhiskyWine"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Downloader Wine"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloader Wine"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine herunterladen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine herunterladen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Downloading WhiskyWine"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloading WhiskyWine"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargando WhiskyWine"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargando WhiskyWine"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ladataan WhiskyWine"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ladataan WhiskyWine"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Téléchargement de WhiskyWine"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargement de WhiskyWine"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scarico Wine"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scarico Wine"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine をダウンロード中"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine をダウンロード中"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine를 다운로드 중입니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine를 다운로드 중입니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine downloaden"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine downloaden"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pobieranie WhiskyWine"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pobieranie WhiskyWine"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baixando Wine"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baixando Wine"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transferindo Wine"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transferindo Wine"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se descarcă WhiskyWine"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se descarcă WhiskyWine"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скачивание WhiskyWine"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скачивание WhiskyWine"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine İndiriliyor"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine İndiriliyor"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завантаження WhiskyWine"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантаження WhiskyWine"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đang tải xuống Wine"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang tải xuống Wine"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在下载 WhiskyWine"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下载 WhiskyWine"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在下載 WhiskyWine"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下載 WhiskyWine"
           }
         }
       }
     },
-    "setup.whiskywine.download.subtitle" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ستختلف السرعة على حسب اتصالك بالإنترنت."
+    "setup.whiskywine.download.subtitle": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ستختلف السرعة على حسب اتصالك بالإنترنت."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rychlost stahování se bude lišit v závislosti na vašem internetovém připojení."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rychlost stahování se bude lišit v závislosti na vašem internetovém připojení."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hastigheden vil variere ud fra din internethastighed."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hastigheden vil variere ud fra din internethastighed."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Geschwindigkeit variiert je nach Internetverbindung."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Geschwindigkeit variiert je nach Internetverbindung."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speeds will vary on your internet connection."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speeds will vary on your internet connection."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La velocidad de descarga varía según tu conexión a Internet."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La velocidad de descarga varía según tu conexión a Internet."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nopeus vaihtelee internetyhteytesi mukaan."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nopeus vaihtelee internetyhteytesi mukaan."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La vitesse de téléchargement peut varier selon votre connexion Internet."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La vitesse de téléchargement peut varier selon votre connexion Internet."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La velocità di download varia in base alla tua connessione internet."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La velocità di download varia in base alla tua connessione internet."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "速度はインターネット環境によって変化します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "速度はインターネット環境によって変化します。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "속도는 인터넷 연결 상태에 따라 달라질 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "속도는 인터넷 연결 상태에 따라 달라질 수 있습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snelheden zullen variëren gebaseerd op je internet connectie."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snelheden zullen variëren gebaseerd op je internet connectie."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prędkości będą się różnić w zależności od połączenia internetowego."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prędkości będą się różnić w zależności od połączenia internetowego."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As velocidades irão variar de acordo com sua internet."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As velocidades irão variar de acordo com sua internet."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As velocidades variam de acordo com a sua ligação de Internet."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As velocidades variam de acordo com a sua ligação de Internet."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Viteza va depinde de conexiunea dvs. de internet."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Viteza va depinde de conexiunea dvs. de internet."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скорость скачивания зависит от вашего подключения к Интернету."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скорость скачивания зависит от вашего подключения к Интернету."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yükleme hızı internet bağlantınıza göre değişecektir."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yükleme hızı internet bağlantınıza göre değişecektir."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Швидкість залежить від швидкості Вашого підключення до Інтернету."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Швидкість залежить від швидкості Вашого підключення до Інтернету."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tốc độ tải xuống sẽ phụ thuộc vào kết nối Internet của bạn."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tốc độ tải xuống sẽ phụ thuộc vào kết nối Internet của bạn."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下载速度受您的网络质量影响。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载速度受您的网络质量影响。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "速度會因你的網路頻寬而有所不同。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "速度會因你的網路頻寬而有所不同。"
           }
         }
       }
     },
-    "setup.whiskywine.copyDiagnostics" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نسخ التشخيصات"
+    "setup.whiskywine.copyDiagnostics": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ التشخيصات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zkopírovat diagnostiku"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zkopírovat diagnostiku"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopiér diagnostik"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiér diagnostik"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnosedaten kopieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnosedaten kopieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Diagnostics"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Diagnostics"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar diagnósticos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar diagnósticos"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopioi diagnostiikka"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopioi diagnostiikka"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copier les diagnostics"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier les diagnostics"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copia diagnosi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia diagnosi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "診断情報をコピー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断情報をコピー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "진단 정보 복사"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "진단 정보 복사"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnose kopiëren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnose kopiëren"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopiuj diagnostykę"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj diagnostykę"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar diagnósticos"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar diagnósticos"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiar diagnósticos"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar diagnósticos"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copy Diagnostics"
+        "ro": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Diagnostics"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Копировать диагностику"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать диагностику"
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopiera diagnostik"
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiera diagnostik"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tanılamayı kopyala"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tanılamayı kopyala"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скопіювати діагностику"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопіювати діагностику"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sao chép chẩn đoán"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sao chép chẩn đoán"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制诊断"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制诊断"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "複製診斷"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製診斷"
           }
         }
       }
     },
-    "setup.whiskywine.error.installFailed" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فشل تثبيت WhiskyWine. يُرجى نسخ التشخيصات وإرفاق السجلات."
+    "setup.whiskywine.error.installFailed": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل تثبيت WhiskyWine. يُرجى نسخ التشخيصات وإرفاق السجلات."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalace WhiskyWine se nezdařila. Zkopírujte diagnostiku a přiložte protokoly."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalace WhiskyWine se nezdařila. Zkopírujte diagnostiku a přiložte protokoly."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installationen af WhiskyWine mislykkedes. Kopiér diagnostik og vedhæft logfiler."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installationen af WhiskyWine mislykkedes. Kopiér diagnostik og vedhæft logfiler."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Installation von WhiskyWine ist fehlgeschlagen. Bitte Diagnosedaten kopieren und Protokolle anhängen."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Installation von WhiskyWine ist fehlgeschlagen. Bitte Diagnosedaten kopieren und Protokolle anhängen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine installation failed. Please copy diagnostics and attach logs."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine installation failed. Please copy diagnostics and attach logs."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La instalación de WhiskyWine falló. Copie los diagnósticos y adjunte los registros."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La instalación de WhiskyWine falló. Copie los diagnósticos y adjunte los registros."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine-asennus epäonnistui. Kopioi diagnostiikka ja liitä lokit."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine-asennus epäonnistui. Kopioi diagnostiikka ja liitä lokit."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'installation de WhiskyWine a échoué. Veuillez copier les diagnostics et joindre les journaux."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'installation de WhiskyWine a échoué. Veuillez copier les diagnostics et joindre les journaux."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installazione di WhiskyWine non riuscita. Copia la diagnostica e allega i log."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installazione di WhiskyWine non riuscita. Copia la diagnostica e allega i log."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine のインストールに失敗しました。診断情報をコピーしてログを添付してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine のインストールに失敗しました。診断情報をコピーしてログを添付してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine 설치에 실패했습니다. 진단 정보를 복사하고 로그를 첨부하세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine 설치에 실패했습니다. 진단 정보를 복사하고 로그를 첨부하세요."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installatie van WhiskyWine is mislukt. Kopieer de diagnostiek en voeg logbestanden toe."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installatie van WhiskyWine is mislukt. Kopieer de diagnostiek en voeg logbestanden toe."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalacja WhiskyWine nie powiodła się. Skopiuj diagnostykę i dołącz logi."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalacja WhiskyWine nie powiodła się. Skopiuj diagnostykę i dołącz logi."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A instalação do WhiskyWine falhou. Copie os diagnósticos e anexe os logs."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A instalação do WhiskyWine falhou. Copie os diagnósticos e anexe os logs."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A instalação do WhiskyWine falhou. Copie os diagnósticos e anexe os registos."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A instalação do WhiskyWine falhou. Copie os diagnósticos e anexe os registos."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "WhiskyWine installation failed. Please copy diagnostics and attach logs."
+        "ro": {
+          "stringUnit": {
+            "state": "new",
+            "value": "WhiskyWine installation failed. Please copy diagnostics and attach logs."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установка WhiskyWine не удалась. Скопируйте диагностику и приложите журналы."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установка WhiskyWine не удалась. Скопируйте диагностику и приложите журналы."
           }
         },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installationen av WhiskyWine misslyckades. Kopiera diagnostik och bifoga loggar."
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installationen av WhiskyWine misslyckades. Kopiera diagnostik och bifoga loggar."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine kurulumu başarısız oldu. Lütfen tanılamayı kopyalayıp günlükleri ekleyin."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine kurulumu başarısız oldu. Lütfen tanılamayı kopyalayıp günlükleri ekleyin."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося встановити WhiskyWine. Скопіюйте діагностику та додайте журнали."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося встановити WhiskyWine. Скопіюйте діагностику та додайте журнали."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt WhiskyWine thất bại. Vui lòng sao chép chẩn đoán và đính kèm nhật ký."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt WhiskyWine thất bại. Vui lòng sao chép chẩn đoán và đính kèm nhật ký."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine 安装失败。请复制诊断并附上日志。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine 安装失败。请复制诊断并附上日志。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine 安裝失敗。請複製診斷並附上記錄。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine 安裝失敗。請複製診斷並附上記錄。"
           }
         }
       }
     },
-    "setup.whiskywine.error.accessDenied" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Access denied"
+    "setup.whiskywine.error.accessDenied": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Access denied"
           }
         }
       }
     },
-    "setup.whiskywine.error.downloadFailed" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download failed: %@"
+    "setup.whiskywine.error.downloadFailed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download failed: %@"
           }
         }
       }
     },
-    "setup.whiskywine.error.fetchVersionFailed" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to fetch version: %@"
+    "setup.whiskywine.error.fetchVersionFailed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to fetch version: %@"
           }
         }
       }
     },
-    "setup.whiskywine.error.fileNotFound" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "File not found"
+    "setup.whiskywine.error.fileNotFound": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File not found"
           }
         }
       }
     },
-    "setup.whiskywine.error.httpError" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HTTP error %d"
+    "setup.whiskywine.error.httpError": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTP error %d"
           }
         }
       }
     },
-    "setup.whiskywine.error.invalidDownloadURL" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid download URL"
+    "setup.whiskywine.error.invalidDownloadURL": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid download URL"
           }
         }
       }
     },
-    "setup.whiskywine.error.invalidVersionURL" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid version URL"
+    "setup.whiskywine.error.invalidVersionURL": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid version URL"
           }
         }
       }
     },
-    "setup.whiskywine.error.noFileReceived" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download failed: no file received"
+    "setup.whiskywine.error.noFileReceived": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download failed: no file received"
           }
         }
       }
     },
-    "setup.whiskywine.error.rateLimit" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rate limit exceeded. Please try again later."
+    "setup.whiskywine.error.rateLimit": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rate limit exceeded. Please try again later."
           }
         }
       }
     },
-    "setup.whiskywine.error.serverError" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server error. Please try again later."
+    "setup.whiskywine.error.serverError": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server error. Please try again later."
           }
         }
       }
     },
-    "setup.whiskywine.eta" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- متبقي %@"
+    "setup.whiskywine.eta": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- متبقي %@"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- zbývá %@"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- zbývá %@"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ tilbage"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ tilbage"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ verbleibend"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ verbleibend"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ remaining"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ remaining"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ restante"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ restante"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ jäljellä"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ jäljellä"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ restantes"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ restantes"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ rimanenti"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ rimanenti"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 残り %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- 残り %@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ 남음"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ 남음"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ resterend"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ resterend"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- pozostało %@"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- pozostało %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ restantes"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ restantes"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ em falta"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ em falta"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- A rămas %@"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- A rămas %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- осталось %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- осталось %@"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "-%@ kaldı"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "-%@ kaldı"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- залишилось %@"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- залишилось %@"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- %@ còn lại"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- %@ còn lại"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 剩余 %@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- 剩余 %@"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 剩餘%@"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "- 剩餘%@"
           }
         }
       }
     },
-    "setup.whiskywine.install" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تثبيت WhiskyWine"
+    "setup.whiskywine.install": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تثبيت WhiskyWine"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalace WhiskyWine"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalace WhiskyWine"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installere Wine"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installere Wine"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine wird installiert"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine wird installiert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installing WhiskyWine"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installing WhiskyWine"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalando WhiskyWine"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando WhiskyWine"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asennetaan WhiskyWine"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asennetaan WhiskyWine"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installation de WhiskyWine"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation de WhiskyWine"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installazione di WhiskyWine"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installazione di WhiskyWine"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine をインストール中"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine をインストール中"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine 설치 중"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine 설치 중"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine installeren"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine installeren"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalowanie WhiskyWine"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalowanie WhiskyWine"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalando Wine"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando Wine"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalando Wine"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando Wine"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se instalează WhiskyWine"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se instalează WhiskyWine"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установка WhiskyWine"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установка WhiskyWine"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine Yükleniyor"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine Yükleniyor"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Встановлення WhiskyWine"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Встановлення WhiskyWine"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đang cài đặt Wine"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang cài đặt Wine"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在安装 WhiskyWine"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在安装 WhiskyWine"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在安裝 WhiskyWine"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在安裝 WhiskyWine"
           }
         }
       }
     },
-    "setup.whiskywine.install.subtitle" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اوشكت على الوصول. لا تضبط الخروج بعد."
+    "setup.whiskywine.install.subtitle": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اوشكت على الوصول. لا تضبط الخروج بعد."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Už to bude. Zatím nezavírejte."
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Už to bude. Zatím nezavírejte."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Er der næsten. Luk ikke programmet endnu."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Er der næsten. Luk ikke programmet endnu."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fast fertig. Noch nicht abbrechen."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fast fertig. Noch nicht abbrechen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Almost there. Don't tune out yet."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almost there. Don't tune out yet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Un momento, ya casi está."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un momento, ya casi está."
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Melkein valmista. Älä karkaa vielä."
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melkein valmista. Älä karkaa vielä."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous y êtes presque. Veuillez patienter s'il vous plaît."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous y êtes presque. Veuillez patienter s'il vous plaît."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quasi fatto. Non disconnetterti adesso."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quasi fatto. Non disconnetterti adesso."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "あと少しです。そのままお待ち下さい。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "あと少しです。そのままお待ち下さい。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "거의 다 왔어요. 아직 끄지 마세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "거의 다 왔어요. 아직 끄지 마세요."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bijna daar. Nog niet weg gaan."
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bijna daar. Nog niet weg gaan."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prawie gotowe. Jeszcze nie wyłączaj."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prawie gotowe. Jeszcze nie wyłączaj."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quase lá. Por favor, aguarde."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quase lá. Por favor, aguarde."
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quase lá. Não desligue ainda."
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quase lá. Não desligue ainda."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aproape terminat. Nu ieși deocamdată."
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aproape terminat. Nu ieși deocamdată."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Почти закончили. Не отключайтесь."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Почти закончили. Не отключайтесь."
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitmek üzere. Lütfen Kapatmayınız."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitmek üzere. Lütfen Kapatmayınız."
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Майже готово."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Майже готово."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt sắp hoàn tất."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt sắp hoàn tất."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "就快完成了，请不要退出。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "就快完成了，请不要退出。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "快完成了。請不要退出。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快完成了。請不要退出。"
           }
         }
       }
     },
-    "setup.whiskywine.progress" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ من %@"
+    "setup.whiskywine.progress": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ من %@"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ z %@"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ z %@"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ af %@"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ af %@"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ von %@"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ von %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ of %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ of %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ de %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ de %@"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / %@"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ / %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ sur %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ sur %@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ di %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ di %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ / %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ / %@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ 중 %1$@"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ 중 %1$@"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ van de %@"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ van de %@"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ z %@"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ z %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ de %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ de %@"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ de %@"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ de %@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ din %@"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ din %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ из %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ из %@"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@'nin %@'si"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@'nin %@'si"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ з %@"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ з %@"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ của %@"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ của %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ 中的 %1$@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ 中的 %1$@"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ 中的 %1$@"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ 中的 %1$@"
           }
         }
       }
     },
-    "showAlertOnFirstLaunch.button.dontMove" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا تنقل"
+    "showAlertOnFirstLaunch.button.dontMove": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا تنقل"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nepřesouvat"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nepřesouvat"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flyt Ikke"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flyt Ikke"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht Bewegen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht Bewegen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Don't Move"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Don't Move"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Mover"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Mover"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Älä siirrä"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Älä siirrä"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ne pas déplacer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne pas déplacer"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non spostare"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non spostare"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移動しない"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移動しない"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "옮기지 않기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "옮기지 않기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niet verplaatsen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niet verplaatsen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie przenoś"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie przenoś"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não Mover"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não Mover"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não Mover"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não Mover"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu Muta"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nu Muta"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не двигать"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не двигать"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taşıma"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taşıma"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не переміщати"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не переміщати"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không Chuyển"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không Chuyển"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不要移动"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不要移动"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不移動"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不移動"
           }
         }
       }
     },
-    "showAlertOnFirstLaunch.button.moveToApplications" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "النقل إلى التطبيقات"
+    "showAlertOnFirstLaunch.button.moveToApplications": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النقل إلى التطبيقات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přesunout do složky Aplikace"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Přesunout do složky Aplikace"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flyt til mappen Applications"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flyt til mappen Applications"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In den Programm-Ordner legen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In den Programm-Ordner legen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Move to Applications"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to Applications"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mover a Aplicaciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover a Aplicaciones"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Siirrä Applikaatioihin"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siirrä Applikaatioihin"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Déplacer vers Applications"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déplacer vers Applications"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sposta in Applicazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sposta in Applicazioni"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「アプリケーション」に移動"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「アプリケーション」に移動"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "애플리케이션 폴더로 옮기기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "애플리케이션 폴더로 옮기기"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ga naar Toepassingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ga naar Toepassingen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przenieś do folderu Aplikacje"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przenieś do folderu Aplikacje"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mover para Aplicativos"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover para Aplicativos"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mover para Aplicações"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover para Aplicações"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mutare în Aplicații"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mutare în Aplicații"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перенести в «Приложения»"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перенести в «Приложения»"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uygulamalar'a Taşı"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulamalar'a Taşı"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перемістити до Застосунків"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемістити до Застосунків"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chuyển tới Applications"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển tới Applications"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移动到应用程序文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移动到应用程序文件夹"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移動到應用程式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移動到應用程式"
           }
         }
       }
     },
-    "showAlertOnFirstLaunch.informativeText" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "في بعض الحالات، Whisky لن يكون قادراً على العمل بشكل صحيح من مجلد مختلف"
+    "showAlertOnFirstLaunch.informativeText": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "في بعض الحالات، Whisky لن يكون قادراً على العمل بشكل صحيح من مجلد مختلف"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "V některých případech nemusí být Whisky schopna správně fungovat z jiné složky"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "V některých případech nemusí být Whisky schopna správně fungovat z jiné složky"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I nogle tilfælde vil Whisky ikke være i stand til at fungere korrekt fra en anden mappe"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I nogle tilfælde vil Whisky ikke være i stand til at fungere korrekt fra en anden mappe"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In manchen Fällen wird Whisky nicht richtig funktionieren, wenn es in einem anderen Ordner gespeichert ist"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In manchen Fällen wird Whisky nicht richtig funktionieren, wenn es in einem anderen Ordner gespeichert ist"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In some cases, Whisky wont't be able to function properly from a different folder"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In some cases, Whisky wont't be able to function properly from a different folder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En algunos casos, Whisky podría no funcionar correctamente desde una carpeta diferente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En algunos casos, Whisky podría no funcionar correctamente desde una carpeta diferente"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Joissakin tapauksissa, Whiskyn ei ole mahdollista toimia kunnolla muista kansioista"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Joissakin tapauksissa, Whiskyn ei ole mahdollista toimia kunnolla muista kansioista"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dans certains cas, Whisky ne pourra pas fonctionner correctement depuis un dossier différent"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dans certains cas, Whisky ne pourra pas fonctionner correctement depuis un dossier différent"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In alcuni casi, Whisky non potrà funzionare correttamente da un cartella diversa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In alcuni casi, Whisky non potrà funzionare correttamente da un cartella diversa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "場合によっては、異なるフォルダから Whisky を適切に使用できない場合があります"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "場合によっては、異なるフォルダから Whisky を適切に使用できない場合があります"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "경우에 따라 다른 폴더에서는 Whisky가 제대로 동작하지 않을 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경우에 따라 다른 폴더에서는 Whisky가 제대로 동작하지 않을 수 있습니다."
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In sommige gevallen zal Whiskey niet goed kunnen functioneren vanuit een andere map"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In sommige gevallen zal Whiskey niet goed kunnen functioneren vanuit een andere map"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "W niektórych przypadkach Whisky nie będzie w stanie działać poprawnie w innym folderze"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "W niektórych przypadkach Whisky nie będzie w stanie działać poprawnie w innym folderze"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Em alguns casos, o Whisky pode não funcionar corretamente numa pasta diferente"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Em alguns casos, o Whisky pode não funcionar corretamente numa pasta diferente"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Em alguns casos, o Whisky pode não funcionar corretamente numa pasta diferente"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Em alguns casos, o Whisky pode não funcionar corretamente numa pasta diferente"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "În unele cazuri, Whisky nu va putea funcționa corect dintr-un folder diferit"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "În unele cazuri, Whisky nu va putea funcționa corect dintr-un folder diferit"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "В некоторых случаях Whisky не сможет правильно функционировать из другой папки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В некоторых случаях Whisky не сможет правильно функционировать из другой папки"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazı durumlarda, Whisky başka bir klasörden düzgün çalışamayabilir"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bazı durumlarda, Whisky başka bir klasörden düzgün çalışamayabilir"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "У деяких випадках, Whisky може не працювати належним чином з іншої папки"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "У деяких випадках, Whisky може не працювати належним чином з іншої папки"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trong một số trường hợp, Whisky sẽ không hoạt động đúng nếu không nằm trong Applications"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trong một số trường hợp, Whisky sẽ không hoạt động đúng nếu không nằm trong Applications"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在某些情况下，Whisky 可能无法在其他的文件夹中正常工作"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在某些情况下，Whisky 可能无法在其他的文件夹中正常工作"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在某些情況下，Whisky 可能無法在不同的資料夾中正常運作"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在某些情況下，Whisky 可能無法在不同的資料夾中正常運作"
           }
         }
       }
     },
-    "showAlertOnFirstLaunch.messageText" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هل ترغب في نقل Whisky إلى مجلد التطبيقات الخاص بك؟"
+    "showAlertOnFirstLaunch.messageText": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هل ترغب في نقل Whisky إلى مجلد التطبيقات الخاص بك؟"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chtěli byste přesunout Whisky do složky s aplikacemi?"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chtěli byste přesunout Whisky do složky s aplikacemi?"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vil du flytte Whisky til Applications mappen?"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vil du flytte Whisky til Applications mappen?"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Möchtest du Whisky in deinen Programm-Ordner legen?"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möchtest du Whisky in deinen Programm-Ordner legen?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Would you like to move Whisky to your Applications folder?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Would you like to move Whisky to your Applications folder?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Te gustaría mover Whisky a la carpeta de Aplicaciones?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Te gustaría mover Whisky a la carpeta de Aplicaciones?"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haluatko siirtää Whiskyn Applikaatio-kansioon?"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haluatko siirtää Whiskyn Applikaatio-kansioon?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Souhaitez-vous déplacer Whisky dans votre dossier Applications ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Souhaitez-vous déplacer Whisky dans votre dossier Applications ?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vuoi spostare Whisky nella tua cartella Applicazioni?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuoi spostare Whisky nella tua cartella Applicazioni?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky を「アプリケーション」フォルダに移動しますか？"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky を「アプリケーション」フォルダに移動しますか？"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky를 애플리케이션 폴더로 옮기시겠습니까?"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky를 애플리케이션 폴더로 옮기시겠습니까?"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wilt u Whiskey verplaatsen naar uw map Toepassingen?"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wilt u Whiskey verplaatsen naar uw map Toepassingen?"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czy chcesz przenieść Whisky do folderu Aplikacje?"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czy chcesz przenieść Whisky do folderu Aplikacje?"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Você gostaria de mover o Whisky para a pasta dos Aplicativos?"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você gostaria de mover o Whisky para a pasta dos Aplicativos?"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gostaria de mover o Whisky para a pasta das Aplicações ?"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gostaria de mover o Whisky para a pasta das Aplicações ?"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Doriți să mutați Whisky în folder-ul dvs. Aplicații?"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doriți să mutați Whisky în folder-ul dvs. Aplicații?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вы хотите переместить Whisky в папку «Приложения»?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы хотите переместить Whisky в папку «Приложения»?"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whisky'yi Uygulamalar klasörünüze taşımak ister misiniz?"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky'yi Uygulamalar klasörünüze taşımak ister misiniz?"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хотіли б ви перемістити Whisky у вашу папку Застосунки?"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хотіли б ви перемістити Whisky у вашу папку Застосунки?"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bạn có muốn chuyển Whisky tới folder Applications?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn có muốn chuyển Whisky tới folder Applications?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你想要将 Whisky 移动到你的应用程序文件夹吗？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你想要将 Whisky 移动到你的应用程序文件夹吗？"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你希望將 Whisky 移動到你的應用程式資料夾嗎？"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你希望將 Whisky 移動到你的應用程式資料夾嗎？"
           }
         }
       }
     },
-    "Steam and Chromium-based launchers require en_US locale to avoid steamwebhelper crashes" : {
-
+    "Steam and Chromium-based launchers require en_US locale to avoid steamwebhelper crashes": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steam and Chromium-based launchers require en_US locale to avoid steamwebhelper crashes"
+          }
+        }
+      }
     },
-    "status.launched %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Launched: %@"
+    "status.launched %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launched: %@"
           }
         }
       }
     },
-    "status.launchedTerminal %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Launched in Terminal: %@"
+    "status.launchedTerminal %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launched in Terminal: %@"
           }
         }
       }
     },
-    "status.launchFailed %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Launch failed: %@"
+    "status.launchFailed %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch failed: %@"
           }
         }
       }
     },
-    "tab.config" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تكوين القارورة"
+    "tab.config": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تكوين القارورة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurace lahve"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurace lahve"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle-konfigurering"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle-konfigurering"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle Konfiguration"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle Konfiguration"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle Configuration"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle Configuration"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración de la botella"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración de la botella"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pullon asetukset"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pullon asetukset"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration de la bouteille"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration de la bouteille"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurazione della bottiglia"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurazione della bottiglia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle の設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle の設定"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle 설정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle 설정"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle configuratie"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle configuratie"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguracja butelki"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguracja butelki"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuração da Bottle"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuração da Bottle"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuração da Bottle"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuração da Bottle"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurare Sticlă"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurare Sticlă"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Конфигурация бутылки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Конфигурация бутылки"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottle Konfigürasyon'u"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottle Konfigürasyon'u"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Налаштування пляшки"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування пляшки"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt Bottle"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt Bottle"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "容器配置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "容器配置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "容器設定"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "容器設定"
           }
         }
       }
     },
-    "tab.processes" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "العمليات قيد التشغيل"
+    "tab.processes": {
+      "extractionState": "stale",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "العمليات قيد التشغيل"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spuštěné procesy"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spuštěné procesy"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kørende processer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kørende processer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laufende Prozesse"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laufende Prozesse"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Running Processes"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running Processes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Procesos en ejecución"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Procesos en ejecución"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Käynnissä olevat prosessit"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käynnissä olevat prosessit"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processus en cours d'exécution"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processus en cours d'exécution"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processi in esecuzione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processi in esecuzione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "実行中のプロセス"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行中のプロセス"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "실행중인 프로세스들"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행중인 프로세스들"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lopende processen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lopende processen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uruchamianie procesów"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uruchamianie procesów"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processos em Execução"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processos em Execução"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processos em Execução"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processos em Execução"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Procese Active"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Procese Active"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запущенные процессы"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запущенные процессы"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Çalışan İşlemler"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışan İşlemler"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запущені процеси"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запущені процеси"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiến trình đang chạy"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiến trình đang chạy"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行中进程"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行中进程"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在執行進程"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在執行進程"
           }
         }
       }
     },
-    "tab.programs" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "البرامج المثبتة"
+    "tab.programs": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "البرامج المثبتة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nainstalované programy"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nainstalované programy"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installerede programmer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installerede programmer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installierte Programme"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installierte Programme"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installed Programs"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed Programs"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programas Instalados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programas Instalados"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asennetut ohjelmat"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asennetut ohjelmat"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programmes installés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programmes installés"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programmi installati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programmi installati"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストール済みのプログラム"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済みのプログラム"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설치된 프로그램"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설치된 프로그램"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geïnstalleerde programma's"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geïnstalleerde programma's"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zainstalowane programy"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zainstalowane programy"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programas Instalados"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programas Instalados"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programas Instalados"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programas Instalados"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programe Instalate"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programe Instalate"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установленные программы"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установленные программы"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İndirilmiş Programlar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İndirilmiş Programlar"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Встановлені програми"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Встановлені програми"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ứng dụng đã cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ứng dụng đã cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已安装的程序"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装的程序"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已安裝的程式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安裝的程式"
           }
         }
       }
     },
-    "update.whiskywine.description" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أنت تقوم بتشغيل WhiskyWine %@، ولكن %@ متوفر. هل ترغب في التحديث؟"
+    "update.whiskywine.description": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أنت تقوم بتشغيل WhiskyWine %@، ولكن %@ متوفر. هل ترغب في التحديث؟"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Máte spuštěnou %@, ale %@ není k dispozici. Chcete aktualizovat?"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máte spuštěnou %@, ale %@ není k dispozici. Chcete aktualizovat?"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du kører WhiskyWine %@, men %@ er tilgængelig. Ønsker du at opdatere?"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du kører WhiskyWine %@, men %@ er tilgængelig. Ønsker du at opdatere?"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sie verwenden WhiskyWine %@, die aktuelle Version ist %@. Möchten Sie WhiskyWine aktualisieren?"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie verwenden WhiskyWine %@, die aktuelle Version ist %@. Möchten Sie WhiskyWine aktualisieren?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You are running WhiskyWine %@, but %@ is available. Would you like to update?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You are running WhiskyWine %@, but %@ is available. Would you like to update?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estás ejecutando WhiskyWine %@, pero %@ está disponible. ¿Quieres actualizar?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estás ejecutando WhiskyWine %@, pero %@ está disponible. ¿Quieres actualizar?"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Käytössäsi on WhiskyWine %@, mutta %@ on saatavilla. Haluatko päivittää sen?"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käytössäsi on WhiskyWine %@, mutta %@ on saatavilla. Haluatko päivittää sen?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous utilisez WhiskyWine %@, mais %@ est disponible. Voulez-vous le mettre à jour ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous utilisez WhiskyWine %@, mais %@ est disponible. Voulez-vous le mettre à jour ?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stai utilizzando WhiskyWine %@, ma %@ è disponibile. Vuoi aggiornare?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stai utilizzando WhiskyWine %@, ma %@ è disponibile. Vuoi aggiornare?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在 WhiskyWine %@ を使用していますが、 %@ を利用可能です。アップデートしますか？"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在 WhiskyWine %@ を使用していますが、 %@ を利用可能です。アップデートしますか？"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine %@ 버전을 사용 중이지만 %@ 버전을 사용할 수 있습니다. 업데이트하시겠습니까?"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine %@ 버전을 사용 중이지만 %@ 버전을 사용할 수 있습니다. 업데이트하시겠습니까?"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U gebruikt WhiskyWine %@, maar %@ is beschikbaar. Wilt u updaten?"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "U gebruikt WhiskyWine %@, maar %@ is beschikbaar. Wilt u updaten?"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Używasz WhiskyWine %@, lecz nowsza wersja %@ jest dostępna. Czy chcesz zaktualizować?"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Używasz WhiskyWine %@, lecz nowsza wersja %@ jest dostępna. Czy chcesz zaktualizować?"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine %@ está sendo usada, mas %@ está disponível. Atualizar?"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine %@ está sendo usada, mas %@ está disponível. Atualizar?"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Está a usar o WhiskyWine %@, mas o %@ está disponível. Gostaria de atualizar?"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Está a usar o WhiskyWine %@, mas o %@ está disponível. Gostaria de atualizar?"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dvs. rulați WhiskyWine %@, dar %@ este disponibil. Doriți să actualizați?"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dvs. rulați WhiskyWine %@, dar %@ este disponibil. Doriți să actualizați?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вы используете WhiskyWine %@, но %@ доступен. Желаете обновить?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы используете WhiskyWine %@, но %@ доступен. Желаете обновить?"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine %@ versiyonu kullanıyorsunuz ama %@ versiyonu mevcut. Güncellemek ister misiniz?"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine %@ versiyonu kullanıyorsunuz ama %@ versiyonu mevcut. Güncellemek ister misiniz?"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ви використовуєте WhiskyWine %@, але доступна версія %@. Оновити?"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ви використовуєте WhiskyWine %@, але доступна версія %@. Оновити?"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bạn đang sử dụng WhiskyWine phiên bản %@, nhưng phiên bản%@ đã được phát hành. Bạn có muốn cập nhật không?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn đang sử dụng WhiskyWine phiên bản %@, nhưng phiên bản%@ đã được phát hành. Bạn có muốn cập nhật không?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您正在运行 WhiskyWine %@，但 %@ 可用。您想要更新吗？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您正在运行 WhiskyWine %@，但 %@ 可用。您想要更新吗？"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您正在使用WhiskyWine %@, %@已可更新 請問是否要更新?"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您正在使用WhiskyWine %@, %@已可更新 請問是否要更新?"
           }
         }
       }
     },
-    "update.whiskywine.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إصدار جديد من WhiskyWine متوفر"
+    "update.whiskywine.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إصدار جديد من WhiskyWine متوفر"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "K dispozici je nová verze WhiskyWine"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "K dispozici je nová verze WhiskyWine"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ny version af WhiskyWine tilgængelig"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ny version af WhiskyWine tilgængelig"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eine neue WhiskyWine Version ist verfügbar"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine neue WhiskyWine Version ist verfügbar"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Version of WhiskyWine Available"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Version of WhiskyWine Available"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nueva versión de WhiskyWine disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva versión de WhiskyWine disponible"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uusi WhiskyWine versio on saatavilla"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uusi WhiskyWine versio on saatavilla"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nouvelle version de WhiskyWine disponible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle version de WhiskyWine disponible"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nuova versione di WhiskyWine disponibile"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuova versione di WhiskyWine disponibile"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine の新しいバージョンがあります"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine の新しいバージョンがあります"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "새로운 버전의 WhiskyWine를 사용할 수 있습니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로운 버전의 WhiskyWine를 사용할 수 있습니다"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nieuwe WhiskyWine versie is beschikbaar"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nieuwe WhiskyWine versie is beschikbaar"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nowa wersja WhiskyWine jest dostępna"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowa wersja WhiskyWine jest dostępna"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nova versão do WhiskyWine disponível"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova versão do WhiskyWine disponível"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nova versão do WhiskyWine disponível"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova versão do WhiskyWine disponível"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O Nouă Versiune WhiskyWine este Disponibilă"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Nouă Versiune WhiskyWine este Disponibilă"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Доступна новая версия WhiskyWine"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доступна новая версия WhiskyWine"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhiskyWine'nin yeni versiyonu mevcut"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WhiskyWine'nin yeni versiyonu mevcut"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Доступна нова версія WhiskyWine"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доступна нова версія WhiskyWine"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phiên bản mới của WhiskyWine đã được phát hành"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phiên bản mới của WhiskyWine đã được phát hành"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有更新的 WhiskyWine 版本可用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有更新的 WhiskyWine 版本可用"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有新的WhiskyWine版本可供安裝"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有新的WhiskyWine版本可供安裝"
           }
         }
       }
     },
-    "update.whiskywine.update" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحديث"
+    "update.whiskywine.update": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحديث"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualizovat"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualizovat"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opdater"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opdater"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualisierung"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisierung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Päivitä"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Päivitä"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mettre à jour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiornamento"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamento"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アップデート"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデート"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "업데이트"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updaten"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updaten"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualizuj"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualizuj"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualizar"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizare"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizare"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обновить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Güncelle"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güncelle"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Оновити"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оновити"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cập nhật"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cập nhật"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
           }
         }
       }
     },
-    "wine.clearShaderCaches" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مسح ذاكرة التخزين المؤقت"
+    "wine.clearShaderCaches": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسح ذاكرة التخزين المؤقت"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vyčistit Shader Cache"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vyčistit Shader Cache"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ryd Shader Caches"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ryd Shader Caches"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shader-Cache löschen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shader-Cache löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear Shader Caches"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Shader Caches"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpiar Caché de Shaders"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiar Caché de Shaders"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tyhjennä Varjostin-välimuistit"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tyhjennä Varjostin-välimuistit"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vider les caches du shader"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vider les caches du shader"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pulisci cache shader"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pulisci cache shader"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シェーダーのキャッシュを消去"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェーダーのキャッシュを消去"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셰이더 캐시 초기화"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셰이더 캐시 초기화"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwijder shader caches"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijder shader caches"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyczyść pamięć podręczną cieni"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyczyść pamięć podręczną cieni"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpar Cache de Shader"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar Cache de Shader"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpar Cache de Shader"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar Cache de Shader"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Golire Cache Shader"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Golire Cache Shader"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистить кэш шейдеров"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить кэш шейдеров"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shader Cache'lerini Temizle"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shader Cache'lerini Temizle"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очищення кеша шейдерів"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очищення кеша шейдерів"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xoá cache shader"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xoá cache shader"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清空 Shader 缓存"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清空 Shader 缓存"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除著色器快取"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除著色器快取"
           }
         }
       }
     },
-    "winetricks.category.apps" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التطبيقات"
+    "winetricks.category.apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التطبيقات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplikace"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikace"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programmer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Programmer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apps"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apps"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplicaciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicaciones"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sovellukset"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sovellukset"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Applications"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applications"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Applicazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applicazioni"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "앱"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Applicaties"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applicaties"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplikacje"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplikacje"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apps"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplicações"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicações"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplicaţii"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicaţii"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Приложения"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приложения"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uygulamalar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulamalar"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Програми"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програми"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ứng dụng"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ứng dụng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用程序"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用程序"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "應用程式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "應用程式"
           }
         }
       }
     },
-    "winetricks.category.benchmarks" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اختبار الأداء"
+    "winetricks.category.benchmarks": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختبار الأداء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmark"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmark"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmarks"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmarks"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmarks"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmarks"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmarks"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmarks"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prueba de rendimiento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prueba de rendimiento"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suorituskykytesti"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suorituskykytesti"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmarks"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmarks"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmark"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmark"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ベンチマーク"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ベンチマーク"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "벤치마크"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "벤치마크"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmarks"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmarks"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testy wydajnościowe (Benchmarki)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testy wydajnościowe (Benchmarki)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmarks"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmarks"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valores de Referência"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valores de Referência"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmark-uri"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmark-uri"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Тесты производительности"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тесты производительности"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kıyaslama Testleri"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kıyaslama Testleri"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Контрольні показники"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Контрольні показники"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmarks"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmarks"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benchmarks"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benchmarks"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "效能評測"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "效能評測"
           }
         }
       }
     },
-    "winetricks.category.dlls" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ملفات DLL"
+    "winetricks.category.dlls": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ملفات DLL"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLL'er"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLL'er"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLL"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLL"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Biblioteki (DLL)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biblioteki (DLL)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLL-uri"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLL-uri"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Библиотеки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Библиотеки"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DLLs"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DLLs"
           }
         }
       }
     },
-    "winetricks.category.fonts" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الخطوط"
+    "winetricks.category.fonts": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الخطوط"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Písmo"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Písmo"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skrifttyper"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skrifttyper"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schriftarten"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schriftarten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fonts"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonts"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fuentes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuentes"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fontit"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fontit"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polices"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polices"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fonts"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonts"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フォント"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォント"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "글꼴"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lettertypen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettertypen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czcionki"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czcionki"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fonts"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonts"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fontes"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fontes"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fonturi"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonturi"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Шрифты"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шрифты"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yazı tipleri"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yazı tipleri"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Шрифти"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шрифти"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phông chữ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phông chữ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "字体"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "字型"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字型"
           }
         }
       }
     },
-    "winetricks.category.games" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الألعاب"
+    "winetricks.category.games": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الألعاب"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hry"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hry"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spil"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spil"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spiele"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spiele"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Games"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Games"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Juegos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Juegos"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pelit"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pelit"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jeux"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jeux"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giochi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giochi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ゲーム"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲーム"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "게임"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "게임"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Games"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Games"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gry"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gry"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Games"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Games"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jogos"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jogos"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jocuri"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jocuri"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Игры"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Игры"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oyunlar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oyunlar"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ігри"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ігри"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trò chơi"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trò chơi"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "游戏"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "游戏"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "遊戲"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "遊戲"
           }
         }
       }
     },
-    "winetricks.category.settings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإعدادات"
+    "winetricks.category.settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإعدادات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nastavení"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indstillinger"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indstillinger"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asetukset"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asetukset"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramètres"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instellingen"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instellingen"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ustawienia"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienia"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Definições"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definições"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setări"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setări"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayarlar"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayarlar"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Налаштування"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
           }
         }
       }
     },
-    "winetricks.error.copyDiagnostics" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Diagnostics"
+    "winetricks.error.copyDiagnostics": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Diagnostics"
           }
         }
       }
     },
-    "winetricks.error.corruptedPrefix" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The Wine prefix is corrupted or missing essential directories."
+    "winetricks.error.corruptedPrefix": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Wine prefix is corrupted or missing essential directories."
           }
         }
       }
     },
-    "winetricks.error.missingAppData" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The AppData directory is missing or incomplete. This will cause dependency installations to fail."
+    "winetricks.error.missingAppData": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The AppData directory is missing or incomplete. This will cause dependency installations to fail."
           }
         }
       }
     },
-    "winetricks.error.missingUserProfile" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The user profile directory is missing. Wine may not be properly initialized."
+    "winetricks.error.missingUserProfile": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The user profile directory is missing. Wine may not be properly initialized."
           }
         }
       }
     },
-    "winetricks.error.prefixTitle" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wine Prefix Issue"
+    "winetricks.error.prefixTitle": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wine Prefix Issue"
           }
         }
       }
     },
-    "winetricks.error.repairFailed" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Repair Failed"
+    "winetricks.error.repairFailed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repair Failed"
           }
         }
       }
     },
-    "winetricks.error.repairFailedInfo" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to repair the Wine prefix. Please try recreating the bottle."
+    "winetricks.error.repairFailedInfo": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to repair the Wine prefix. Please try recreating the bottle."
           }
         }
       }
     },
-    "winetricks.error.repairPrefix" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Repair Prefix"
+    "winetricks.error.repairPrefix": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repair Prefix"
           }
         }
       }
     },
-    "winetricks.table.description" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الوصف"
+    "winetricks.table.description": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوصف"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Popis"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Popis"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beskrivelse"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beskrivelse"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beschreibung"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beschreibung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Description"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Description"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descripción"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descripción"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kuvaus"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kuvaus"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Description"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Description"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descrizione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descrizione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "説明"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "説明"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "상세 설명"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상세 설명"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Omschrijving"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omschrijving"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opis"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opis"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Description"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Description"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descrição"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descrição"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descriere"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descriere"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Описание"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Описание"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Açıklama"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Açıklama"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Описання"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Описання"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Miêu tả"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Miêu tả"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "说明"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "说明"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "描述"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "描述"
           }
         }
       }
     },
-    "winetricks.table.name" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أمر"
+    "winetricks.table.name": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أمر"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Příkaz"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Příkaz"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kommando"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kommando"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Befehl"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehl"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Command"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comando"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komento"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komento"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commande"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commande"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comando"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comando"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コマンド"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コマンド"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "명령어"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "명령어"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opdracht"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opdracht"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komenda"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komenda"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Command"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comando"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comando"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comandă"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comandă"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Команда"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Команда"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komut"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komut"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Команда"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Команда"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Câu lệnh"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Câu lệnh"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "指令"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指令"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "指令"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指令"
           }
         }
       }
     },
-    "winetricks.title" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تشغيل أمر Winetricks"
+    "winetricks.title": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل أمر Winetricks"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spustit Winetricks příkaz"
+        "cs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spustit Winetricks příkaz"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kør kommandoen Winetricks"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kør kommandoen Winetricks"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks-Befehl ausführen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks-Befehl ausführen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Run Winetricks Command"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Winetricks Command"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ejecutar comando de Winetricks"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar comando de Winetricks"
           }
         },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suorita Winetricks komento"
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suorita Winetricks komento"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exécuter une commande Winetricks"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécuter une commande Winetricks"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esegui comando Winetricks"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esegui comando Winetricks"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks コマンドを実行"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks コマンドを実行"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks 명령어 실행"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks 명령어 실행"
           }
         },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voer Winetricks commando uit"
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voer Winetricks commando uit"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uruchom polecenie Winetricks"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uruchom polecenie Winetricks"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executar comando Winetricks"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar comando Winetricks"
           }
         },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executar o comando Winetricks"
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar o comando Winetricks"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rulează comanda Winetricks"
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rulează comanda Winetricks"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выполнить команду Winetricks"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполнить команду Winetricks"
           }
         },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winetricks komutlarını çalıştırın"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winetricks komutlarını çalıştırın"
           }
         },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запустити команду Winetricks"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустити команду Winetricks"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chạy lệnh Winetricks"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạy lệnh Winetricks"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行 Winetricks 命令"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行 Winetricks 命令"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "執行Winetricks指令"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行Winetricks指令"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }


### PR DESCRIPTION
## Summary
Fix localization fallback for non-English users who see raw localization keys instead of text.

- Add English translations to 32 xcstrings entries with empty localizations
- All Launcher Compatibility strings now fall back to English properly

## Problem
Non-English users were seeing raw keys like "Configuration Warnings" and "Auto-Enable DXVK for Launchers" instead of readable text. This happened because these string entries had empty `localizations` blocks in the xcstrings file.

**Apple's fallback chain:** User language → English (source) → Raw key

When English was missing, the raw key was displayed.

## Changes
- Added English translations to 32 string entries that had empty localizations
- Most are Launcher Compatibility strings where the key IS the English text

## Test plan
- [ ] Set macOS to non-English language
- [ ] Open Whisky → Bottle → Config → Launcher Compatibility
- [ ] Verify all strings display in English (not raw keys)

Refs #49