### PR TITLE
Measure app-target coverage from WhiskyUITests (best-effort)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,6 +152,9 @@ jobs:
         run: |
           brew install xcresultparser
           xcresultparser --output-format cobertura TestResults.xcresult > coverage-app.xml
+          # Normalize any absolute source paths to repo-relative so Codecov's `Whisky/**`
+          # flag filter matches. No-op if xcresultparser already emits relative paths.
+          sed -i '' "s|${GITHUB_WORKSPACE}/||g" coverage-app.xml || true
           echo "=== coverage-app.xml (first 20 lines) ==="
           head -20 coverage-app.xml || true
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,23 +129,49 @@ jobs:
 
       - name: Run WhiskyUITests
         run: |
+          rm -rf TestResults.xcresult
           xcodebuild -project Whisky.xcodeproj \
             -scheme Whisky \
             -configuration Debug \
             -destination 'platform=macOS' \
             -only-testing:WhiskyUITests \
+            -enableCodeCoverage YES \
+            -resultBundlePath TestResults.xcresult \
             test \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
+
+      # App-target (Whisky scheme) coverage from the UI-test run, uploaded under the
+      # `whiskyapp` Codecov flag so the SwiftUI app/CLI/thumbnail aren't completely
+      # dark. This is BEST-EFFORT: every step below is `continue-on-error`, so a broken
+      # extraction just means no app-target number that run and can never gate CI.
+      - name: Convert app-target coverage to Cobertura
+        if: always()
+        continue-on-error: true
+        run: |
+          brew install xcresultparser
+          xcresultparser --output-format cobertura TestResults.xcresult > coverage-app.xml
+          echo "=== coverage-app.xml (first 20 lines) ==="
+          head -20 coverage-app.xml || true
+
+      - name: Upload app-target coverage to Codecov
+        if: always()
+        continue-on-error: true
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage-app.xml
+          flags: whiskyapp
+          fail_ci_if_error: false
+          verbose: true
 
       - name: Upload xcresult bundle on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: ui-test-xcresult
-          path: |
-            ~/Library/Developer/Xcode/DerivedData/Whisky-*/Logs/Test/*.xcresult
+          path: TestResults.xcresult
           if-no-files-found: ignore
 
   # Test job for WhiskyKit - always runs to ensure coverage is uploaded

--- a/README.md
+++ b/README.md
@@ -121,10 +121,12 @@ against the WhiskyKit Swift package per
 "WhiskyKit unit-test coverage," not full-app coverage.
 
 WhiskyUITests gives behavioural coverage of the SwiftUI surface (toolbar,
-create-bottle sheet, fixture-dependent flows), but those tests don't feed
-the Codecov number. A future job that runs `xcodebuild test
--enableCodeCoverage YES` against the `Whisky` scheme would close that
-gap; tracked as a follow-up.
+create-bottle sheet, fixture-dependent flows). CI now runs them with
+`-enableCodeCoverage YES` and uploads the resulting app-target coverage to
+Codecov under a separate `whiskyapp` flag (best-effort — the upload never gates
+CI). Because UI tests exercise far less of the app than the unit tests do of
+WhiskyKit, expect the app-target number to read lower than the WhiskyKit badge
+above.
 
 ---
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,10 @@ coverage:
         if_ci_failed: error
         # Only post coverage status on pull requests, not on commits to default branch
         only_pulls: true
+        # Gate on WhiskyKit unit-test coverage only. The best-effort app-target (whiskyapp)
+        # coverage from UI tests is informational and must not drag this project gate down.
+        flags:
+          - whiskykit
     # Per-patch (diff) coverage requirements
     patch:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -41,10 +41,16 @@ flags:
     paths:
       - WhiskyKit/Sources/**
     carryforward: true
+  whiskyapp:
+    paths:
+      - Whisky/**
+    carryforward: true
 
 # Ignore paths from coverage calculation
 ignore:
   - "WhiskyKit/Tests/**"
+  - "WhiskyTests/**"
+  - "WhiskyUITests/**"
   - "**/*.generated.swift"
   - "**/Preview Content/**"
 
@@ -63,3 +69,7 @@ component_management:
       name: WhiskyKit
       paths:
         - WhiskyKit/Sources/**
+    - component_id: whiskyapp
+      name: Whisky (app)
+      paths:
+        - Whisky/**


### PR DESCRIPTION
Closes the README-flagged gap where the Codecov badge only reflected **WhiskyKit** and the SwiftUI app target (plus CLI/thumbnail) was completely dark.

## What changed

The existing `WhiskyUITests` CI job now also produces app-target coverage:
- Runs the UI tests with `-enableCodeCoverage YES` and a fixed `-resultBundlePath TestResults.xcresult`.
- Converts the result to Cobertura with `xcresultparser` and uploads it to Codecov under a separate **`whiskyapp`** flag + component (so it reads independently of the WhiskyKit badge).
- `codecov.yml` gains the `whiskyapp` flag/component and ignores the test targets.

## Safety

This **cannot break CI**. Every coverage step is `continue-on-error: true`, and the upload uses `fail_ci_if_error: false`. The UI-test job's own pass/fail is unchanged — a broken extraction just means no app-target number is uploaded that run.

## ⚠️ Needs one CI run to confirm

I can't run GitHub Actions locally, so the `xcresultparser` install + the xcresult→Cobertura path mapping haven't been exercised end-to-end. The two things to check on the first CI run of this branch:
1. The **Convert app-target coverage to Cobertura** step succeeds (`xcresultparser` installs and emits non-empty `coverage-app.xml`).
2. Codecov associates the file paths with `Whisky/**` (the `whiskyapp` flag's `paths`). If paths come through absolute, a small `sed` path-fix may be needed — the existing WhiskyKit job already does this for its lcov.

Because it's fail-safe, it's safe to merge and iterate on the live run rather than blocking. YAML validated locally.