### PR TITLE
fix: don't abort install/pin loops on the first skipped entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   context-menu actions dedupe against the existing blocklist before
   appending, both for single-row and multi-selection cases
   (Closes whisky-app/whisky#431).
+- DXVK installation no longer stops short when the bundle directory contains a
+  non-DLL file. The copy loop returned on the first non-`.dll` entry (e.g. a
+  stray `.DS_Store`), which could leave some DXVK DLLs uninstalled; it now skips
+  non-DLL entries and continues.
+- Pinning start-menu programs no longer stops at the first already-pinned entry.
+  The pin loop returned early once it found a program already in the pin list,
+  leaving every subsequent start-menu program unpinned; it now skips that entry
+  and continues processing the rest.
 
 ### Documentation
 - Added project governance and support docs: `docs/GOVERNANCE.md` (honest single-maintainer

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -279,7 +279,10 @@ struct BottleView: View {
                 // For some godforsaken reason "foo/bar" != "foo/Bar" so...
                 program.url.path().caseInsensitiveCompare(startMenuProgram.url.path()) == .orderedSame {
                 program.pinned = true
-                guard !bottle.settings.pins.contains(where: { $0.url == program.url }) else { return }
+                // Skip programs that are already pinned, but keep processing the
+                // rest. Using `return` here would stop pinning every remaining
+                // start-menu program after the first already-pinned one.
+                guard !bottle.settings.pins.contains(where: { $0.url == program.url }) else { continue }
                 bottle.settings.pins.append(PinnedProgram(
                     name: program.url.deletingPathExtension().lastPathComponent,
                     url: program.url

--- a/WhiskyKit/Sources/WhiskyKit/Extensions/FileManager+Extensions.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Extensions/FileManager+Extensions.swift
@@ -27,7 +27,11 @@ extension FileManager {
         )
 
         while let fileURL = enumerator?.nextObject() as? URL {
-            guard fileURL.pathExtension == "dll" else { return }
+            // Skip non-DLL entries (e.g. .DS_Store, license files) and keep
+            // scanning. Using `return` here would abort the whole copy on the
+            // first non-DLL the enumerator yields, silently leaving later DLLs
+            // uninstalled.
+            guard fileURL.pathExtension == "dll" else { continue }
             let originalURL = destinationDirectory.appending(path: fileURL.lastPathComponent)
             try FileManager.default.replaceFile(at: originalURL, with: fileURL, makeOriginalCopy: makeOriginalCopy)
         }

--- a/WhiskyKit/Sources/WhiskyKit/Extensions/FileManager+Extensions.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Extensions/FileManager+Extensions.swift
@@ -27,9 +27,10 @@ extension FileManager {
         )
 
         while let fileURL = enumerator?.nextObject() as? URL {
-            // Skip non-DLL entries (e.g. .DS_Store, license files) and keep
-            // scanning. Using `return` here would abort the whole copy on the
-            // first non-DLL the enumerator yields, silently leaving later DLLs
+            // Skip non-DLL entries and keep scanning. The enumerator is
+            // recursive, so it also yields subdirectory URLs and stray files
+            // (.DS_Store, license text). Using `return` here would abort the
+            // whole copy on the first such entry, silently leaving later DLLs
             // uninstalled.
             guard fileURL.pathExtension == "dll" else { continue }
             let originalURL = destinationDirectory.appending(path: fileURL.lastPathComponent)

--- a/WhiskyKit/Tests/WhiskyKitTests/FileExtensionTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/FileExtensionTests.swift
@@ -332,6 +332,24 @@ final class FileManagerReplaceDLLsTests: XCTestCase {
         XCTAssertEqual(content, "original exe")
     }
 
+    func testReplaceDLLsReplacesDLLWhenNonDLLPresent() throws {
+        // Regression: a non-DLL entry in the source directory must not abort the
+        // copy before later DLLs are processed. The non-DLL files are created
+        // first so the enumerator is likely to yield one before the DLL.
+        try Data("notes".utf8).write(to: sourceDir.appending(path: "readme.txt"))
+        try Data("cache".utf8).write(to: sourceDir.appending(path: ".DS_Store"))
+
+        let destDLL = destinationDir.appending(path: "core.dll")
+        let srcDLL = sourceDir.appending(path: "core.dll")
+        try Data("original dll".utf8).write(to: destDLL)
+        try Data("new dll".utf8).write(to: srcDLL)
+
+        try FileManager.default.replaceDLLs(in: destinationDir, withContentsIn: sourceDir)
+
+        let content = try String(contentsOf: destDLL, encoding: .utf8)
+        XCTAssertEqual(content, "new dll", "DLL must be replaced even when non-DLL files are also present")
+    }
+
     func testReplaceDLLsWithMakeOriginalCopy() throws {
         let destDLL = destinationDir.appending(path: "test.dll")
         let srcDLL = sourceDir.appending(path: "test.dll")

--- a/WhiskyKit/Tests/WhiskyKitTests/FileExtensionTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/FileExtensionTests.swift
@@ -334,20 +334,26 @@ final class FileManagerReplaceDLLsTests: XCTestCase {
 
     func testReplaceDLLsReplacesDLLWhenNonDLLPresent() throws {
         // Regression: a non-DLL entry in the source directory must not abort the
-        // copy before later DLLs are processed. The non-DLL files are created
-        // first so the enumerator is likely to yield one before the DLL.
-        try Data("notes".utf8).write(to: sourceDir.appending(path: "readme.txt"))
-        try Data("cache".utf8).write(to: sourceDir.appending(path: ".DS_Store"))
+        // copy. With the old early-return, the first non-DLL the enumerator
+        // yielded skipped every remaining DLL. `enumerator(at:)` order is
+        // unspecified, so we interleave several non-DLL files among multiple
+        // DLLs and assert that *all* DLLs are replaced regardless of order.
+        for name in ["aaa.txt", "mmm.cfg", ".DS_Store", "zzz.log"] {
+            try Data("ignore".utf8).write(to: sourceDir.appending(path: name))
+        }
 
-        let destDLL = destinationDir.appending(path: "core.dll")
-        let srcDLL = sourceDir.appending(path: "core.dll")
-        try Data("original dll".utf8).write(to: destDLL)
-        try Data("new dll".utf8).write(to: srcDLL)
+        let dllNames = ["d3d9.dll", "d3d11.dll", "dxgi.dll", "d3d10.dll"]
+        for name in dllNames {
+            try Data("original".utf8).write(to: destinationDir.appending(path: name))
+            try Data("replacement".utf8).write(to: sourceDir.appending(path: name))
+        }
 
         try FileManager.default.replaceDLLs(in: destinationDir, withContentsIn: sourceDir)
 
-        let content = try String(contentsOf: destDLL, encoding: .utf8)
-        XCTAssertEqual(content, "new dll", "DLL must be replaced even when non-DLL files are also present")
+        for name in dllNames {
+            let content = try String(contentsOf: destinationDir.appending(path: name), encoding: .utf8)
+            XCTAssertEqual(content, "replacement", "\(name) must be replaced even when non-DLL files are present")
+        }
     }
 
     func testReplaceDLLsWithMakeOriginalCopy() throws {


### PR DESCRIPTION
## Summary

Two latent early-return bugs where a loop bailed out entirely on the first entry it should have just *skipped*. Both were surfaced while reviewing a downstream fork; both reproduce against current `main`.

### `FileManager.replaceDLLs` — stops on the first non-DLL file
The DXVK-install copy loop did `guard fileURL.pathExtension == "dll" else { return }`. The directory enumerator yields entries in no guaranteed order, so a single non-`.dll` file in the bundle directory (a stray `.DS_Store`, a license/txt) could `return` before later DLLs were copied — silently under-installing DXVK. Changed to `continue`.

### `BottleView.updateStartMenu` — stops on the first already-pinned program
The pin loop did `guard !…pins.contains(…) else { return }`, so the moment it hit a program already in the pin list it returned out of the whole nested loop, leaving every remaining start-menu program unpinned. Changed to `continue`.

## Tests
- New `testReplaceDLLsReplacesDLLWhenNonDLLPresent` — a non-DLL file alongside a real DLL; asserts the DLL is still replaced. (The existing `testReplaceDLLsIgnoresNonDLLFiles` only had a lone non-DLL, so it passed even with the bug.)
- WhiskyKit test suite green; `Whisky` app builds; SwiftFormat clean.

## Notes
Minimal, surgical `return`→`continue` changes only. No behavior change beyond completing the loops.