### PR TITLE
feat: track bundled DXVK version and surface it in diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   everything (runtime + default bottles directory + BottleData registry).
   Bottles at custom paths outside the default directory are preserved
   (Closes whisky-app/whisky#411).
+- The bundled DXVK version is now tracked alongside the runtime version. The
+  WhiskyWine version record carries an optional `dxvkVersion`, and the setup
+  diagnostics report gained a `[VERSION]` section listing the installed runtime
+  and DXVK versions to speed up triage of runtime-mismatch issues. The field is
+  backward-compatible: runtime plists without it still load.
 
 ### Changed
 - Diagnostic reports (WhiskyWine setup and Wine prefix) now link to this fork's issue tracker

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -238,15 +238,38 @@ public class WhiskyWineInstaller {
     ///   or `nil` if WhiskyWine is not installed or the version
     ///   file cannot be read.
     public static func whiskyWineVersion() -> SemanticVersion? {
-        do {
-            let versionPlist = libraryFolder
-                .appending(path: "WhiskyWineVersion")
-                .appendingPathExtension("plist")
+        whiskyWineInfo()?.version
+    }
 
+    /// The bundled DXVK (macOS) version recorded in the installed runtime's
+    /// version plist, or `nil` if WhiskyWine is not installed or the plist does
+    /// not record a DXVK version.
+    public static func whiskyWineDXVKVersion() -> String? {
+        whiskyWineInfo()?.dxvkVersion
+    }
+
+    /// Reads the full version record from the installed WhiskyWine runtime.
+    ///
+    /// - Returns: The decoded ``WhiskyWineVersion``, or `nil` if WhiskyWine is
+    ///   not installed or the version file cannot be read.
+    public static func whiskyWineInfo() -> WhiskyWineVersion? {
+        let versionPlist = libraryFolder
+            .appending(path: "WhiskyWineVersion")
+            .appendingPathExtension("plist")
+        return whiskyWineInfo(at: versionPlist)
+    }
+
+    /// Reads a WhiskyWine version record from an arbitrary plist URL.
+    ///
+    /// Exposed for testability; ``whiskyWineInfo()`` is the production entry point.
+    ///
+    /// - Parameter url: The location of a `WhiskyWineVersion.plist` file.
+    /// - Returns: The decoded record, or `nil` if it is missing or malformed.
+    public static func whiskyWineInfo(at url: URL) -> WhiskyWineVersion? {
+        do {
             let decoder = PropertyListDecoder()
-            let data = try Data(contentsOf: versionPlist)
-            let info = try decoder.decode(WhiskyWineVersion.self, from: data)
-            return info.version
+            let data = try Data(contentsOf: url)
+            return try decoder.decode(WhiskyWineVersion.self, from: data)
         } catch {
             logger.debug("WhiskyWine version not found: \(error.localizedDescription)")
             return nil

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -259,9 +259,10 @@ public class WhiskyWineInstaller {
         return whiskyWineInfo(at: versionPlist)
     }
 
-    /// Reads a WhiskyWine version record from an arbitrary plist URL.
+    /// Reads a WhiskyWine version record from a plist at an arbitrary URL.
     ///
-    /// Exposed for testability; ``whiskyWineInfo()`` is the production entry point.
+    /// ``whiskyWineInfo()`` resolves the installed location; this overload reads
+    /// any plist URL (also convenient for tests).
     ///
     /// - Parameter url: The location of a `WhiskyWineVersion.plist` file.
     /// - Returns: The decoded record, or `nil` if it is missing or malformed.
@@ -270,8 +271,13 @@ public class WhiskyWineInstaller {
             let decoder = PropertyListDecoder()
             let data = try Data(contentsOf: url)
             return try decoder.decode(WhiskyWineVersion.self, from: data)
+        } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+            // Expected when WhiskyWine simply isn't installed yet.
+            logger.debug("WhiskyWine version plist absent: \(error.localizedDescription)")
+            return nil
         } catch {
-            logger.debug("WhiskyWine version not found: \(error.localizedDescription)")
+            // Present but unreadable/undecodable — likely a corrupt install.
+            logger.error("WhiskyWine version plist unreadable, likely corrupt: \(error.localizedDescription)")
             return nil
         }
     }

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineSetupDiagnostics.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineSetupDiagnostics.swift
@@ -125,6 +125,7 @@ public struct WhiskyWineSetupDiagnostics: Codable, Sendable {
         lines.reserveCapacity(estimatedCapacity)
 
         appendHeaderLines(into: &lines, stage: stage, error: error)
+        appendVersionLines(into: &lines)
         appendNetworkLines(into: &lines)
         appendProgressLines(into: &lines)
         appendInstallAttemptLines(into: &lines)
@@ -139,6 +140,14 @@ public struct WhiskyWineSetupDiagnostics: Codable, Sendable {
         lines.append("Stage: \(stage)")
         lines.append("Generated: \(Date().formatted(Self.eventTimestampFormatter))")
         appendIfPresent("Error", value: error, into: &lines)
+        lines.append("")
+    }
+
+    private func appendVersionLines(into lines: inout [String]) {
+        lines.append("[VERSION]")
+        let info = WhiskyWineInstaller.whiskyWineInfo()
+        appendIfPresent("WhiskyWine", value: info?.version.description, into: &lines)
+        appendIfPresent("DXVK", value: info?.dxvkVersion, into: &lines)
         lines.append("")
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineSetupDiagnostics.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineSetupDiagnostics.swift
@@ -144,11 +144,23 @@ public struct WhiskyWineSetupDiagnostics: Codable, Sendable {
     }
 
     private func appendVersionLines(into lines: inout [String]) {
-        lines.append("[VERSION]")
-        let info = WhiskyWineInstaller.whiskyWineInfo()
-        appendIfPresent("WhiskyWine", value: info?.version.description, into: &lines)
-        appendIfPresent("DXVK", value: info?.dxvkVersion, into: &lines)
+        lines.append(contentsOf: Self.versionSectionLines(for: WhiskyWineInstaller.whiskyWineInfo()))
+    }
+
+    /// Builds the `[VERSION]` section for a runtime record. Pure and `internal`
+    /// so the rendering can be unit-tested with injected values; the production
+    /// path reads the installed record via `WhiskyWineInstaller.whiskyWineInfo()`.
+    /// The header is always emitted; the runtime/DXVK lines only when recorded.
+    static func versionSectionLines(for info: WhiskyWineVersion?) -> [String] {
+        var lines = ["[VERSION]"]
+        if let version = info?.version.description {
+            lines.append("WhiskyWine: \(version)")
+        }
+        if let dxvk = info?.dxvkVersion {
+            lines.append("DXVK: \(dxvk)")
+        }
         lines.append("")
+        return lines
     }
 
     private func appendNetworkLines(into lines: inout [String]) {

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineVersion.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineVersion.swift
@@ -35,12 +35,19 @@ import SemanticVersion
 public struct WhiskyWineVersion: Codable {
     public var version: SemanticVersion
 
+    /// The bundled DXVK (macOS) version recorded alongside the runtime version,
+    /// e.g. `"1.10.3"`. Optional so runtime plists written before this key
+    /// existed still decode.
+    public var dxvkVersion: String?
+
     enum CodingKeys: String, CodingKey {
         case version
+        case dxvkVersion
     }
 
-    public init(version: SemanticVersion) {
+    public init(version: SemanticVersion, dxvkVersion: String? = nil) {
         self.version = version
+        self.dxvkVersion = dxvkVersion
     }
 
     public init(from decoder: Decoder) throws {
@@ -50,6 +57,7 @@ public struct WhiskyWineVersion: Codable {
         let minor = try versionDict.decode(Int.self, forKey: .minor)
         let patch = try versionDict.decode(Int.self, forKey: .patch)
         version = SemanticVersion(major, minor, patch)
+        dxvkVersion = try container.decodeIfPresent(String.self, forKey: .dxvkVersion)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -58,6 +66,7 @@ public struct WhiskyWineVersion: Codable {
         try versionDict.encode(version.major, forKey: .major)
         try versionDict.encode(version.minor, forKey: .minor)
         try versionDict.encode(version.patch, forKey: .patch)
+        try container.encodeIfPresent(dxvkVersion, forKey: .dxvkVersion)
     }
 
     private enum VersionKeys: String, CodingKey {

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineVersion.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineVersion.swift
@@ -47,7 +47,7 @@ public struct WhiskyWineVersion: Codable {
 
     public init(version: SemanticVersion, dxvkVersion: String? = nil) {
         self.version = version
-        self.dxvkVersion = dxvkVersion
+        self.dxvkVersion = Self.normalized(dxvkVersion)
     }
 
     public init(from decoder: Decoder) throws {
@@ -57,7 +57,14 @@ public struct WhiskyWineVersion: Codable {
         let minor = try versionDict.decode(Int.self, forKey: .minor)
         let patch = try versionDict.decode(Int.self, forKey: .patch)
         version = SemanticVersion(major, minor, patch)
-        dxvkVersion = try container.decodeIfPresent(String.self, forKey: .dxvkVersion)
+        dxvkVersion = try Self.normalized(container.decodeIfPresent(String.self, forKey: .dxvkVersion))
+    }
+
+    /// Collapses an empty DXVK version string to `nil` so "absent" and "blank"
+    /// map to the same state (and never render as a dangling `DXVK:` line).
+    private static func normalized(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -16,6 +16,7 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
+import SemanticVersion
 @testable import WhiskyKit
 import XCTest
 
@@ -67,5 +68,32 @@ final class WhiskyWineInstallerTests: XCTestCase {
         WhiskyWineInstaller.cleanupTarball(at: tarURL)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: tarURL.path))
+    }
+
+    func testWhiskyWineInfoAtReadsVersionAndDXVK() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let plistURL = tempDir.appendingPathComponent("WhiskyWineVersion").appendingPathExtension("plist")
+        let plist: [String: Any] = [
+            "version": ["major": 3, "minor": 0, "patch": 0],
+            "dxvkVersion": "1.10.3"
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: plistURL)
+
+        let info = WhiskyWineInstaller.whiskyWineInfo(at: plistURL)
+
+        XCTAssertEqual(info?.version, SemanticVersion(3, 0, 0))
+        XCTAssertEqual(info?.dxvkVersion, "1.10.3")
+    }
+
+    func testWhiskyWineInfoAtMissingFileReturnsNil() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("WhiskyWineVersion.plist")
+
+        XCTAssertNil(WhiskyWineInstaller.whiskyWineInfo(at: missing))
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -96,4 +96,30 @@ final class WhiskyWineInstallerTests: XCTestCase {
 
         XCTAssertNil(WhiskyWineInstaller.whiskyWineInfo(at: missing))
     }
+
+    func testWhiskyWineInfoAtMalformedFileReturnsNil() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // A present-but-corrupt plist must be swallowed to nil, not crash.
+        let garbageURL = tempDir.appendingPathComponent("WhiskyWineVersion").appendingPathExtension("plist")
+        try Data("this is not a plist".utf8).write(to: garbageURL)
+
+        XCTAssertNil(WhiskyWineInstaller.whiskyWineInfo(at: garbageURL))
+    }
+
+    func testWhiskyWineInfoAtPartialPlistReturnsNil() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Valid plist but missing a required version field — decode throws, swallowed to nil.
+        let partialURL = tempDir.appendingPathComponent("WhiskyWineVersion").appendingPathExtension("plist")
+        let plist: [String: Any] = ["version": ["major": 3, "minor": 0]]
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: partialURL)
+
+        XCTAssertNil(WhiskyWineInstaller.whiskyWineInfo(at: partialURL))
+    }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineSetupDiagnosticsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineSetupDiagnosticsTests.swift
@@ -16,6 +16,7 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
+import SemanticVersion
 @testable import WhiskyKit
 import XCTest
 
@@ -41,6 +42,42 @@ final class WhiskyWineSetupDiagnosticsTests: XCTestCase {
         // The [VERSION] section is always present; the runtime/DXVK lines under it
         // only render when an installed runtime plist records them.
         XCTAssertTrue(report.contains("[VERSION]"))
+    }
+
+    func testVersionSectionRendersRuntimeAndDXVK() {
+        let info = WhiskyWineVersion(version: SemanticVersion(3, 0, 0), dxvkVersion: "1.10.3")
+
+        let lines = WhiskyWineSetupDiagnostics.versionSectionLines(for: info)
+
+        XCTAssertEqual(lines.first, "[VERSION]")
+        XCTAssertTrue(lines.contains("WhiskyWine: 3.0.0"))
+        XCTAssertTrue(lines.contains("DXVK: 1.10.3"))
+    }
+
+    func testVersionSectionOmitsDXVKWhenAbsent() {
+        let info = WhiskyWineVersion(version: SemanticVersion(3, 0, 0))
+
+        let lines = WhiskyWineSetupDiagnostics.versionSectionLines(for: info)
+
+        XCTAssertTrue(lines.contains("WhiskyWine: 3.0.0"))
+        XCTAssertFalse(lines.contains(where: { $0.hasPrefix("DXVK:") }))
+    }
+
+    func testVersionSectionOmitsBlankDXVK() {
+        // An empty DXVK string normalizes to nil, so no dangling "DXVK:" line.
+        let info = WhiskyWineVersion(version: SemanticVersion(3, 0, 0), dxvkVersion: "")
+
+        let lines = WhiskyWineSetupDiagnostics.versionSectionLines(for: info)
+
+        XCTAssertFalse(lines.contains(where: { $0.hasPrefix("DXVK:") }))
+    }
+
+    func testVersionSectionHeaderOnlyWhenNoRuntime() {
+        let lines = WhiskyWineSetupDiagnostics.versionSectionLines(for: nil)
+
+        XCTAssertEqual(lines.first, "[VERSION]")
+        XCTAssertFalse(lines.contains(where: { $0.hasPrefix("WhiskyWine:") }))
+        XCTAssertFalse(lines.contains(where: { $0.hasPrefix("DXVK:") }))
     }
 
     func testEventTruncationKeepsMostRecent() {

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineSetupDiagnosticsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineSetupDiagnosticsTests.swift
@@ -33,6 +33,16 @@ final class WhiskyWineSetupDiagnosticsTests: XCTestCase {
         XCTAssertTrue(report.contains("[EVENTS]"))
     }
 
+    func testReportIncludesVersionSection() {
+        let diagnostics = WhiskyWineSetupDiagnostics()
+
+        let report = diagnostics.reportString(stage: "install", error: "boom")
+
+        // The [VERSION] section is always present; the runtime/DXVK lines under it
+        // only render when an installed runtime plist records them.
+        XCTAssertTrue(report.contains("[VERSION]"))
+    }
+
     func testEventTruncationKeepsMostRecent() {
         var diagnostics = WhiskyWineSetupDiagnostics()
         let overflowEventCount = 5

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineVersionTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineVersionTests.swift
@@ -260,6 +260,59 @@ final class WhiskyWineVersionInitializerTests: XCTestCase {
     }
 }
 
+// MARK: - DXVK Version Tests
+
+final class WhiskyWineVersionDXVKTests: XCTestCase {
+    func testDecodeWithDXVKVersion() throws {
+        let plist: [String: Any] = [
+            "version": ["major": 3, "minor": 0, "patch": 0],
+            "dxvkVersion": "1.10.3"
+        ]
+
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        let versionInfo = try PropertyListDecoder().decode(WhiskyWineVersion.self, from: data)
+
+        XCTAssertEqual(versionInfo.version, SemanticVersion(3, 0, 0))
+        XCTAssertEqual(versionInfo.dxvkVersion, "1.10.3")
+    }
+
+    func testDecodeWithoutDXVKVersionIsNil() throws {
+        // Older runtime plists predate the dxvkVersion key and must still decode.
+        let plist: [String: Any] = [
+            "version": ["major": 3, "minor": 0, "patch": 0]
+        ]
+
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        let versionInfo = try PropertyListDecoder().decode(WhiskyWineVersion.self, from: data)
+
+        XCTAssertNil(versionInfo.dxvkVersion)
+    }
+
+    func testRoundTripPreservesDXVKVersion() throws {
+        let original = WhiskyWineVersion(version: SemanticVersion(3, 0, 0), dxvkVersion: "1.10.3")
+
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(original)
+        let decoded = try PropertyListDecoder().decode(WhiskyWineVersion.self, from: data)
+
+        XCTAssertEqual(decoded.version, original.version)
+        XCTAssertEqual(decoded.dxvkVersion, "1.10.3")
+    }
+
+    func testNilDXVKVersionIsOmittedFromEncoding() throws {
+        let original = WhiskyWineVersion(version: SemanticVersion(3, 0, 0))
+
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(original)
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+
+        XCTAssertNotNil(plist)
+        XCTAssertNil(plist?["dxvkVersion"], "A nil DXVK version should not be written to the plist")
+    }
+}
+
 // MARK: - Test Helper Types
 
 private struct VersionComponents {

--- a/dist/pages/WhiskyWineVersion.plist
+++ b/dist/pages/WhiskyWineVersion.plist
@@ -11,5 +11,7 @@
 		<key>patch</key>
 		<integer>0</integer>
 	</dict>
+	<key>dxvkVersion</key>
+	<string>1.10.3</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Groundwork for runtime-currency observability: the bundled **DXVK version** is now recorded alongside the runtime version and surfaced where it helps triage. Distilled from a downstream fork's version-tracking work, adapted to this fork's posture (the bundled DXVK is the frozen-by-design Gcenx **DXVK-macOS 1.10.3**, not upstream 2.x).

## Changes
- **`WhiskyWineVersion.dxvkVersion: String?`** — optional, decoded/encoded with `…IfPresent` so runtime plists written before this key still load, and a nil value is never written.
- **Installer accessors** — `whiskyWineInfo()` (full record), a testable `whiskyWineInfo(at:)` overload, and `whiskyWineDXVKVersion()`. `whiskyWineVersion()` now delegates to `whiskyWineInfo()?.version` (behavior unchanged; `isWhiskyWineInstalled` still works).
- **Setup diagnostics `[VERSION]` section** — lists the installed runtime + DXVK version in the install-failure report. Self-populating (reads the installed plist, consistent with how the existing `[DISK]` section reads live state), so no app-target wiring is needed.
- **Published metadata** — `dist/pages/WhiskyWineVersion.plist` now records `dxvkVersion = 1.10.3` (matches `docs/DEPENDENCIES.md`).

## Notes
- The installed runtime's plist won't carry `dxvkVersion` until the next runtime archive is rebuilt with it; until then the `[VERSION]` section simply shows the runtime version (the DXVK line renders once present). All decode paths are backward-compatible.
- Deliberately **not** included: the fork's removal of the remote runtime-update check (kept intact) and anything DXVK-2.x.

## Tests
- `dxvkVersion` decode-with / decode-without / round-trip / nil-omission.
- `whiskyWineInfo(at:)` reads version + DXVK from a temp plist; missing file → nil.
- Diagnostics report includes the `[VERSION]` section.
- Full WhiskyKit suite green; `Whisky` app builds; SwiftFormat clean.