### PR TITLE
One-click migration of bottles from the original Whisky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **File → Migrate from the Original Whisky** discovers bottles created by the
+  archived original app (`com.isaacmarovitz.Whisky`) and imports them in one
+  step, with checkboxes to choose which. Bottles are referenced in place —
+  nothing is moved or copied — so the import is non-destructive and the original
+  app keeps working, replacing the previous manual export/import dance.
 - Bottle creation now copies host fonts (Arial Unicode, Arial, Tahoma) into
   `drive_c/windows/Fonts` so Unity titles render fallback glyphs instead of
   empty boxes (Closes whisky-app/whisky#1050).

--- a/README.md
+++ b/README.md
@@ -78,13 +78,11 @@ The original [whisky-app/whisky](https://github.com/whisky-app/whisky) was archi
 
 To switch:
 
-1. Quit the original Whisky app.
-2. Export bottles you want to keep first via the original app's **Bottle → Export** menu — this fork uses a different bundle identifier (`com.franke.Whisky`) so it won't see them automatically.
-3. Drag the existing **/Applications/Whisky.app** to the Trash, or `brew uninstall --cask whisky` if you installed it via Homebrew. Bottles in `~/Library/Containers/com.isaacmarovitz.Whisky/` stay put.
-4. Install this fork: `brew install --cask frankea/whisky/whisky` or follow the manual steps above.
-5. Re-import any exported bottles through **File → Import Bottle** in the new app.
+1. Install this fork: `brew install --cask frankea/whisky/whisky` or follow the manual steps above.
+2. Open it and choose **File → Migrate from the Original Whisky**. It finds the bottles the original app left in `~/Library/Containers/com.isaacmarovitz.Whisky/` and imports the ones you pick. Bottles are referenced **in place** — nothing is moved or copied — so the original app keeps working if you'd like to keep it around.
+3. *(Optional)* Once you're happy, remove the original app: drag **/Applications/Whisky.app** to the Trash, or `brew uninstall --cask whisky` if you installed it via Homebrew. Your bottles stay put.
 
-If you have no critical bottles, you can skip the export — the new app will create a fresh bottle on first launch.
+The original app uses a different bundle identifier (`com.franke.Whisky` here vs. `com.isaacmarovitz.Whisky`), which is why bottles aren't shared automatically. The old **Bottle → Export** / **File → Import Bottle** route still works if you'd rather move bottles by hand or onto another Mac. With no critical bottles, you can skip migration entirely — the new app creates a fresh bottle on first launch.
 
 ## Documentation
 

--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		2E9E4AD3124BDF8D5238BE32 /* DPIConfigSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3735C5328F7A6ABD2D1248 /* DPIConfigSheetView.swift */; };
 		396CD6101FAF0380C459ACEE /* DXVKConfigSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5770D2EE01AEF235634646 /* DXVKConfigSection.swift */; };
 		484A57DAD0A7634094236533 /* DiagnosticsPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8797408D60F55718DFC61664 /* DiagnosticsPickerSheet.swift */; };
+		C16DA5430762A5F33C8714AA /* MigrateBottlesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB85C8A3D3900AA9A7DDCE72 /* MigrateBottlesSheet.swift */; };
 		52513FA35312809A9760BCB2 /* MetalConfigSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2699006F97F862815633C9F /* MetalConfigSection.swift */; };
 		6330DD962B1B0EA4007A625A /* RenameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6330DD952B1B0EA4007A625A /* RenameView.swift */; };
 		6365C4C12B1AA69D00AAE1FD /* Animation+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6365C4C02B1AA69D00AAE1FD /* Animation+Extensions.swift */; };
