### PR TITLE
docs: strengthen landing/trust surface

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,9 @@ contact_links:
   - name: 💥 Crash / freeze / kernel panic troubleshooting
     url: https://github.com/frankea/Whisky/blob/main/docs/StabilityTroubleshooting.md
     about: Run the in-app diagnostics (Bottle Configuration → View Diagnostics) before reporting.
-  - name: 🎮 Game support wiki (community-maintained)
-    url: https://github.com/frankea/Whisky/wiki/Game-Support
-    about: Check whether your game already has a known status or a recommended config.
+  - name: 🎮 Game configurations (bundled)
+    url: https://github.com/frankea/Whisky/blob/main/WhiskyKit/Sources/WhiskyKit/GameDatabase/Resources/GameDB.json
+    about: Check whether your game already has a recommended config (also browsable in-app under Game Configurations).
   - name: 📜 Upstream issue audit
     url: https://github.com/frankea/Whisky/blob/main/docs/AUDIT.md
     about: Per-issue accounting of how this fork addresses the archived upstream's open issues.

--- a/.github/ISSUE_TEMPLATE/game-compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game-compatibility.yml
@@ -10,7 +10,6 @@ body:
         For non-game bugs (Whisky UI, bottle creation, etc.), use the **Bug Report** template instead.
 
         **Before filing:**
