### PR TITLE
Main-release foundation: identity hygiene, governance/support docs, runtime tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -97,6 +97,8 @@ body:
       options:
         - label: I searched existing issues and didn't find a duplicate.
           required: true
+        - label: I'm running **this fork** (`frankea/Whisky`, confirmed via **Whisky → About**) — not the archived original that the default `brew install --cask whisky` installs.
+          required: true
         - label: I confirmed this is **not** a game-specific compatibility issue (use the other template if it is).
           required: true
         - label: My issue is written in English so all maintainers can read it.

--- a/.github/workflows/RuntimeTrack.yml
+++ b/.github/workflows/RuntimeTrack.yml
@@ -1,0 +1,87 @@
+name: Runtime Dependency Tracking
+
+# Polls the upstream sources of the bundled Wine runtime and opens a tracking issue when a pinned
+# component falls behind its latest upstream release. The runtime (Libraries.tar.gz) is assembled
+# from third-party binaries; this keeps that otherwise-invisible dependency visible.
+#
+# Pinned tags live below in `env`. When you cut a new runtime release, bump the matching *_PINNED tag
+# to whatever you actually consumed and keep docs/DEPENDENCIES.md in sync. A pin left as "SET_ME"
+# is treated as informational only (reported, never flagged as drift) so this is safe to run unattended.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # Mondays 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # repo (owner/name)         pinned upstream tag we currently bundle
+  WINE_REPO: Gcenx/macOS_Wine_builds
+  WINE_PINNED: SET_ME
+  DXVK_REPO: Gcenx/DXVK-macOS
+  DXVK_PINNED: SET_ME
+  DXMT_REPO: 3Shain/dxmt
+  DXMT_PINNED: SET_ME
+
+jobs:
+  track:
+    name: Check runtime upstreams
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compare pinned vs latest and open an issue on drift
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          latest_tag() {
+            # Latest *published* release tag for a repo, or empty string if none.
+            gh api "repos/$1/releases/latest" --jq '.tag_name' 2>/dev/null || true
+          }
+
+          drift_body=""
+          summary="| Component | Pinned | Latest upstream | Status |\n|---|---|---|---|\n"
+
+          check() {
+            local name="$1" repo="$2" pinned="$3"
+            local latest
+            latest="$(latest_tag "$repo")"
+            latest="${latest:-(none found)}"
+            local status
+            if [ "$pinned" = "SET_ME" ]; then
+              status="ℹ️ pin not set"
+            elif [ "$pinned" = "$latest" ]; then
+              status="✅ current"
+            else
+              status="⚠️ behind"
+              drift_body="${drift_body}- **${name}** (\`${repo}\`): bundled \`${pinned}\` → latest \`${latest}\`\n"
+            fi
+            summary="${summary}| ${name} | ${pinned} | ${latest} | ${status} |\n"
+          }
+
+          check "Wine"  "$WINE_REPO" "$WINE_PINNED"
+          check "DXVK"  "$DXVK_REPO" "$DXVK_PINNED"
+          check "DXMT"  "$DXMT_REPO" "$DXMT_PINNED"
+
+          printf "### Runtime dependency check\n\n%b\n" "$summary" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -z "$drift_body" ]; then
+            echo "No drift detected."
+            exit 0
+          fi
+
+          title="Runtime dependency drift detected"
+          existing="$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number' || true)"
+          body="$(printf "One or more bundled runtime components are behind upstream:\n\n%b\nReview, test, and (if appropriate) bump the runtime per docs/ReleaseWorkflow.md, then update the pinned tags in .github/workflows/RuntimeTrack.yml and docs/DEPENDENCIES.md.\n\n_Filed automatically by RuntimeTrack._" "$drift_body")"
+
+          if [ -n "${existing:-}" ] && [ "${existing}" != "null" ]; then
+            gh issue comment "$existing" --body "$body"
+            echo "Updated existing tracking issue #$existing"
+          else
+            gh issue create --title "$title" --label runtime --body "$body"
+            echo "Opened new tracking issue"
+          fi