@@ -239,6 +240,7 @@
 		6EFDF6652AAE303300EF622F /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Icons.xcassets; sourceTree = "<group>"; };
 		6F2BCF2BAEDF0AA7B418E096 /* Winetricks+InstalledVerbs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Winetricks+InstalledVerbs.swift"; sourceTree = "<group>"; };
 		8797408D60F55718DFC61664 /* DiagnosticsPickerSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiagnosticsPickerSheet.swift; sourceTree = "<group>"; };
+		DB85C8A3D3900AA9A7DDCE72 /* MigrateBottlesSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MigrateBottlesSheet.swift; sourceTree = "<group>"; };
 		8C73E1332AF472FC00B6FB45 /* ProgramMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramMenuView.swift; sourceTree = "<group>"; };
 		8CB681E42AED7C6F0018D319 /* WhiskyKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = WhiskyKit; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718A9B0C1D3 /* DLLOverrideEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DLLOverrideEditor.swift; sourceTree = "<group>"; };
@@ -507,6 +509,7 @@
 				6E7C07BF2AAF570100F6E66B /* FileOpenView.swift */,
 				FADF69F903E9EA676A27FC69 /* Common */,
 				8797408D60F55718DFC61664 /* DiagnosticsPickerSheet.swift */,
+				DB85C8A3D3900AA9A7DDCE72 /* MigrateBottlesSheet.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -970,6 +973,7 @@
 				C1A2B3C4E5F60601A9B0C2D4 /* AudioDeviceHistoryView.swift in Sources */,
 				D6EEECF2BAE764BAE529B9BA /* AudioAlertTracker.swift in Sources */,
 				484A57DAD0A7634094236533 /* DiagnosticsPickerSheet.swift in Sources */,
+				C16DA5430762A5F33C8714AA /* MigrateBottlesSheet.swift in Sources */,
 				E1A2B3C4E5F60701A9B0C1D0 /* GameEntryRowView.swift in Sources */,
 				E1A2B3C4E5F60701A9B0C1D2 /* GameConfigurationView.swift in Sources */,
 				E1A2B3C4E5F60701A9B0C2D0 /* GameEntryDetailView.swift in Sources */,