-        - Check the [Game Support wiki](https://github.com/frankea/Whisky/wiki/Game-Support) for known status.
         - Open the **Game Configurations** browser inside Whisky — your game may already have a recommended config.
         - Search [existing issues](https://github.com/frankea/Whisky/issues?q=is%3Aissue+label%3Agame-compatibility).
   - type: input
@@ -124,7 +123,7 @@ body:
     attributes:
       label: Pre-flight checks
       options:
-        - label: I checked the Game Support wiki and Game Configurations browser for an existing config.
+        - label: I checked the in-app Game Configurations browser for an existing config.
           required: true
         - label: I searched existing issues for this game.
           required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+- Landing page (`frankea.github.io/Whisky`) now shows app screenshots, adds an
+  honest "Graphics backends" section (D3DMetal default, why DXVK is pinned at
+  1.10.3 by design, and the Wine-wide anti-cheat limitation), and bumps the
+  advertised version to 3.1.0.
+- Replaced the dead "Game Support wiki" links (the wiki page bounced to the repo
+  root) across the README, landing page, and issue templates with the bundled
+  Game Configurations database.
+
 ## [3.1.0] - 2026-06-08 (App)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ WhiskyKit, the core framework powering Whisky, has comprehensive API documentati
 - **[Steam Compatibility Guide](docs/SteamCompatibility.md)** - Detailed guide for Steam on Whisky
 - **[Stability Troubleshooting](docs/StabilityTroubleshooting.md)** - Diagnose crashes, freezes, reboots, and kernel panics
 - **Controller Issues** - Enable "Controller Compatibility Mode" in Bottle Config → Controller & Input
-- **[Game Support Wiki](https://github.com/frankea/Whisky/wiki/Game-Support)** - Community-maintained game compatibility list
+- **[Game Configurations](https://github.com/frankea/Whisky/blob/main/WhiskyKit/Sources/WhiskyKit/GameDatabase/Resources/GameDB.json)** - 80+ curated per-game compatibility configs, also browsable in-app under Game Configurations
 
 ### Upstream issue audit
 

--- a/dist/pages/index.html
+++ b/dist/pages/index.html
@@ -35,7 +35,7 @@
   "operatingSystem": "macOS 15.0+",
   "applicationCategory": "GameApplication",
   "applicationSubCategory": "Wine wrapper",
-  "softwareVersion": "3.0.1",
+  "softwareVersion": "3.1.0",
   "license": "https://www.gnu.org/licenses/gpl-3.0.html",
   "downloadUrl": "https://github.com/frankea/Whisky/releases/latest",
   "url": "https://github.com/frankea/Whisky",
@@ -147,6 +147,9 @@ img.screenshot {
   <a class="cta secondary" href="https://github.com/frankea/Whisky">View on GitHub</a>
 </p>
 
+<img class="screenshot" src="https://raw.githubusercontent.com/frankea/Whisky/main/images/new-bottle-screenshot.png" alt="Creating a new Wine bottle in Whisky" loading="lazy" width="1200">
+<img class="screenshot" src="https://raw.githubusercontent.com/frankea/Whisky/main/images/config-screenshot.png" alt="Whisky bottle configuration — graphics backend, Wine, and performance settings" loading="lazy" width="1200">
+
 <h2>Install via Homebrew</h2>
 <pre><code>brew install --cask frankea/whisky/whisky</code></pre>
 <p class="muted">Note: the default <code>brew install --cask whisky</code> still installs the archived original. Use the qualified <code>frankea/whisky/whisky</code> form for this fork.</p>
@@ -168,13 +171,21 @@ img.screenshot {
   <li>Signed and notarized DMG; Sparkle delivers in-app updates</li>
 </ul>
 
+<h2>Graphics backends</h2>
+<p>Whisky translates Direct3D to the Mac GPU two ways, selectable per bottle:</p>
+<ul>
+  <li><strong>D3DMetal</strong> (default) — Apple's Direct3D-to-Metal layer from the Game Porting Toolkit. The fastest path for most modern Direct3D 11/12 titles.</li>
+  <li><strong>DXVK</strong> — Direct3D-to-Vulkan (via MoltenVK), a broad-compatibility fallback for titles D3DMetal doesn't handle. Pinned at the macOS-compatible 1.10.3 <em>by design</em>: the DXVK 2.x line needs Vulkan features macOS doesn't expose, so a higher version number wouldn't run here — a deliberate choice, not a stale dependency.</li>
+</ul>
+<p class="muted"><strong>Anti-cheat:</strong> games using kernel-level anti-cheat (EAC, BattlEye, and similar) generally do not run under any Wine-based wrapper on macOS, including Whisky. This is a Wine-wide limitation, not specific to this fork.</p>
+
 <h2>Documentation</h2>
 <ul>
   <li><a href="documentation/whiskykit/">WhiskyKit API documentation</a> — DocC-generated reference for the framework</li>
   <li><a href="https://github.com/frankea/Whisky/blob/main/docs/AUDIT.md">Upstream issue audit</a> — per-issue accounting against the archived upstream</li>
   <li><a href="https://github.com/frankea/Whisky/blob/main/docs/LauncherTroubleshooting.md">Launcher troubleshooting</a></li>
   <li><a href="https://github.com/frankea/Whisky/blob/main/docs/StabilityTroubleshooting.md">Stability troubleshooting</a></li>
-  <li><a href="https://github.com/frankea/Whisky/wiki/Game-Support">Game support wiki</a> (community-maintained)</li>
+  <li><a href="https://github.com/frankea/Whisky/blob/main/WhiskyKit/Sources/WhiskyKit/GameDatabase/Resources/GameDB.json">Bundled game configurations</a> — 80+ curated per-game setups, browsable in-app under Game Configurations</li>
 </ul>
 
 <hr>

--- a/dist/pages/index.html
+++ b/dist/pages/index.html
@@ -158,7 +158,7 @@ img.screenshot {
 <ul>
   <li>Apple Silicon Mac (M1, M2, M3, M4)</li>
   <li>macOS Sequoia 15.0 or later</li>
-  <li>~313 MB disk space for the bundled Wine runtime</li>
+  <li>~800 MB disk space for the bundled Wine runtime (a ~313 MB download)</li>
 </ul>
 
 <h2>What's included</h2>


### PR DESCRIPTION
## Summary
Your repo-traffic shows `frankea.github.io` is the **#1 referrer (354 unique visitors / 2 weeks)** — but the landing page was text-only, advertised the old 3.0.1, and carried dead links. This sharpens the surface real traffic already lands on.

## Changes
- **Screenshots on the landing page** — adds the new-bottle and config shots (via `raw.githubusercontent` URLs, matching the existing OG-card pattern since images live in repo-root `images/`, not `dist/pages/`). The `img.screenshot` style was already defined but unused.
- **Honest "Graphics backends" section** — D3DMetal as the default modern path, and an explicit note that **DXVK 1.10.3 is pinned by design** (the 2.x line needs Vulkan features macOS doesn't expose) so visitors don't misread it as a stale dependency vs CrossOver. Plus a frank anti-cheat note (a Wine-wide limit, not fork-specific).
- **Version bump** — JSON-LD `softwareVersion` 3.0.1 → 3.1.0.
- **Killed the dead "Game Support wiki" links** — `/wiki/Game-Support` returns 200 but its *final URL is the repo root* (GitHub bounces a non-existent wiki page home), and "community-maintained" was inaccurate. Repointed across README, landing page, and both issue templates to the bundled **Game Configurations** database (`GameDB.json`, also browsable in-app).

## Verification
- No `wiki/Game-Support` references remain.
- Both screenshot raw URLs and the GameDB.json link return HTTP 200.
- Both issue-template YAMLs validate.

Merging redeploys Pages via the Documentation workflow (~1-2 min).