### PR TITLE
Remove dead macOS 14 warning code; add funding + Wine-CVE policy docs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,9 +1,8 @@
-# Funding for Whisky Fork
+# Funding for Whisky (this fork)
 #
-# This fork is maintained by @frankea
-# The custom links below support key community contributors whose work makes Whisky possible:
-# - Gcenx: Maintains Wine macOS builds and DXVK-macOS
-# - CodeWeavers: Develops CrossOver/Wine (affiliate link)
+# Maintained by @frankea. This project has NO affiliate or revenue-sharing arrangement with anyone.
+# The custom link points to Gcenx, who maintains the macOS Wine and DXVK-macOS builds Whisky bundles —
+# it's a direct donation to that upstream contributor, not income for this fork.
 
 github: frankea
-custom: ["https://ko-fi.com/gcenx", "https://www.codeweavers.com/store?ad=1010"]
+custom: ["https://ko-fi.com/gcenx"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SECURITY.md` now documents how Wine/DXVK runtime vulnerabilities are handled — pinned versions are
   tracked against upstream, and a critical bundled-component CVE triggers an out-of-band runtime rebuild
   and release. Added `FUNDING.md` describing the volunteer, single-maintainer sustainability model.
+- Removed the inherited CrossOver affiliate links (`ad=1010`) from the README and funding config; this
+  fork has no affiliate or revenue-sharing arrangement, and those links credited the original project.
 
 ## [3.0.1] - 2026-05-01 (App)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   appending, both for single-row and multi-selection cases
   (Closes whisky-app/whisky#431).
 
+### Documentation
+- `SECURITY.md` now documents how Wine/DXVK runtime vulnerabilities are handled — pinned versions are
+  tracked against upstream, and a critical bundled-component CVE triggers an out-of-band runtime rebuild
+  and release. Added `FUNDING.md` describing the volunteer, single-maintainer sustainability model.
+
 ## [3.0.1] - 2026-05-01 (App)
 
 ### Fixed

--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,0 +1,29 @@
+# Funding
+
+Whisky (this fork) is free, GPL-v3 software maintained by one person in their spare time. There is no
+company behind it and no paid team. Funding is **not required** to use Whisky and never will be — this
+page just explains where money goes if you choose to give some.
+
+## How to support the work
+
+- **GitHub Sponsors** — sponsor [@frankea](https://github.com/sponsors/frankea). This goes toward the
+  maintainer's time: triaging issues, cutting signed/notarized releases, and keeping the bundled Wine
+  runtime current. It also covers the recurring costs of shipping a notarized macOS app (an Apple
+  Developer Program membership is required to sign and notarize the DMG).
+- **CrossOver** — Whisky stands on CrossOver/Wine. If you buy CrossOver through our
+  [affiliate link](https://www.codeweavers.com/store?ad=1010), CodeWeavers shares a portion with the
+  project, and you get a polished commercial Wine product. Supporting CodeWeavers directly funds the
+  upstream Wine work everything here depends on.
+- **Gcenx** — the macOS Wine and DXVK-macOS builds Whisky bundles come from Gcenx. Consider
+  [buying them a coffee](https://ko-fi.com/gcenx); without that work this fork could not ship a runtime.
+
+## What funding does *not* buy
+
+- **Priority support or an SLA.** Issues are triaged best-effort regardless of sponsorship.
+- **Influence over the roadmap.** Feature direction stays in the open on the issue tracker.
+
+## Sustainability
+
+Because this is a single-maintainer project, the most valuable contribution is not money but **help**:
+code, triage, testing, and documentation. If funding ever reached a level that could meaningfully buy
+down the maintainer's time or bring on a second maintainer, that intent would be documented here.

--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,21 +1,25 @@
 # Funding
 
 Whisky (this fork) is free, GPL-v3 software maintained by one person in their spare time. There is no
-company behind it and no paid team. Funding is **not required** to use Whisky and never will be — this
-page just explains where money goes if you choose to give some.
+company behind it and no paid team. Funding is **not required** to use Whisky and never will be.
+
+To be clear up front: **this project has no affiliate or revenue-sharing arrangement with anyone.**
+There are no referral links here that pay the project a cut.
 
 ## How to support the work
 
-- **GitHub Sponsors** — sponsor [@frankea](https://github.com/sponsors/frankea). This goes toward the
-  maintainer's time: triaging issues, cutting signed/notarized releases, and keeping the bundled Wine
-  runtime current. It also covers the recurring costs of shipping a notarized macOS app (an Apple
-  Developer Program membership is required to sign and notarize the DMG).
-- **CrossOver** — Whisky stands on CrossOver/Wine. If you buy CrossOver through our
-  [affiliate link](https://www.codeweavers.com/store?ad=1010), CodeWeavers shares a portion with the
-  project, and you get a polished commercial Wine product. Supporting CodeWeavers directly funds the
-  upstream Wine work everything here depends on.
-- **Gcenx** — the macOS Wine and DXVK-macOS builds Whisky bundles come from Gcenx. Consider
-  [buying them a coffee](https://ko-fi.com/gcenx); without that work this fork could not ship a runtime.
+- **GitHub Sponsors** — if you'd like to support the maintainer's time (triaging issues, cutting
+  signed/notarized releases, keeping the bundled Wine runtime current), you can sponsor
+  [@frankea](https://github.com/frankea). Shipping a notarized macOS app also carries a recurring cost
+  (an Apple Developer Program membership is required to sign and notarize the DMG).
+
+Whisky also stands on the shoulders of upstream projects. Whisky receives nothing from supporting them —
+but if you value the work, supporting them directly is worthwhile:
+
+- **CrossOver / CodeWeavers** — the commercial Wine product Whisky's stack ultimately derives from.
+  [codeweavers.com/crossover](https://www.codeweavers.com/crossover).
+- **Gcenx** — maintains the macOS Wine and DXVK-macOS builds Whisky bundles.
+  [ko-fi.com/gcenx](https://ko-fi.com/gcenx).
 
 ## What funding does *not* buy
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Special thanks to Gcenx, ohaiibuzzle, Nat Brown, and [Isaac Marovitz](https://gi
         </picture>
     </td>
     <td>
-        Whisky doesn't exist without CrossOver. Support the work of CodeWeavers using our <a href="https://www.codeweavers.com/store?ad=1010">affiliate link</a>.
+        Whisky doesn't exist without CrossOver. If you want a fully-supported commercial Wine experience on macOS, check out <a href="https://www.codeweavers.com/crossover">CrossOver</a> from CodeWeavers. (This fork has no affiliate arrangement and receives nothing from CrossOver sales.)
     </td>
   </tr>
 </table>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,22 @@ The following are generally out of scope:
 - Vulnerabilities in DXVK (report to the respective project)
 - Issues in third-party dependencies (report upstream, then notify us)
 
+### Wine / DXVK Vulnerability Response
+
+Whisky bundles a Wine runtime (Wine, DXVK, D3DMetal, and related components) that it does not develop.
+A vulnerability in those components is fixed upstream, not here — but it still reaches Whisky users, so
+we track it as a runtime-currency concern rather than a closed door:
+
+- Bundled component versions are pinned and checked against their upstream sources, so a new upstream
+  build carrying a security fix is surfaced rather than missed.
+- A **critical** vulnerability in a bundled component (one exploitable through normal Whisky use) is a
+  trigger to rebuild the runtime archive on the patched upstream version and cut a new app release out
+  of band, rather than waiting for the next scheduled runtime update.
+- Non-critical upstream fixes are picked up as part of the normal runtime-update cadence.
+
+If you believe a bundled-runtime vulnerability is being mishandled or under-prioritized in Whisky's
+packaging, report it through the private channel above and say so explicitly.
+
 ## Security Best Practices for Users
 
 - Only run trusted Windows applications within Whisky

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -24659,28 +24659,6 @@
         }
       }
     },
-    "config.graphics.warning.d3dmetalMacOS": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "D3DMetal requires macOS 14 (Sonoma) or later"
-          }
-        }
-      }
-    },
-    "config.graphics.warning.dxvkMacOS": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "DXVK works best on macOS 15 (Sequoia) or later"
-          }
-        }
-      }
-    },
     "config.virtualDesktop.custom": {
       "extractionState": "manual",
       "localizations": {

--- a/Whisky/Views/Bottle/BackendPickerView.swift
+++ b/Whisky/Views/Bottle/BackendPickerView.swift
@@ -41,19 +41,6 @@ struct BackendPickerView: View {
 
             // Helper text below grid
             helperText
-
-            // Inline compatibility warning
-            if let warning = compatibilityWarning {
-                HStack(alignment: .top, spacing: 6) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.yellow)
-                    Text(warning)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(8)
-                .background(.yellow.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
-            }
         }
     }
 
@@ -69,25 +56,6 @@ struct BackendPickerView: View {
             Text("config.graphics.helperNextLaunch")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-        }
-    }
-
-    // MARK: - Compatibility Warning
-
-    private var compatibilityWarning: String? {
-        switch selection {
-        case .dxvk:
-            if #unavailable(macOS 14.0) {
-                return String(localized: "config.graphics.warning.dxvkMacOS")
-            }
-            return nil
-        case .d3dMetal:
-            if #unavailable(macOS 14.0) {
-                return String(localized: "config.graphics.warning.d3dmetalMacOS")
-            }
-            return nil
-        case .wined3d, .recommended:
-            return nil
         }
     }
 }


### PR DESCRIPTION
Project-hygiene changes.

### Dead code removal
`BackendPickerView.compatibilityWarning` returned a warning string only inside `if #unavailable(macOS 14.0)` blocks. With the deployment target at macOS 15, those conditions are never true, so the property always returned `nil` and the warning banner was unreachable. Removed the property and its consumer. (The two `config.graphics.warning.*MacOS` strings are now unused in code; left in the catalog to avoid hand-editing `Localizable.xcstrings`.)

### Honest funding docs (no affiliate)
This fork has **no affiliate or revenue-sharing arrangement with anyone**. The `?ad=1010` CrossOver links throughout the repo were inherited from the original project and credit *its* affiliate account, not this fork. This PR:
- Adds `FUNDING.md` documenting the volunteer single-maintainer model — GitHub Sponsors as the only direct support channel, plain (non-affiliate) attribution links for CrossOver/CodeWeavers and Gcenx, and an explicit "we receive nothing from these" note.
- Removes the `ad=1010` affiliate code and the false "CodeWeavers shares a portion with the project" wording from the README CrossOver panel and `.github/FUNDING.yml`; keeps plain attribution + the Gcenx donation link.

### `SECURITY.md` — Wine/DXVK vulnerability response
Adds a section: bundled-runtime CVEs are fixed upstream, but Whisky tracks pinned versions against upstream and treats a critical bundled-component CVE as a trigger for an out-of-band runtime rebuild + release.

### Verification
- `xcodebuild -scheme Whisky -configuration Debug build` → BUILD SUCCEEDED
- `swiftformat --lint` clean; `.github/FUNDING.yml` valid YAML; no `ad=1010` / affiliate-revenue claims remain