--- a/Whisky/Views/MigrateBottlesSheet.swift
+++ b/Whisky/Views/MigrateBottlesSheet.swift
@@ -134,9 +134,12 @@ struct MigrateBottlesSheet: View {
     }
 
     private func importSelected() {
-        for url in rows.filter(\.isSelected).map(\.bottle.url)
-            where !bottleVM.bottlesList.paths.contains(url) {
-            bottleVM.bottlesList.paths.append(url)
+        let existing = bottleVM.bottlesList.paths
+        let toAdd = rows.filter(\.isSelected).map(\.bottle.url).filter { !existing.contains($0) }
+        if !toAdd.isEmpty {
+            // Assign once: `BottleData.paths` re-encodes the registry plist in its didSet,
+            // so appending in a loop would rewrite it N times.
+            bottleVM.bottlesList.paths = existing + toAdd
         }
         bottleVM.loadBottles()
         dismiss()

--- a/Whisky/Views/MigrateBottlesSheet.swift
+++ b/Whisky/Views/MigrateBottlesSheet.swift
@@ -1,0 +1,144 @@
+//
+//  MigrateBottlesSheet.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import WhiskyKit
+
+/// Lets the user import bottles created by the archived original Whisky app, which this
+/// fork doesn't see automatically because it uses a different bundle identifier. Bottles
+/// are referenced in place (not copied), so the import is non-destructive.
+struct MigrateBottlesSheet: View {
+    @EnvironmentObject var bottleVM: BottleVM
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var rows: [Row] = []
+    @State private var didLoad = false
+
+    private struct Row: Identifiable {
+        let bottle: LegacyBottleImport.DiscoveredBottle
+        var isSelected: Bool
+        var id: URL {
+            bottle.url
+        }
+    }
+
+    private var selectedCount: Int {
+        rows.filter(\.isSelected).count
+    }
+
+    private var allSelected: Bool {
+        !rows.isEmpty && rows.allSatisfy(\.isSelected)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            content
+            Divider()
+            footer
+        }
+        .frame(width: 460, height: 420)
+        .onAppear(perform: loadIfNeeded)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Import Bottles from the Original Whisky")
+                .font(.headline)
+            Text(
+                """
+                These bottles were created by the archived original Whisky app. Importing references \
+                them in place — your files aren't moved or copied, and the original app keeps working.
+                """
+            )
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if rows.isEmpty {
+            VStack(spacing: 8) {
+                Image(systemName: "tray")
+                    .font(.largeTitle)
+                    .foregroundStyle(.secondary)
+                Text("No bottles from the original Whisky were found.")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List {
+                ForEach($rows) { $row in
+                    Toggle(isOn: $row.isSelected) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(row.bottle.name)
+                            Text(row.bottle.url.path(percentEncoded: false))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            if !rows.isEmpty {
+                Button(allSelected ? "Deselect All" : "Select All", action: toggleAll)
+            }
+            Spacer()
+            Button("Cancel", role: .cancel) { dismiss() }
+                .keyboardShortcut(.cancelAction)
+            Button("Import Selected", action: importSelected)
+                .keyboardShortcut(.defaultAction)
+                .disabled(selectedCount == 0)
+        }
+        .padding()
+    }
+
+    private func toggleAll() {
+        let target = !allSelected
+        for index in rows.indices {
+            rows[index].isSelected = target
+        }
+    }
+
+    private func loadIfNeeded() {
+        guard !didLoad else { return }
+        didLoad = true
+        rows = LegacyBottleImport
+            .importableBottles(existingPaths: bottleVM.bottlesList.paths)
+            .map { Row(bottle: $0, isSelected: true) }
+    }
+
+    private func importSelected() {
+        for url in rows.filter(\.isSelected).map(\.bottle.url)
+            where !bottleVM.bottlesList.paths.contains(url) {
+            bottleVM.bottlesList.paths.append(url)
+        }
+        bottleVM.loadBottles()
+        dismiss()
+    }
+}

--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -28,6 +28,7 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.fran
 // swiftlint:disable:next type_body_length
 struct WhiskyApp: App {
     @State var showSetup: Bool = false
+    @State private var showMigrate: Bool = false
     @State private var showDiagnosticsSheet: Bool = false
     @State private var showTroubleshootingPicker: Bool = false
     @State private var showTroubleshootingWizard: Bool = false
@@ -95,6 +96,10 @@ struct WhiskyApp: App {
                         )
                     }
                 }
+                .sheet(isPresented: $showMigrate) {
+                    MigrateBottlesSheet()
+                        .environmentObject(BottleVM.shared)
+                }
                 .overlay(alignment: .top) {
                     if let banner = crashDiagnosisBanner {
                         crashDiagnosisBannerView(banner)
@@ -140,6 +145,9 @@ struct WhiskyApp: App {
                     }
                 }
                 .keyboardShortcut("I", modifiers: [.command])
+                Button("Migrate from the Original Whisky…") {
+                    showMigrate = true
+                }
             }
             CommandGroup(after: .importExport) {
                 Button("open.logs") {

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/LegacyBottleImport.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/LegacyBottleImport.swift
@@ -116,17 +116,31 @@ public enum LegacyBottleImport {
     }
 
     /// Like ``importableBottleURLs(legacyContainer:existingPaths:)`` but also reads each bottle's
-    /// display name. Names are read **non-destructively** with ``BottleSettings/decode(from:)`` —
-    /// unlike constructing a ``Bottle``, this never rewrites the original bottle's metadata.
+    /// display name. Names are read **non-destructively** (see ``readOnlyName(at:)``) — discovery
+    /// must never mutate the original app's bottles.
     public static func importableBottles(
         legacyContainer: URL = legacyContainerDirectory,
         existingPaths: [URL]
     ) -> [DiscoveredBottle] {
         importableBottleURLs(legacyContainer: legacyContainer, existingPaths: existingPaths).map { url in
-            let metadata = url.appending(path: "Metadata").appendingPathExtension("plist")
-            let name = (try? BottleSettings.decode(from: metadata))?.name ?? url.lastPathComponent
-            return DiscoveredBottle(url: url, name: name)
+            DiscoveredBottle(url: url, name: readOnlyName(at: url) ?? url.lastPathComponent)
         }
+    }
+
+    /// Reads a bottle's display name from its `Metadata.plist` **without writing anything**.
+    ///
+    /// This decodes `BottleSettings` directly via `PropertyListDecoder` (whose `init(from:)` is
+    /// pure). It deliberately does **not** use `BottleSettings.decode(from:)` or construct a
+    /// `Bottle`: both of those rewrite the metadata file when the bottle's file/wine version
+    /// differs from the current app's defaults — which a bottle from the original app almost
+    /// always does — and that would silently mutate the user's original bottles just by opening
+    /// the migration sheet. Returns `nil` if the metadata is missing or undecodable.
+    private static func readOnlyName(at bottleURL: URL) -> String? {
+        let metadata = bottleURL.appending(path: "Metadata").appendingPathExtension("plist")
+        guard let data = try? Data(contentsOf: metadata),
+              let settings = try? PropertyListDecoder().decode(BottleSettings.self, from: data)
+        else { return nil }
+        return settings.name
     }
 
     /// A directory is treated as a bottle when it contains a `Metadata.plist`, the marker

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/LegacyBottleImport.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/LegacyBottleImport.swift
@@ -1,0 +1,138 @@
+//
+//  LegacyBottleImport.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import os.log
+
+/// Discovery of bottles created by the archived original Whisky app
+/// (bundle identifier `com.isaacmarovitz.Whisky`) so this fork can import them.
+///
+/// The fork uses a different bundle identifier, so it doesn't see the original app's
+/// bottles automatically. It is not sandboxed, though, so it can read the original
+/// container directly. Discovered bottles are referenced **in place** (no copy) —
+/// the same way custom-path bottles already work — so importing is non-destructive
+/// and the original app keeps working if it's still installed.
+public enum LegacyBottleImport {
+    private static let logger = Logger(
+        subsystem: Bundle.whiskyBundleIdentifier,
+        category: "LegacyBottleImport"
+    )
+
+    /// Bundle identifier of the archived original Whisky app.
+    public static let legacyBundleIdentifier = "com.isaacmarovitz.Whisky"
+
+    /// `~/Library/Containers/com.isaacmarovitz.Whisky`.
+    public static var legacyContainerDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appending(path: "Library")
+            .appending(path: "Containers")
+            .appending(path: legacyBundleIdentifier)
+    }
+
+    /// Minimal decode of the original app's bottle registry. Same plist shape as
+    /// ``BottleData`` — we only need the registered paths.
+    private struct LegacyRegistry: Decodable {
+        var paths: [URL]
+    }
+
+    /// Whether the original app's container exists at all. Used to decide whether the
+    /// migration option is worth offering in the UI.
+    public static func legacyContainerExists(at container: URL = legacyContainerDirectory) -> Bool {
+        FileManager.default.fileExists(atPath: container.path(percentEncoded: false))
+    }
+
+    /// URLs of original-app bottles that are valid (contain a `Metadata.plist`) and are
+    /// not already registered in `existingPaths`.
+    ///
+    /// Sources, in order: the original app's `BottleVM.plist` registry (which also covers
+    /// bottles stored at custom paths outside the default Bottles directory), then a scan
+    /// of the default `Bottles` directory as a fallback. Results are de-duplicated and
+    /// sorted by directory name.
+    ///
+    /// - Parameters:
+    ///   - legacyContainer: the original app's container directory (injectable for testing).
+    ///   - existingPaths: bottle paths already registered in this fork, to avoid duplicates.
+    public static func importableBottleURLs(
+        legacyContainer: URL = legacyContainerDirectory,
+        existingPaths: [URL]
+    ) -> [URL] {
+        let existing = Set(existingPaths.map(\.standardizedFileURL))
+        var candidates: [URL] = []
+
+        // 1. The registry plist lists every bottle the original app knew about, including
+        //    bottles stored at custom paths outside the Bottles directory.
+        let registryURL = legacyContainer.appending(path: "BottleVM").appendingPathExtension("plist")
+        if let data = try? Data(contentsOf: registryURL),
+           let registry = try? PropertyListDecoder().decode(LegacyRegistry.self, from: data) {
+            candidates.append(contentsOf: registry.paths)
+        }
+
+        // 2. Scan the default Bottles directory in case the registry is missing or stale.
+        let bottlesDir = legacyContainer.appending(path: "Bottles")
+        if let entries = try? FileManager.default.contentsOfDirectory(
+            at: bottlesDir,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        ) {
+            candidates.append(contentsOf: entries)
+        }
+
+        var seen = Set<URL>()
+        var result: [URL] = []
+        for candidate in candidates {
+            let standardized = candidate.standardizedFileURL
+            guard !existing.contains(standardized), seen.insert(standardized).inserted else { continue }
+            guard isBottle(at: standardized) else { continue }
+            result.append(standardized)
+        }
+
+        logger.info("Discovered \(result.count) importable legacy bottle(s)")
+        return result.sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    /// An importable original-app bottle, with the display name read from its settings.
+    public struct DiscoveredBottle: Identifiable, Hashable, Sendable {
+        /// The bottle's directory URL (also its identity).
+        public let url: URL
+        /// The bottle's display name, read from its settings (falls back to the directory name).
+        public let name: String
+        public var id: URL {
+            url
+        }
+    }
+
+    /// Like ``importableBottleURLs(legacyContainer:existingPaths:)`` but also reads each bottle's
+    /// display name. Names are read **non-destructively** with ``BottleSettings/decode(from:)`` —
+    /// unlike constructing a ``Bottle``, this never rewrites the original bottle's metadata.
+    public static func importableBottles(
+        legacyContainer: URL = legacyContainerDirectory,
+        existingPaths: [URL]
+    ) -> [DiscoveredBottle] {
+        importableBottleURLs(legacyContainer: legacyContainer, existingPaths: existingPaths).map { url in
+            let metadata = url.appending(path: "Metadata").appendingPathExtension("plist")
+            let name = (try? BottleSettings.decode(from: metadata))?.name ?? url.lastPathComponent
+            return DiscoveredBottle(url: url, name: name)
+        }
+    }
+
+    /// A directory is treated as a bottle when it contains a `Metadata.plist`, the marker
+    /// ``Bottle`` and ``BottleData`` use to recognise a real bottle on disk.
+    private static func isBottle(at url: URL) -> Bool {
+        let metadata = url.appending(path: "Metadata").appendingPathExtension("plist")
+        return FileManager.default.fileExists(atPath: metadata.path(percentEncoded: false))
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/LegacyBottleImportTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/LegacyBottleImportTests.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import SemanticVersion
 @testable import WhiskyKit
 import XCTest
 
@@ -115,6 +116,42 @@ final class LegacyBottleImportTests: XCTestCase {
 
         // Discovery is non-destructive: the original metadata is untouched.
         XCTAssertEqual(try Data(contentsOf: metadata), before)
+    }
+
+    func testReadsRealNameWithoutRewritingMetadata() throws {
+        let bottles = try bottlesDir()
+        let dir = bottles.appending(path: "real-bottle")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let metadata = dir.appending(path: "Metadata").appendingPathExtension("plist")
+
+        var settings = BottleSettings()
+        settings.name = "My Real Bottle"
+        // Deliberately differ from the current default so the writing BottleSettings.decode(from:)
+        // path would rewrite this file — discovery must not.
+        settings.wineVersion = SemanticVersion(0, 0, 1)
+        try settings.encode(to: metadata)
+        let before = try Data(contentsOf: metadata)
+
+        let discovered = LegacyBottleImport.importableBottles(legacyContainer: container, existingPaths: [])
+        XCTAssertEqual(discovered.map(\.url), [dir.standardizedFileURL])
+        XCTAssertEqual(discovered.first?.name, "My Real Bottle")
+        XCTAssertEqual(
+            try Data(contentsOf: metadata),
+            before,
+            "discovery must not rewrite the original bottle's metadata"
+        )
+    }
+
+    func testExcludesRegistryEntriesWhoseDirectoryIsGone() throws {
+        // The original registry can list a bottle whose directory was since deleted; it must
+        // not be offered for import (no Metadata.plist marker to validate).
+        let bottles = try bottlesDir()
+        let present = try makeBottle("present", in: bottles)
+        let deleted = container.appending(path: "Bottles").appending(path: "deleted").standardizedFileURL
+        try writeRegistry([present, deleted])
+
+        let found = LegacyBottleImport.importableBottleURLs(legacyContainer: container, existingPaths: [])
+        XCTAssertEqual(found, [present])
     }
 
     func testReturnsEmptyWhenContainerMissing() {

--- a/WhiskyKit/Tests/WhiskyKitTests/LegacyBottleImportTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/LegacyBottleImportTests.swift
@@ -1,0 +1,129 @@
+//
+//  LegacyBottleImportTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WhiskyKit
+import XCTest
+
+final class LegacyBottleImportTests: XCTestCase {
+    private var container: URL!
+
+    override func setUpWithError() throws {
+        container = FileManager.default.temporaryDirectory.appending(path: "legacy_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: container, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: container)
+    }
+
+    /// Creates a directory under `parent`; when `valid` it also gets the `Metadata.plist`
+    /// marker that identifies a real bottle on disk.
+    @discardableResult
+    private func makeBottle(_ name: String, in parent: URL, valid: Bool = true) throws -> URL {
+        let dir = parent.appending(path: name)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if valid {
+            let metadata = dir.appending(path: "Metadata").appendingPathExtension("plist")
+            try Data("<plist></plist>".utf8).write(to: metadata)
+        }
+        return dir.standardizedFileURL
+    }
+
+    /// Matches the on-disk shape of the original app's `BottleVM.plist` (we only need `paths`).
+    private struct Registry: Encodable { var paths: [URL] }
+
+    private func writeRegistry(_ paths: [URL]) throws {
+        let url = container.appending(path: "BottleVM").appendingPathExtension("plist")
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        try encoder.encode(Registry(paths: paths)).write(to: url)
+    }
+
+    private func bottlesDir() throws -> URL {
+        let dir = container.appending(path: "Bottles")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    func testDiscoversValidBottlesAndSkipsNonBottles() throws {
+        let bottles = try bottlesDir()
+        let valid1 = try makeBottle("a", in: bottles)
+        let valid2 = try makeBottle("b", in: bottles)
+        try makeBottle("not-a-bottle", in: bottles, valid: false)
+
+        let found = LegacyBottleImport.importableBottleURLs(legacyContainer: container, existingPaths: [])
+        XCTAssertEqual(Set(found), Set([valid1, valid2]))
+    }
+
+    func testExcludesAlreadyImportedPaths() throws {
+        let bottles = try bottlesDir()
+        let alreadyHave = try makeBottle("a", in: bottles)
+        let fresh = try makeBottle("b", in: bottles)
+
+        let found = LegacyBottleImport.importableBottleURLs(
+            legacyContainer: container,
+            existingPaths: [alreadyHave]
+        )
+        XCTAssertEqual(found, [fresh])
+    }
+
+    func testIncludesCustomPathBottlesKnownOnlyToTheRegistry() throws {
+        // A bottle stored outside the default Bottles directory — discoverable only via the registry.
+        let custom = try makeBottle("custom-location", in: container)
+        try writeRegistry([custom])
+
+        let found = LegacyBottleImport.importableBottleURLs(legacyContainer: container, existingPaths: [])
+        XCTAssertEqual(found, [custom])
+    }
+
+    func testDeduplicatesAcrossRegistryAndScan() throws {
+        let bottles = try bottlesDir()
+        let shared = try makeBottle("a", in: bottles)
+        try writeRegistry([shared]) // present in both the registry and the directory scan
+
+        let found = LegacyBottleImport.importableBottleURLs(legacyContainer: container, existingPaths: [])
+        XCTAssertEqual(found, [shared])
+    }
+
+    func testImportableBottlesCarryNamesWithDirectoryFallback() throws {
+        let bottles = try bottlesDir()
+        // The dummy Metadata.plist isn't a decodable BottleSettings, so the name should
+        // fall back to the directory name (and crucially, the read must not rewrite metadata).
+        let bottle = try makeBottle("my-bottle", in: bottles)
+        let metadata = bottle.appending(path: "Metadata").appendingPathExtension("plist")
+        let before = try Data(contentsOf: metadata)
+
+        let discovered = LegacyBottleImport.importableBottles(legacyContainer: container, existingPaths: [])
+        XCTAssertEqual(discovered.map(\.url), [bottle])
+        XCTAssertEqual(discovered.first?.name, "my-bottle")
+
+        // Discovery is non-destructive: the original metadata is untouched.
+        XCTAssertEqual(try Data(contentsOf: metadata), before)
+    }
+
+    func testReturnsEmptyWhenContainerMissing() {
+        let missing = FileManager.default.temporaryDirectory.appending(path: "missing_\(UUID().uuidString)")
+        XCTAssertEqual(LegacyBottleImport.importableBottleURLs(legacyContainer: missing, existingPaths: []), [])
+        XCTAssertFalse(LegacyBottleImport.legacyContainerExists(at: missing))
+    }
+
+    func testLegacyContainerExists() {
+        XCTAssertTrue(LegacyBottleImport.legacyContainerExists(at: container))
+    }
+}


### PR DESCRIPTION
Makes switching from the archived original Whisky a one-step operation instead of a manual export/import dance.

## What it does

New **File → Migrate from the Original Whisky** sheet:
- Discovers bottles the original app (`com.isaacmarovitz.Whisky`) left in its container, with checkboxes to choose which to import.
- References bottles **in place** — nothing is moved or copied — so the import is non-destructive and the original app keeps working if it's still installed.
- Shows an empty state when there's nothing to import (e.g. the original app was never installed).

This is possible because the app isn't sandboxed (no `com.apple.security.app-sandbox` entitlement), so it can read the original container directly.

## Implementation

`WhiskyKit/.../LegacyBottleImport`:
- Discovers candidates from the original app's `BottleVM.plist` registry (which also covers bottles stored at **custom paths** outside the default Bottles directory), plus a scan of its `Bottles/` directory as a fallback.
- Validates each candidate via its `Metadata.plist` marker (the same signal `Bottle`/`BottleData` use) and excludes anything already registered in this fork.
- Reads display names **non-destructively** with `BottleSettings.decode(from:)` — deliberately *not* by constructing a `Bottle`, whose `init` rewrites the metadata file on a decode failure.
- The discovery base directory is injectable, so it's unit-tested over temporary containers (discovery, non-bottle skipping, custom-path registry entries, dedup across registry+scan, exclusion of already-imported paths, non-destructive name read, missing container).

The sheet reuses the existing import mechanism (`BottleVM.bottlesList.paths.append` + `loadBottles()`).

## Verification

- `swift test --package-path WhiskyKit` → 947 tests, 0 failures (incl. 7 new `LegacyBottleImportTests`)
- `xcodebuild -scheme Whisky -configuration Debug build` → BUILD SUCCEEDED (new file registered in the project)
- `swiftformat --lint` clean

**Caveat:** the discovery/import *logic* is unit-tested against synthetic containers, but the end-to-end flow against a real original-Whisky install hasn't been exercised in this environment (no legacy container here). Worth a manual smoke test on a machine that still has the original app's bottles before release.