### PR TITLE
Fix high CPU when a Wine process goes quiet (EOF readability-handler spin, #917)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (Closes whisky-app/whisky#293, whisky-app/whisky#995, whisky-app/whisky#1020, whisky-app/whisky#1070).
 
 ### Fixed
+- Wine no longer pegs a CPU core when a running process goes quiet. After a
+  process closed its stdout/stderr but kept running, the pipe's readability
+  handler fired continuously on the permanently-readable EOF condition. The
+  handler now removes itself on EOF (the final bytes are still drained when the
+  process exits), so an idle Wine process no longer spins
+  (Closes whisky-app/whisky#917).
 - Moving a bottle no longer wipes its pinned-program list. The `move()` loop
   was shadowing the bottle's `url` with `pin.url`, causing
   `updateParentBottle` to compare a pin path against itself instead of the

--- a/WhiskyKit/Sources/WhiskyKit/Extensions/Process+Extensions.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Extensions/Process+Extensions.swift
@@ -120,8 +120,10 @@ public extension Process {
                 // handler's `readToEnd` (whisky-app/whisky#917).
                 pipeHandle.readabilityHandler = nil
             case .pending:
-                // Non-empty but not yet decodable (e.g. a split multi-byte sequence) —
-                // keep the handler installed and wait for the next read.
+                // A non-empty chunk that isn't valid UTF-8 on its own (e.g. a multi-byte
+                // sequence split across reads). Its bytes are already consumed, so this is not
+                // a recovery — we just don't treat the stream as EOF, and leave the handler
+                // installed for the remaining output.
                 return
             case let .text(line):
                 outputLock.lock()
@@ -234,8 +236,10 @@ extension FileHandle {
     enum OutputRead: Equatable {
         /// Decodable, non-empty output ready to emit.
         case text(String)
-        /// A non-empty but not-yet-decodable chunk (e.g. a split multi-byte
-        /// sequence); the caller should keep reading.
+        /// A non-empty read that isn't valid UTF-8 on its own (e.g. a multi-byte sequence
+        /// split across reads). The bytes are already consumed, so this is not EOF — the
+        /// caller should keep its handler installed for the rest of the output. The split
+        /// character itself is not reassembled.
         case pending
         /// An empty read: the pipe's write end has closed. The caller should
         /// remove its `readabilityHandler`, which otherwise fires continuously

--- a/WhiskyKit/Sources/WhiskyKit/Extensions/Process+Extensions.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Extensions/Process+Extensions.swift
@@ -111,10 +111,23 @@ public extension Process {
         fileHandle: FileHandle?
     ) -> @Sendable (FileHandle) -> Void {
         { pipeHandle in
-            guard let line = pipeHandle.nextLine() else { return }
-            outputLock.lock()
-            defer { outputLock.unlock() }
-            self.emit(line: line, kind: kind, continuation: continuation, fileHandle: fileHandle)
+            switch pipeHandle.nextOutput() {
+            case .endOfFile:
+                // The pipe's write end closed while this handler is still installed
+                // (the process can stop writing well before it exits). `readabilityHandler`
+                // keeps firing on the permanently-readable EOF condition, pegging a CPU
+                // core, so remove it here. Any final bytes are drained by the termination
+                // handler's `readToEnd` (whisky-app/whisky#917).
+                pipeHandle.readabilityHandler = nil
+            case .pending:
+                // Non-empty but not yet decodable (e.g. a split multi-byte sequence) —
+                // keep the handler installed and wait for the next read.
+                return
+            case let .text(line):
+                outputLock.lock()
+                defer { outputLock.unlock() }
+                self.emit(line: line, kind: kind, continuation: continuation, fileHandle: fileHandle)
+            }
         }
     }
 
@@ -217,12 +230,26 @@ public extension Process {
 }
 
 extension FileHandle {
-    func nextLine() -> String? {
-        guard let line = String(data: availableData, encoding: .utf8) else { return nil }
-        if !line.isEmpty {
-            return line
-        } else {
-            return nil
-        }
+    /// The classification of a single read from a pipe's readable end.
+    enum OutputRead: Equatable {
+        /// Decodable, non-empty output ready to emit.
+        case text(String)
+        /// A non-empty but not-yet-decodable chunk (e.g. a split multi-byte
+        /// sequence); the caller should keep reading.
+        case pending
+        /// An empty read: the pipe's write end has closed. The caller should
+        /// remove its `readabilityHandler`, which otherwise fires continuously
+        /// on the permanently-readable EOF condition.
+        case endOfFile
+    }
+
+    /// Reads the next available chunk, distinguishing EOF (an empty read) from a
+    /// merely not-yet-decodable chunk. The distinction lets a `readabilityHandler`
+    /// stop itself on EOF instead of spinning on it (whisky-app/whisky#917).
+    func nextOutput() -> OutputRead {
+        let data = availableData
+        guard !data.isEmpty else { return .endOfFile }
+        guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return .pending }
+        return .text(text)
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/ProcessExtensionTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ProcessExtensionTests.swift
@@ -152,14 +152,14 @@ final class ProcessOutputExtendedTests: XCTestCase {
     }
 }
 
-// MARK: - FileHandle.nextLine Tests
+// MARK: - FileHandle.nextOutput Tests
 
-final class FileHandleNextLineTests: XCTestCase {
+final class FileHandleNextOutputTests: XCTestCase {
     var tempURL: URL!
 
     override func setUp() {
         super.setUp()
-        tempURL = FileManager.default.temporaryDirectory.appending(path: "nextline_\(UUID().uuidString).txt")
+        tempURL = FileManager.default.temporaryDirectory.appending(path: "nextoutput_\(UUID().uuidString).txt")
     }
 
     override func tearDown() {
@@ -167,45 +167,108 @@ final class FileHandleNextLineTests: XCTestCase {
         super.tearDown()
     }
 
-    func testNextLineWithContent() throws {
+    func testReturnsTextForContent() throws {
         try Data("Hello, World!".utf8).write(to: tempURL)
 
         let handle = try FileHandle(forReadingFrom: tempURL)
         defer { try? handle.close() }
 
-        let line = handle.nextLine()
-        XCTAssertEqual(line, "Hello, World!")
+        XCTAssertEqual(handle.nextOutput(), .text("Hello, World!"))
     }
 
-    func testNextLineWithEmptyFile() throws {
+    /// The crux of the fix: an empty read is EOF, reported distinctly so the
+    /// readability handler can remove itself instead of spinning on it.
+    func testReturnsEndOfFileForEmptyRead() throws {
         try Data().write(to: tempURL)
 
         let handle = try FileHandle(forReadingFrom: tempURL)
         defer { try? handle.close() }
 
-        let line = handle.nextLine()
-        XCTAssertNil(line)
+        XCTAssertEqual(handle.nextOutput(), .endOfFile)
     }
 
-    func testNextLineWithMultipleLines() throws {
+    func testReturnsTextForMultipleLines() throws {
         try Data("Line 1\nLine 2\nLine 3".utf8).write(to: tempURL)
 
         let handle = try FileHandle(forReadingFrom: tempURL)
         defer { try? handle.close() }
 
-        // First call gets all available data
-        let line = handle.nextLine()
-        XCTAssertNotNil(line)
-        XCTAssertTrue(line?.contains("Line 1") ?? false)
+        // A single read returns all currently-available data as one chunk.
+        XCTAssertEqual(handle.nextOutput(), .text("Line 1\nLine 2\nLine 3"))
     }
 
-    func testNextLineWithUnicodeContent() throws {
+    func testReturnsTextForUnicodeContent() throws {
         try Data("日本語テスト 🍷".utf8).write(to: tempURL)
 
         let handle = try FileHandle(forReadingFrom: tempURL)
         defer { try? handle.close() }
 
-        let line = handle.nextLine()
-        XCTAssertEqual(line, "日本語テスト 🍷")
+        XCTAssertEqual(handle.nextOutput(), .text("日本語テスト 🍷"))
+    }
+
+    /// A non-empty but not-yet-decodable chunk (e.g. a split multi-byte sequence)
+    /// is `.pending`, NOT `.endOfFile` — the handler must keep reading, not stop.
+    func testReturnsPendingForUndecodableData() throws {
+        try Data([0xFF, 0xFE]).write(to: tempURL)
+
+        let handle = try FileHandle(forReadingFrom: tempURL)
+        defer { try? handle.close() }
+
+        XCTAssertEqual(handle.nextOutput(), .pending)
+    }
+}
+
+// MARK: - Process.runStream Integration Tests
+
+final class ProcessRunStreamTests: XCTestCase {
+    /// Collects every `ProcessOutput` a short-lived `/bin/sh -c <script>` emits.
+    private func collectOutput(script: String) async throws -> [ProcessOutput] {
+        let process = Process()
+        process.executableURL = URL(filePath: "/bin/sh")
+        process.arguments = ["-c", script]
+
+        var outputs: [ProcessOutput] = []
+        let stream = try process.runStream(name: "runStreamTest", fileHandle: nil)
+        for await output in stream {
+            outputs.append(output)
+        }
+        return outputs
+    }
+
+    func testHappyPathYieldsOutputAndTermination() async throws {
+        let outputs = try await collectOutput(script: "printf 'hello\\n'")
+
+        XCTAssertEqual(outputs.first, .started)
+        XCTAssertEqual(outputs.last, .terminated(0))
+        XCTAssertTrue(
+            outputs.contains { if case let .message(line) = $0 { line.contains("hello") } else { false } },
+            "expected a stdout message containing 'hello', got \(outputs)"
+        )
+    }
+
+    /// The regression case: the child closes stdout/stderr while still running,
+    /// so the pipe reaches EOF before termination. Output must still arrive and
+    /// the stream must finish cleanly (and promptly — no hang from the spin path).
+    func testEOFBeforeExitStillDeliversOutputAndTerminates() async throws {
+        let outputs = try await collectOutput(
+            script: "printf 'early\\n'; exec 1>&-; exec 2>&-; sleep 0.3"
+        )
+
+        XCTAssertEqual(outputs.last, .terminated(0))
+        XCTAssertTrue(
+            outputs.contains { if case let .message(line) = $0 { line.contains("early") } else { false } },
+            "output written before the pipe closed must not be lost, got \(outputs)"
+        )
+    }
+
+    func testSilentProcessTerminatesWithoutSpuriousOutput() async throws {
+        let outputs = try await collectOutput(script: "sleep 0.2")
+
+        XCTAssertEqual(outputs.first, .started)
+        XCTAssertEqual(outputs.last, .terminated(0))
+        XCTAssertFalse(
+            outputs.contains { if case .message = $0 { true } else if case .error = $0 { true } else { false } },
+            "a silent process should produce no message/error output, got \(outputs)"
+        )
     }
 }


### PR DESCRIPTION
## The bug

Reported upstream as whisky-app/whisky#917: Wine pegs a CPU core when a process is running but producing no output.

Root cause: a process can close its stdout/stderr **while still running**. That puts the read end of our pipe at EOF, which is a *permanently readable* condition — so `FileHandle.readabilityHandler` fires in a tight loop, each call reading empty data, until the process finally exits.

## Why the existing mitigation isn't enough

The fork already sets both readability handlers to `nil` in the **termination handler** (the equivalent of upstream PR #1374). But that only covers EOF *at* process termination. The spin happens in the window between "process closed its pipes" and "process exited," which the termination handler hasn't reached yet. (Upstream PR #1305 tried to fix this by making the read busy-wait with `Thread.sleep` — that blocks the handler thread forever at EOF, so it's not viable.)

## The fix

Per [Apple's `readabilityHandler` docs](https://developer.apple.com/documentation/foundation/pipe/1408980-readabilityhandler), the handler removes itself the moment it sees EOF:

- New `FileHandle.nextOutput()` returns `.text` / `.pending` / `.endOfFile`, replacing `nextLine()` which conflated EOF (empty read) with a decode failure. The distinction matters now: on `.endOfFile` the handler nils itself; on `.pending` (a non-empty but not-yet-decodable chunk) it keeps reading.
- Any bytes buffered before EOF are still drained by the termination handler's `readToEnd`, so no output is lost.

## Tests

- **Unit** (`FileHandleNextOutputTests`): `nextOutput()` classifies content, multi-line, unicode, an empty read (`.endOfFile`), and undecodable bytes (`.pending`).
- **Integration** (`ProcessRunStreamTests`): `runStream` over real short-lived processes — happy path, **EOF-before-exit** (output preserved + clean, prompt termination), and a silent process.

Honest scope note: the unit tests verify the EOF *classification* that drives the fix; the spin itself is a CPU-profile symptom (confirmed by the upstream Instruments capture in #917), and the integration test passes on the old spinning code too — so it's a regression guard for output integrity, not a red-on-old proof. The `.pending` path discards the partial bytes it read, so a UTF-8 sequence split across two reads is still dropped — that's **pre-existing** behavior (identical to the old `nextLine()`), left as-is here.

## Verification

- `swift test --package-path WhiskyKit` → 944 tests, 0 failures (incl. 8 new); EOF-before-exit test completes in ~0.3s (no hang)
- `xcodebuild -scheme Whisky -configuration Debug build` → BUILD SUCCEEDED
- `swiftformat --lint` → clean