### PR TITLE
release: 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-06-08 (App)
+
 ### Added
 - **File → Migrate from the Original Whisky** discovers bottles created by the
   archived original app (`com.isaacmarovitz.Whisky`) and imports them in one

--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -1166,7 +1166,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Whisky/Preview Content\"";
 				DEVELOPMENT_TEAM = Z7JS58F8U3;
@@ -1184,7 +1184,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.0.1;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.franke.Whisky;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1204,7 +1204,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Whisky/Preview Content\"";
 				DEVELOPMENT_TEAM = Z7JS58F8U3;
@@ -1222,7 +1222,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.0.1;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.franke.Whisky;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1290,7 +1290,7 @@
 				CODE_SIGN_ENTITLEMENTS = WhiskyThumbnail/WhiskyThumbnail.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = Z7JS58F8U3;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1306,7 +1306,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 3.0.1;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.franke.Whisky.WhiskyThumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1325,7 +1325,7 @@
 				CODE_SIGN_ENTITLEMENTS = WhiskyThumbnail/WhiskyThumbnail.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = Z7JS58F8U3;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1341,7 +1341,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 3.0.1;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.franke.Whisky.WhiskyThumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Release prep: Whisky 3.1.0

Bumps `MARKETING_VERSION` → **3.1.0** and `CURRENT_PROJECT_VERSION` → **46** (monotonic over 3.0.1's Sparkle build 45, ×4 occurrences each), and rolls the `[Unreleased]` changelog into a dated `[3.1.0]` section. **App-only release** — nothing here touches the `Libraries.tar.gz` runtime, so no `vX.Y.Z` runtime release is needed.

First release since 3.0.1 (2026-05-01). Verified: Debug **and** Release `-showBuildSettings` both resolve to 3.1.0 / 46.

### Highlights
- **One-click migration from the original Whisky** (File → Migrate from the Original Whisky) — imports existing bottles in place, non-destructively.
- **Idle Wine no longer pegs a CPU core** (whisky-app/whisky#917).
- **~50 new bundled GameDB entries** with one-click recommended configs (now 79 titles).
- Wine inherits the **host timezone**; **display sleep suppressed** during play; **host fonts** copied for Unity titles; broader file-picker support (`.msix`/`.appx`/`.url`…); searchable Winetricks browser.
- Identity cleanup onto `com.franke.Whisky`; bundled-DXVK-version diagnostics; download resilience; launcher-helper filtering.

---

## Remaining steps (yours — needs your signing keychain)

Do these **in this order** so the Sparkle feed never advertises a DMG that isn't uploaded yet:

1. **Merge this PR** → `main` is now at 3.1.0 / 46.
2. **Build + notarize:**
   ```sh
   scripts/release.sh 3.1.0
   # → build/release/Whisky-3.1.0.dmg
   ```
3. **Sign the DMG for Sparkle** and capture the `edSignature` + `length`:
   ```sh
   ~/Library/Developer/Xcode/DerivedData/Whisky-*/SourcePackages/artifacts/sparkle/Sparkle/bin/sign_update build/release/Whisky-3.1.0.dmg
   ```
4. **Create the GitHub release first** (this creates the `app-v3.1.0` tag and makes the download URL live):
   ```sh
   gh release create app-v3.1.0 --repo frankea/Whisky \
     --title "Whisky 3.1.0" \
     --notes-file <(awk '/^## \[3.1.0\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md) \
     build/release/Whisky-3.1.0.dmg
   ```
5. **Then** add the appcast `<item>` and push — the Documentation workflow republishes the feed pointing at a DMG that already exists. Edit **`dist/pages/appcast.xml`** (NOT the stale root `appcast.xml`, which Pages does not serve); add this near the top of `<channel>`, filling the three `__…__` placeholders:
   ```xml
   <item>
       <title>Whisky 3.1.0</title>
       <pubDate>__RFC822_DATE__</pubDate>
       <sparkle:version>46</sparkle:version>
       <sparkle:shortVersionString>3.1.0</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
       <description><![CDATA[
           <p>One-click migration from the original Whisky, ~50 more supported games, and reliability fixes.</p>
           <ul>
               <li><strong>File → Migrate from the Original Whisky</strong> imports your existing bottles in place.</li>
               <li>Fixes a bug where an idle Wine process could peg a CPU core.</li>
               <li>~50 new bundled GameDB entries with one-click recommended configs.</li>
               <li>Wine inherits the host timezone; display sleep is suppressed during play; host fonts are copied for Unity titles.</li>
           </ul>
           <p>See the <a href="https://github.com/frankea/Whisky/releases/tag/app-v3.1.0">release notes</a> for the full changelog.</p>
       ]]></description>
       <enclosure
           url="https://github.com/frankea/Whisky/releases/download/app-v3.1.0/Whisky-3.1.0.dmg"
           sparkle:edSignature="__ED_SIGNATURE__"
           length="__LENGTH__"
           type="application/octet-stream" />
   </item>
   ```
   - `__RFC822_DATE__` → `date -u "+%a, %d %b %Y %H:%M:%S +0000"`
   - `__ED_SIGNATURE__` / `__LENGTH__` → from step 3
   ```sh
   git add dist/pages/appcast.xml && git commit -m "appcast: Whisky 3.1.0" && git push
   ```

Existing 3.0.x installs pick up the update on their next launch.
