### PR TITLE
ci: retry flaky WhiskyUITests instead of failing on first flake

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -130,6 +130,10 @@ jobs:
       - name: Run WhiskyUITests
         run: |
           rm -rf TestResults.xcresult
+          # Retry failed tests up to 3 total runs. XCUITests against a SwiftUI
+          # surface are timing-sensitive (e.g. waiting for the create-bottle
+          # sheet to render on a busy CI runner), so a single flake shouldn't
+          # red-X main. A genuinely broken test still fails after all retries.
           xcodebuild -project Whisky.xcodeproj \
             -scheme Whisky \
             -configuration Debug \
@@ -137,6 +141,8 @@ jobs:
             -only-testing:WhiskyUITests \
             -enableCodeCoverage YES \
             -resultBundlePath TestResults.xcresult \
+            -retry-tests-on-failure \
+            -test-iterations 3 \
             test \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \


### PR DESCRIPTION
## Summary
`testCreateBottleSheetOpensAndCancels` intermittently fails waiting for the SwiftUI create-bottle sheet to render on a busy CI runner — red-X'ing `main` on unrelated commits (it flaked on the 3.1.0 release PR and was confirmed flaky by a clean re-run). A red badge on `main` from a known flake is a credibility drag for a project asking users to depend on it.

## Fix
Add `-retry-tests-on-failure -test-iterations 3` to the UI-test `xcodebuild` invocation. A flaky test self-heals on retry; a **genuinely** broken test still fails after all 3 iterations. This is strictly better than marking the job non-gating, which would lose signal on real regressions.

YAML validated.