--- a/.github/workflows/RuntimeTrack.yml
+++ b/.github/workflows/RuntimeTrack.yml
@@ -39,8 +39,15 @@ jobs:
           set -euo pipefail
 
           latest_tag() {
-            # Latest *published* release tag for a repo, or empty string if none.
-            gh api "repos/$1/releases/latest" --jq '.tag_name' 2>/dev/null || true
+            # Latest published release tag for a repo. Echoes "ERROR" when the API call fails
+            # (network / rate-limit / no releases) so a transient failure is not mistaken for
+            # "behind" and does not file a spurious drift issue.
+            local out
+            if out="$(gh api "repos/$1/releases/latest" --jq '.tag_name' 2>/dev/null)"; then
+              echo "${out:-ERROR}"
+            else
+              echo "ERROR"
+            fi
           }
 
           drift_body=""
@@ -48,11 +55,11 @@ jobs:
 
           check() {
             local name="$1" repo="$2" pinned="$3"
-            local latest
+            local latest status
             latest="$(latest_tag "$repo")"
-            latest="${latest:-(none found)}"
-            local status
-            if [ "$pinned" = "SET_ME" ]; then
+            if [ "$latest" = "ERROR" ]; then
+              status="⚠️ could not check (skipped)"
+            elif [ "$pinned" = "SET_ME" ]; then
               status="ℹ️ pin not set"
             elif [ "$pinned" = "$latest" ]; then
               status="✅ current"
@@ -82,6 +89,6 @@ jobs:
             gh issue comment "$existing" --body "$body"
             echo "Updated existing tracking issue #$existing"
           else
-            gh issue create --title "$title" --label runtime --body "$body"
+            gh issue create --title "$title" --body "$body"
             echo "Opened new tracking issue"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - Added project governance and support docs: `docs/GOVERNANCE.md` (honest single-maintainer
   continuity stance), `docs/SUPPORT.md` (where to file and what to expect), and
-  `.planning/DEPENDENCIES.md` (pinned Wine/DXVK/D3DMetal/DXMT runtime components and their sources).
+  `docs/DEPENDENCIES.md` (pinned Wine/DXVK/D3DMetal/DXMT runtime components and their sources).
 - Documented the reproducible runtime-assembly procedure in `docs/ReleaseWorkflow.md` (previously
   marked "out of scope") and added a weekly `RuntimeTrack` workflow that flags when a bundled runtime
   component falls behind upstream. The bug-report template now asks reporters to confirm they're on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (Closes whisky-app/whisky#411).
 
 ### Changed
+- Diagnostic reports (WhiskyWine setup and Wine prefix) now link to this fork's issue tracker
+  (`frankea/Whisky`) instead of the archived upstream, so reports reach a maintained repo. Internal
+  Logger subsystems and notification names also moved off the archived `com.isaacmarovitz.Whisky`
+  namespace onto `com.franke.Whisky`.
 - Bundled GameDB grows by 4 more entries from the third-pass retriage:
   DJMAX RESPECT V (Korean fonts + DXVK), They Are Billions (vcrun + DXVK),
   SpellForce 3 (corefonts + d3dcompiler), Fallout 4 (Sequoia compat + xact)
@@ -113,6 +117,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   context-menu actions dedupe against the existing blocklist before
   appending, both for single-row and multi-selection cases
   (Closes whisky-app/whisky#431).
+
+### Documentation
+- Added project governance and support docs: `docs/GOVERNANCE.md` (honest single-maintainer
+  continuity stance), `docs/SUPPORT.md` (where to file and what to expect), and
+  `.planning/DEPENDENCIES.md` (pinned Wine/DXVK/D3DMetal/DXMT runtime components and their sources).
+- Documented the reproducible runtime-assembly procedure in `docs/ReleaseWorkflow.md` (previously
+  marked "out of scope") and added a weekly `RuntimeTrack` workflow that flags when a bundled runtime
+  component falls behind upstream. The bug-report template now asks reporters to confirm they're on
+  this fork rather than the archived original.
 
 ## [3.0.1] - 2026-05-01 (App)
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ If you have no critical bottles, you can skip the export — the new app will cr
 
 ## Documentation
 
+- **[Support](docs/SUPPORT.md)** - Where to file bugs and what to expect from a single-maintainer fork
+- **[Governance & continuity](docs/GOVERNANCE.md)** - Who maintains this and the honest bus-factor situation
+- **[Runtime dependencies](docs/DEPENDENCIES.md)** - The bundled Wine/DXVK/D3DMetal/DXMT versions and their upstream sources
+
 WhiskyKit, the core framework powering Whisky, has comprehensive API documentation:
 
 - **[WhiskyKit API Documentation](https://frankea.github.io/Whisky/documentation/whiskykit/)** - Full API reference with usage examples

--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -179,6 +179,6 @@ extension Notification.Name {
 
     /// Posted from program settings to navigate to the Audio troubleshooting panel.
     static let openAudioTroubleshooting = Notification.Name(
-        "com.isaacmarovitz.Whisky.openAudioTroubleshooting"
+        "com.franke.Whisky.openAudioTroubleshooting"
     )
 }

--- a/Whisky/Utils/ControllerMonitor.swift
+++ b/Whisky/Utils/ControllerMonitor.swift
@@ -138,7 +138,7 @@ class ControllerMonitor: ObservableObject {
     var recentHistory: [ControllerHistoryEntry] = []
 
     private let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "ControllerMonitor"
     )
 

--- a/Whisky/Utils/SteamDownloadMonitor.swift
+++ b/Whisky/Utils/SteamDownloadMonitor.swift
@@ -269,6 +269,6 @@ class SteamDownloadMonitor: ObservableObject {
 extension Notification.Name {
     /// Posted when a Steam download stall is detected.
     static let steamDownloadStallDetected = Notification.Name(
-        "com.isaacmarovitz.Whisky.steamDownloadStallDetected"
+        "com.franke.Whisky.steamDownloadStallDetected"
     )
 }

--- a/Whisky/Views/Bottle/LauncherConfigSection.swift
+++ b/Whisky/Views/Bottle/LauncherConfigSection.swift
@@ -464,7 +464,7 @@ private struct ActiveEnvironmentOverrides: View {
 extension Notification.Name {
     /// Posted to navigate to the Diagnostics section in ConfigView.
     static let openDiagnosticsSection = Notification.Name(
-        "com.isaacmarovitz.Whisky.openDiagnosticsSection"
+        "com.franke.Whisky.openDiagnosticsSection"
     )
 }
 

--- a/Whisky/Views/Common/LaunchTimeBanner.swift
+++ b/Whisky/Views/Common/LaunchTimeBanner.swift
@@ -54,7 +54,7 @@ extension Notification.Name {
     /// Posted when the user taps "View Details" on the launch-time banner to
     /// navigate to the Launcher section in ConfigView.
     static let openLauncherConfig = Notification.Name(
-        "com.isaacmarovitz.Whisky.openLauncherConfig"
+        "com.franke.Whisky.openLauncherConfig"
     )
 }
 

--- a/Whisky/Views/Programs/ProgramOverrideSettingsView.swift
+++ b/Whisky/Views/Programs/ProgramOverrideSettingsView.swift
@@ -883,6 +883,6 @@ struct ProgramOverrideSettingsView: View {
 extension Notification.Name {
     /// Posted to navigate to the Dependencies section in ConfigView.
     static let openDependenciesSection = Notification.Name(
-        "com.isaacmarovitz.Whisky.openDependenciesSection"
+        "com.franke.Whisky.openDependenciesSection"
     )
 }

--- a/WhiskyKit/Sources/WhiskyKit/Audio/AudioDeviceMonitor.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Audio/AudioDeviceMonitor.swift
@@ -30,7 +30,7 @@ public final class AudioDeviceMonitor: @unchecked Sendable {
     public typealias DeviceChangeHandler = @Sendable (AudioDeviceChangeEvent) -> Void
 
     private let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "AudioDeviceMonitor"
     )
 

--- a/WhiskyKit/Sources/WhiskyKit/Audio/AudioTroubleshootingEngine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Audio/AudioTroubleshootingEngine.swift
@@ -86,7 +86,7 @@ public final class AudioTroubleshootingEngine: ObservableObject {
     private let maxFixAttempts = 3
 
     private let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "AudioTroubleshootingEngine"
     )
 

--- a/WhiskyKit/Sources/WhiskyKit/Audio/WineAudioTestProbe.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Audio/WineAudioTestProbe.swift
@@ -38,7 +38,7 @@ public final class WineAudioTestProbe: AudioProbe, @unchecked Sendable {
     private let bottle: Bottle
     private let testExeURL: URL?
     private let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "WineAudioTestProbe"
     )
 

--- a/WhiskyKit/Sources/WhiskyKit/Extensions/Program+Extensions.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Extensions/Program+Extensions.swift
@@ -29,7 +29,7 @@ public extension Notification.Name {
     /// - `"diagnosis"`: ``CrashDiagnosis``
     /// - `"programPath"`: `String` (program URL path)
     /// - `"logFileURL"`: `URL`
-    static let crashDiagnosisAvailable = Notification.Name("com.isaacmarovitz.Whisky.crashDiagnosisAvailable")
+    static let crashDiagnosisAvailable = Notification.Name("com.franke.Whisky.crashDiagnosisAvailable")
 }
 
 // MARK: - Crash Signature Detection

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/CheckRegistry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/CheckRegistry.swift
@@ -40,7 +40,7 @@ public final class CheckRegistry: @unchecked Sendable {
     private var checks: [String: any TroubleshootingCheck] = [:]
 
     private let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "CheckRegistry"
     )
 

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/FixApplicator.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/FixApplicator.swift
@@ -82,7 +82,7 @@ public struct FixPreview: Sendable {
 /// | `restart-wineserver` | Wineserver process restart | No |
 public enum FixApplicator { // swiftlint:disable:this type_body_length
     private static let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "FixApplicator"
     )
 

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/FlowLoader.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/FlowLoader.swift
@@ -29,7 +29,7 @@ import os.log
 /// early. In release builds, failures return nil or empty collections gracefully.
 public enum FlowLoader {
     private static let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "FlowLoader"
     )
 

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/FlowValidator.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/FlowValidator.swift
@@ -26,7 +26,7 @@ import os.log
 /// flow load time to catch authoring errors early.
 public enum FlowValidator {
     private static let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "FlowValidator"
     )
 

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/PreflightCollector.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/PreflightCollector.swift
@@ -29,7 +29,7 @@ import os.log
 /// Follows the caseless enum pattern used by ``PatternLoader`` and ``GameDBLoader``.
 public enum PreflightCollector {
     private static let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "PreflightCollector"
     )
 

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingFlowEngine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingFlowEngine.swift
@@ -88,7 +88,7 @@ public final class TroubleshootingFlowEngine: ObservableObject {
     private let sessionStore: any TroubleshootingSessionStoring
 
     private let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "TroubleshootingFlowEngine"
     )
 

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingHistory.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingHistory.swift
@@ -78,7 +78,7 @@ public struct TroubleshootingHistory: Codable, Sendable {
             let data = try Data(contentsOf: url)
             return try PropertyListDecoder().decode(TroubleshootingHistory.self, from: data)
         } catch {
-            Logger(subsystem: "com.isaacmarovitz.Whisky", category: "TroubleshootingHistory")
+            Logger(subsystem: "com.franke.Whisky", category: "TroubleshootingHistory")
                 .error("Failed to load troubleshooting history: \(error.localizedDescription)")
             return TroubleshootingHistory()
         }
@@ -95,7 +95,7 @@ public struct TroubleshootingHistory: Codable, Sendable {
             let data = try encoder.encode(self)
             try data.write(to: url, options: .atomic)
         } catch {
-            Logger(subsystem: "com.isaacmarovitz.Whisky", category: "TroubleshootingHistory")
+            Logger(subsystem: "com.franke.Whisky", category: "TroubleshootingHistory")
                 .error("Failed to save troubleshooting history: \(error.localizedDescription)")
         }
     }

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingSessionStore.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingSessionStore.swift
@@ -62,7 +62,7 @@ public struct TroubleshootingSessionStore: TroubleshootingSessionStoring {
     public static let staleSessionDays = 14
 
     private let logger = Logger(
-        subsystem: "com.isaacmarovitz.Whisky",
+        subsystem: "com.franke.Whisky",
         category: "TroubleshootingSessionStore"
     )
 

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineSetupDiagnostics.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineSetupDiagnostics.swift
@@ -34,7 +34,7 @@ public struct WhiskyWineSetupDiagnostics: Codable, Sendable {
     private static let reportSectionOverhead = 20
 
     private static let eventTimestampFormatter = Date.ISO8601FormatStyle()
-    private static let issueURL = "https://github.com/Whisky-App/Whisky/issues/63"
+    private static let issueURL = "https://github.com/frankea/Whisky/issues"
 
     public struct InstallAttempt: Codable, Sendable {
         public let startedAt: Date

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WinePrefixDiagnostics.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WinePrefixDiagnostics.swift
@@ -53,7 +53,7 @@ public struct WinePrefixDiagnostics: Codable, Sendable {
     /// Maximum report size in UTF-8 bytes to keep sharing manageable.
     public static let maxReportBytes = 8_000
 
-    private static let issueURL = "https://github.com/Whisky-App/Whisky/issues/64"
+    private static let issueURL = "https://github.com/frankea/Whisky/issues"
     private static let eventTimestampFormatter = Date.ISO8601FormatStyle()
 
     // MARK: - Prefix State

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,45 @@
+# Runtime dependencies
+
+Whisky's app code is built from this repo, but the **Wine runtime** it downloads on first launch
+(`Libraries.tar.gz`) is assembled from third-party binaries. This file is the single source of truth
+for *what versions are bundled* and *where they come from*, so the runtime can't silently go stale and
+any future maintainer can reproduce a build. Update it whenever a runtime release is cut.
+
+See [`ReleaseWorkflow.md`](ReleaseWorkflow.md) for the assembly + publish procedure, and
+[`.github/workflows/RuntimeTrack.yml`](../.github/workflows/RuntimeTrack.yml) for the automation that
+flags when a bundled component falls behind upstream.
+
+## Bundled in runtime `v3.0.0`
+
+| Component | Bundled version | Upstream source | Notes |
+|-----------|-----------------|-----------------|-------|
+| **Wine** | 11.0 (Gcenx stable) | [Gcenx/macOS_Wine_builds](https://github.com/Gcenx/macOS_Wine_builds/releases) | Wine ships a new stable each January; 11.0 = Jan 2026. |
+| **DXVK (macOS)** | 1.10.3 | [Gcenx/DXVK-macOS](https://github.com/Gcenx/DXVK-macOS/releases) | Frozen at 1.10.x **by design** — the DXVK 2.x line needs Vulkan 1.3 features MoltenVK/macOS don't expose. Not stale; do not "upgrade" to upstream 2.x. |
+| **D3DMetal** | from Apple Game Porting Toolkit | [Apple GPTK](https://developer.apple.com/games/game-porting-toolkit/) | **Apple-proprietary. Extracted, never built.** Redistribution is governed by Apple's GPTK license — review terms before bumping. The default backend for most titles. |
+| **MoltenVK** | (confirm against published archive) | [KhronosGroup/MoltenVK](https://github.com/KhronosGroup/MoltenVK/releases) | Vulkan→Metal; underpins the DXVK path. |
+| **msync** | (confirm against published archive) | [marzent/wine-msync](https://github.com/marzent/wine-msync) | Mach-based synchronization patch in the Gcenx build. |
+
+> The exact MoltenVK/msync versions live inside the published `Libraries.tar.gz`, not this repo. When
+> you cut a runtime release, read them off the build and fill them in here so this table is authoritative.
+
+## Planned additions
+
+| Component | Target version | Upstream source | Notes |
+|-----------|----------------|-----------------|-------|
+| **DXMT** | 0.80 | [3Shain/dxmt](https://github.com/3Shain/dxmt/releases) | Direct3D→Metal, production-stable as of Apr 2026 and shipping in CrossOver 26. Bundle the project's **prebuilt release** (no from-source build) and expose as a per-game graphics backend. Benchmark vs. DXVK 1.10.3 on lower-spec Macs before defaulting. |
+
+## Tracking cadence
+
+- **Wine:** check each January for the new stable (next: **Wine 12, ~Jan 2027**). Test before bundling.
+- **DXVK-macOS / DXMT / D3DMetal (GPTK):** `RuntimeTrack.yml` polls upstream releases weekly and opens
+  an issue when a bundled version is behind. Triage; bumping is a deliberate, tested decision, not automatic.
+- **Security:** a critical Wine/DXVK CVE should trigger an out-of-band runtime rebuild + app release.
+  See `SECURITY.md`.
+
+## Why we consume rather than build
+
+Building and maintaining the macOS Wine runtime is the single most specialized, fragile job in this
+ecosystem — it is effectively Gcenx's entire role and CodeWeavers' paid team's. On a deliberately
+solo-maintained project (see [`GOVERNANCE.md`](GOVERNANCE.md)), taking that on would
+*deepen* the bus-factor risk it was meant to reduce. So we consume upstream binaries and invest instead
+in **discipline**: pinned versions, automated staleness detection, and a documented, reproducible assembly.

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -31,8 +31,10 @@ flags when a bundled component falls behind upstream.
 ## Tracking cadence
 
 - **Wine:** check each January for the new stable (next: **Wine 12, ~Jan 2027**). Test before bundling.
-- **DXVK-macOS / DXMT / D3DMetal (GPTK):** `RuntimeTrack.yml` polls upstream releases weekly and opens
-  an issue when a bundled version is behind. Triage; bumping is a deliberate, tested decision, not automatic.
+- **Wine / DXVK-macOS / DXMT:** `RuntimeTrack.yml` polls these GitHub release feeds weekly and opens an
+  issue when a bundled version is behind. Triage; bumping is a deliberate, tested decision, not automatic.
+- **D3DMetal (GPTK):** Apple ships it as a Game Porting Toolkit download with no GitHub release feed, so
+  it is **tracked manually** — check Apple's GPTK page when a new GPTK lands.
 - **Security:** a critical Wine/DXVK CVE should trigger an out-of-band runtime rebuild + app release.
   See `SECURITY.md`.
 

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,44 @@
+# Governance & continuity
+
+This fork exists because the original [whisky-app/whisky](https://github.com/whisky-app/whisky) was
+archived in April 2025 when its maintainer stepped away. It's worth being honest about the fact that
+this project carries the same structural risk.
+
+## Who maintains this
+
+Whisky (this fork) is maintained by **one person**, [@frankea](https://github.com/frankea). There is no
+team, no company, and no co-maintainer. "Active community fork" describes the development pace and the
+openness to contributions — it does not imply a staffed organization.
+
+This is a deliberate choice, not an oversight. Maintaining a Wine wrapper well is mostly steady,
+low-drama work, and a small project moves faster without coordination overhead. But it means the
+**bus factor is one**, and you should weigh that before depending on this fork for anything critical.
+
+## What that means for you
+
+- **Releases depend on one person's availability.** If @frankea is unavailable for a stretch, expect
+  no new releases until they're back. Existing installs keep working.
+- **Bug triage is best-effort.** See [`SUPPORT.md`](SUPPORT.md) for what to realistically expect.
+- **The runtime is consumed, not owned.** Whisky bundles Wine/DXVK/D3DMetal/DXMT binaries from upstream
+  projects (see [`DEPENDENCIES.md`](DEPENDENCIES.md)). If those upstreams stall,
+  Whisky's runtime currency is affected — this fork does not build Wine itself.
+
+## If you want to reduce that risk
+
+The most useful thing a contributor could do is **become a second maintainer**. If you have macOS +
+Swift + Wine-packaging experience and want to share the load (or be a backstop), open an issue or reach
+out — this section will be updated if and when that happens.
+
+## Maintainer continuity (operational)
+
+So that a lapse doesn't silently break things, the maintainer keeps these minimums:
+
+- **Off-machine backup** of the signing material — the Apple Developer ID Application certificate and
+  the Sparkle EdDSA private key — so a lost or dead machine doesn't mean a lost release identity.
+- A **certificate-expiry reminder**: the Developer ID cert and Apple account must not be allowed to
+  lapse, or notarized releases stop building with no obvious cause.
+- The full release procedure is documented in [`ReleaseWorkflow.md`](ReleaseWorkflow.md) so it is
+  reproducible rather than living only in one person's head.
+
+There is intentionally **no shared key escrow** today, because there is no second maintainer to escrow
+to. That is the honest state of things; it will change if the project gains a co-maintainer.

--- a/docs/ReleaseWorkflow.md
+++ b/docs/ReleaseWorkflow.md
@@ -125,9 +125,21 @@ The push to `main` triggers `.github/workflows/Documentation.yml`, which redeplo
 
 ## Wine Libraries release
 
-When the Wine/DXVK runtime needs to change:
+The runtime (`Libraries.tar.gz`) is **assembled from upstream binaries, not built from source** — see
+[`DEPENDENCIES.md`](DEPENDENCIES.md) for the authoritative list of components,
+their pinned versions, and where each comes from. When the runtime needs to change:
 
-1. Build/package the new runtime as `Libraries.tar.gz` (procedure for the Wine build itself is out of scope here).
+1. **Assemble `Libraries.tar.gz`** from the pinned upstream binaries. The archive unpacks to a
+   `Libraries/` tree the app expects (`Libraries/Wine/bin/…` is the Wine binary dir per
+   `WhiskyWineInstaller.binFolder`). To reproduce a build:
+   - Download the pinned **Wine** build (Gcenx `macOS_Wine_builds`) and unpack it as `Libraries/Wine/`.
+   - Add the pinned **DXVK-macOS** DLLs and **DXMT** prebuilt release into the runtime per the Gcenx
+     layout.
+   - Place **D3DMetal** as extracted from Apple's Game Porting Toolkit. ⚠️ Redistribution is governed by
+     Apple's GPTK license — confirm terms before publishing.
+   - Record the exact versions you used back into `docs/DEPENDENCIES.md`, and bump the matching
+     `*_PINNED` tags in `.github/workflows/RuntimeTrack.yml` so drift detection stays accurate.
+   - `tar -czf Libraries.tar.gz Libraries/` (mind the `Tar` pipe-drain pitfall noted below).
 2. Tag with the bare version `vX.Y.Z` (no `app-` prefix).
 3. `gh release create vX.Y.Z --title "Wine Libraries vX.Y.Z" Libraries.tar.gz`.
 4. Update `dist/pages/WhiskyWineVersion.plist`:

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,45 @@
+# Support
+
+Whisky is a community fork maintained by one person (see [`GOVERNANCE.md`](GOVERNANCE.md)). Support is
+best-effort and free. This page sets honest expectations and points you at the fastest path to a fix.
+
+## Before opening an issue
+
+Most problems already have an answer:
+
+1. **Make sure you're running this fork.** The default `brew install --cask whisky` installs the
+   **archived original** (last updated April 2025), *not* this fork. This fork is
+   `brew install --cask frankea/whisky/whisky`, or the DMG from
+   [Releases](https://github.com/frankea/Whisky/releases/latest). Check **Whisky → About** — bugs in
+   the archived original can't be fixed here.
+2. **Search [existing issues](https://github.com/frankea/Whisky/issues?q=is%3Aissue).**
+3. **Check the troubleshooting docs:**
+   [Launcher](LauncherTroubleshooting.md) · [Steam](SteamCompatibility.md) · [Stability](StabilityTroubleshooting.md).
+4. **For a specific game**, check the [Game Support wiki](https://github.com/frankea/Whisky/wiki/Game-Support)
+   and use the **Game Compatibility Report** template.
+
+## Where to go
+
+| You have… | Go to |
+|-----------|-------|
+| A reproducible app bug | [New issue → Bug Report](https://github.com/frankea/Whisky/issues/new/choose) |
+| A game that won't run right | [New issue → Game Compatibility Report](https://github.com/frankea/Whisky/issues/new/choose) |
+| An idea | [New issue → Feature Request](https://github.com/frankea/Whisky/issues/new/choose) |
+| A security report | See [`SECURITY.md`](../SECURITY.md) — **do not** open a public issue |
+| A "how do I…" question | The troubleshooting docs and the Game Support wiki first |
+
+**Do not open issues on the archived [whisky-app/whisky](https://github.com/whisky-app/whisky) repo** —
+it is read-only and no one will see them.
+
+## What to expect
+
+This is a volunteer, single-maintainer project, so please calibrate accordingly:
+
+- **Triage:** new issues are looked at as time allows — think days-to-weeks, not hours. There is no SLA.
+- **A good report gets a faster fix.** Always include: Whisky version (**Whisky → About**), macOS
+  version, the graphics backend, and — for crashes/freezes — the diagnostic export from
+  **Bottle Configuration → View Diagnostics**. Reports missing these usually stall waiting on info.
+- **Wine-layer limits:** Whisky configures and wraps Wine; it can't patch Wine itself. Some
+  incompatibilities (anti-cheat, kernel drivers, and certain OS-version regressions) are genuinely
+  outside what this app can fix — those get documented rather than "fixed."
+- **English, please:** so any maintainer or contributor can read and act on the report.


### PR DESCRIPTION
## Why

Now that the v1.0 milestone closed the upstream issue backlog, the next goal is making this fork the project people trust as the *ongoing* Whisky. A review flagged the two structural risks that actually archived the original — letting the bundled Wine runtime silently go stale, and a single-maintainer bus factor — as the things still unaddressed. This is the low-risk first pass at both, plus identity cleanup.

## What's in here

**Identity hygiene**
- Migrate 19 internal `Logger` subsystems and `NotificationCenter` names off the archived `com.isaacmarovitz.Whisky` namespace onto `com.franke.Whisky`. Each notification name is a single-source `Notification.Name` constant referenced symbolically, so posters and observers stay matched.
- Repoint two in-app diagnostic "report here" URLs (`WhiskyWineSetupDiagnostics`, `WinePrefixDiagnostics`) from the read-only upstream to the fork's issue tracker.
- Left the `whisky-app/whisky#NNN` code comments untouched — correct historical provenance.

**Sustainability & intake docs**
- `docs/GOVERNANCE.md` — honest single-maintainer continuity stance.
- `docs/SUPPORT.md` — where to file, what to expect, fork-vs-archived disambiguation.
- `docs/DEPENDENCIES.md` — pinned Wine / DXVK / D3DMetal / DXMT runtime components, sources, and tracking cadence (incl. why DXVK 1.10.3 is correct rather than stale).

**Runtime currency**
- `.github/workflows/RuntimeTrack.yml` — weekly poll that opens/updates a tracking issue when a bundled runtime component falls behind upstream. Triggered only by `schedule`/`workflow_dispatch`; the one external value (upstream release tag) flows through shell variables, never `${{ }}` interpolation.
- `docs/ReleaseWorkflow.md` — replaced the "Wine build is out of scope" line with a reproducible runtime-assembly procedure.
- Bug-report template now confirms the reporter is on this fork, not the archived original.

## Verification

- `xcodebuild -scheme Whisky -configuration Debug build` → BUILD SUCCEEDED
- `swift test --package-path WhiskyKit` → passing
- `swiftformat --lint` → clean (pre-commit hook also passed)
- `grep -rn com.isaacmarovitz.Whisky` / `Whisky-App/Whisky/issues` in `Whisky/` + `WhiskyKit/` → 0
- Workflow + issue-template YAML validated

## Not in this PR (follow-up passes)

High-CPU pipe-spin fix (upstream PR #1374 + #1305), DXMT graphics backend, in-app bottle migration wizard, app-target coverage CI job, localization dot-key cleanup.