### PR TITLE
feat: pre-flight bottle locations and surface install failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bottle creation now validates the chosen location before doing any work: if
   the folder isn't writable or the disk is nearly full, you get a clear,
   actionable error up front instead of the bottle silently disappearing after a
-  cryptic Wine failure (Closes #61).
+  cryptic Wine failure. Builds on the bottle-creation diagnostics added for
+  issue #61.
 - Runtime installation failures now surface their cause. `install(from:)`
   propagates the underlying error (missing tarball, disk full, archive
   extraction failure) instead of swallowing it, so the setup screen shows the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Bottle creation now validates the chosen location before doing any work: if
+  the folder isn't writable or the disk is nearly full, you get a clear,
+  actionable error up front instead of the bottle silently disappearing after a
+  cryptic Wine failure (Closes #61).
+- Runtime installation failures now surface their cause. `install(from:)`
+  propagates the underlying error (missing tarball, disk full, archive
+  extraction failure) instead of swallowing it, so the setup screen shows the
+  specific reason and the diagnostics report captures it.
+
 ## [3.1.0] - 2026-06-08 (App)
 
 ### Added

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -813,6 +813,26 @@
         }
       }
     },
+    "bottle.creation.preflight.insufficientSpace": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There isn't enough free space to create a bottle: %1$@ available, but about %2$@ is needed. Free up space or choose another disk."
+          }
+        }
+      }
+    },
+    "bottle.creation.preflight.notWritable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whisky can't write to the folder you chose (%@). Pick a folder you can modify, such as one inside your home folder."
+          }
+        }
+      }
+    },
     "bottle.orphan.tooltip": {
       "localizations": {
         "en": {
@@ -20204,6 +20224,16 @@
         }
       }
     },
+    "setup.whiskywine.error.installFailed.detail": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation failed: %@"
+          }
+        }
+      }
+    },
     "setup.whiskywine.error.invalidDownloadURL": {
       "localizations": {
         "en": {
@@ -20250,6 +20280,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "Server error. Please try again later."
+          }
+        }
+      }
+    },
+    "setup.whiskywine.error.tarballMissing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The downloaded Wine runtime is missing and can't be installed. It was likely removed before installation finished. Please try again."
           }
         }
       }

--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -28,6 +28,10 @@ enum BottleCreationError: LocalizedError {
     case metadataCreationFailed
     case wineVersionChangeFailed
     case persistenceSaveFailed
+    /// The chosen location failed pre-flight validation. Carries the already
+    /// localized, user-facing message (built at the throw site) since the alert
+    /// displays `errorDescription` verbatim.
+    case locationUnsuitable(message: String)
 
     var errorDescription: String? {
         switch self {
@@ -39,6 +43,8 @@ enum BottleCreationError: LocalizedError {
             "Failed to configure Windows version"
         case .persistenceSaveFailed:
             "Failed to save bottle to persistence"
+        case let .locationUnsuitable(message):
+            message
         }
     }
 }
@@ -96,6 +102,26 @@ final class BottleVM: ObservableObject {
     private func createBottleTask(request: BottleCreationRequest) async {
         var bottle: Bottle?
         do {
+            // Pre-flight the chosen location before creating anything, so an
+            // unwritable or near-full destination surfaces a clear error up
+            // front instead of a cryptic late wineboot failure (issue #61).
+            switch BottleLocationValidation.validate(at: request.bottleURL) {
+            case .valid:
+                break
+            case let .notWritable(path):
+                throw BottleCreationError.locationUnsuitable(
+                    message: String(format: String(localized: "bottle.creation.preflight.notWritable"), path)
+                )
+            case let .insufficientSpace(availableBytes, requiredBytes):
+                throw BottleCreationError.locationUnsuitable(
+                    message: String(
+                        format: String(localized: "bottle.creation.preflight.insufficientSpace"),
+                        ByteCountFormatter.string(fromByteCount: availableBytes, countStyle: .file),
+                        ByteCountFormatter.string(fromByteCount: requiredBytes, countStyle: .file)
+                    )
+                )
+            }
+
             try createBottleDirectory(at: request.newBottleDir)
 
             // Create bottle on main actor (since Bottle is @MainActor)

--- a/Whisky/Views/Setup/WhiskyWineInstallView.swift
+++ b/Whisky/Views/Setup/WhiskyWineInstallView.swift
@@ -143,11 +143,10 @@ struct WhiskyWineInstallView: View {
 
             let capturedTarURL = tarLocation
             diagnostics.record("Invoking WhiskyWineInstaller.install(from:) in detached task")
-            let installFailureMessage = await Self.performInstall(tarball: capturedTarURL)
+            let (installFailureMessage, isInstalled) = await Self.performInstall(tarball: capturedTarURL)
             if let installFailureMessage {
                 diagnostics.record("Install failed: \(installFailureMessage)")
             }
-            let isInstalled = installFailureMessage == nil && WhiskyWineInstaller.isWhiskyWineInstalled()
             let installStatus = isInstalled ? "installed" : "not installed"
             diagnostics.record(
                 "Detached WhiskyWineInstaller.install(from:) task completed: \(installStatus)"
@@ -182,15 +181,16 @@ struct WhiskyWineInstallView: View {
         }
     }
 
-    /// Runs the install off the main actor and returns the (Sendable) failure
-    /// message, or `nil` on success.
-    private static func performInstall(tarball: URL) async -> String? {
+    /// Runs the install and post-install verification off the main actor, keeping
+    /// the plist read off the main thread. Returns the (Sendable) failure message
+    /// (`nil` on success) and whether the runtime is now present.
+    private static func performInstall(tarball: URL) async -> (failureMessage: String?, installed: Bool) {
         await Task.detached {
             do {
                 try WhiskyWineInstaller.install(from: tarball)
-                return nil
+                return (nil, WhiskyWineInstaller.isWhiskyWineInstalled())
             } catch {
-                return error.localizedDescription
+                return (error.localizedDescription, false)
             }
         }.value
     }

--- a/Whisky/Views/Setup/WhiskyWineInstallView.swift
+++ b/Whisky/Views/Setup/WhiskyWineInstallView.swift
@@ -143,10 +143,11 @@ struct WhiskyWineInstallView: View {
 
             let capturedTarURL = tarLocation
             diagnostics.record("Invoking WhiskyWineInstaller.install(from:) in detached task")
-            let isInstalled = await Task.detached {
-                WhiskyWineInstaller.install(from: capturedTarURL)
-                return WhiskyWineInstaller.isWhiskyWineInstalled()
-            }.value
+            let installFailureMessage = await Self.performInstall(tarball: capturedTarURL)
+            if let installFailureMessage {
+                diagnostics.record("Install failed: \(installFailureMessage)")
+            }
+            let isInstalled = installFailureMessage == nil && WhiskyWineInstaller.isWhiskyWineInstalled()
             let installStatus = isInstalled ? "installed" : "not installed"
             diagnostics.record(
                 "Detached WhiskyWineInstaller.install(from:) task completed: \(installStatus)"
@@ -164,6 +165,11 @@ struct WhiskyWineInstallView: View {
             installing = false
             if isInstalled {
                 installError = nil
+            } else if let installFailureMessage {
+                installError = String(
+                    format: String(localized: "setup.whiskywine.error.installFailed.detail"),
+                    Self.shortened(installFailureMessage)
+                )
             } else {
                 installError = String(localized: "setup.whiskywine.error.installFailed")
             }
@@ -174,5 +180,27 @@ struct WhiskyWineInstallView: View {
             try? await Task.sleep(for: Self.installSuccessDelay)
             proceed()
         }
+    }
+
+    /// Runs the install off the main actor and returns the (Sendable) failure
+    /// message, or `nil` on success.
+    private static func performInstall(tarball: URL) async -> String? {
+        await Task.detached {
+            do {
+                try WhiskyWineInstaller.install(from: tarball)
+                return nil
+            } catch {
+                return error.localizedDescription
+            }
+        }.value
+    }
+
+    /// Trims a possibly long, multi-line underlying error (e.g. raw `tar` output)
+    /// down to a single short line for the install error message. The full text
+    /// is preserved in the diagnostics report.
+    private static func shortened(_ message: String, limit: Int = 200) -> String {
+        let firstLine = message.split(whereSeparator: \.isNewline).first.map(String.init) ?? message
+        let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
+        return trimmed.count <= limit ? trimmed : String(trimmed.prefix(limit)) + "…"
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Documentation.docc/GettingStarted.md
+++ b/WhiskyKit/Sources/WhiskyKit/Documentation.docc/GettingStarted.md
@@ -41,7 +41,11 @@ import WhiskyKit
 if !WhiskyWineInstaller.isWhiskyWineInstalled() {
     // Download and install WhiskyWine
     let tarballURL = // ... download WhiskyWine tarball
-    WhiskyWineInstaller.install(from: tarballURL)
+    do {
+        try WhiskyWineInstaller.install(from: tarballURL)
+    } catch {
+        print("Install failed: \(error.localizedDescription)")
+    }
 }
 
 // Check for updates

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLocationValidation.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLocationValidation.swift
@@ -75,11 +75,15 @@ public enum BottleLocationValidation {
         return .valid
     }
 
-    /// Walks up from `url` to the first existing directory, so writability and
+    /// Walks up from `url` to the first existing path, so writability and
     /// capacity can be probed even when the chosen path does not exist yet.
+    ///
+    /// The first existing path may be a regular file (a malformed location); the
+    /// caller's write probe then fails and yields `.notWritable` rather than
+    /// silently validating the file's parent.
     static func nearestExistingDirectory(for url: URL, fileManager: FileManager) -> URL {
         var candidate = url.resolvingSymlinksInPath()
-        while !fileManager.fileExists(atPath: candidate.path(percentEncoded: false)) {
+        while !exists(candidate, fileManager: fileManager) {
             let parent = candidate.deletingLastPathComponent()
             // `deletingLastPathComponent()` on "/" returns "/"; stop at the root
             // rather than looping forever.
@@ -89,6 +93,17 @@ public enum BottleLocationValidation {
             candidate = parent
         }
         return candidate
+    }
+
+    /// `fileExists(atPath:)` with a trailing slash returns `false` for a regular
+    /// file, and `deletingLastPathComponent()` introduces trailing slashes — so
+    /// strip them before testing existence to detect file components correctly.
+    private static func exists(_ url: URL, fileManager: FileManager) -> Bool {
+        var path = url.path(percentEncoded: false)
+        while path.count > 1, path.hasSuffix("/") {
+            path.removeLast()
+        }
+        return fileManager.fileExists(atPath: path)
     }
 
     /// Probes writability by creating and removing a unique temp file.

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLocationValidation.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLocationValidation.swift
@@ -1,0 +1,120 @@
+//
+//  BottleLocationValidation.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Pre-flight validation of a user-chosen bottle parent directory.
+///
+/// Run this *before* the bottle subdirectory is created and `wineboot`
+/// initializes the prefix, so an unusable location surfaces a clear, actionable
+/// error up front instead of a cryptic late Wine failure (issue #61).
+///
+/// Only the two checks that confidently and directly predict failure are
+/// enforced: whether the location can be written to (a probe write), and
+/// whether the volume has enough free space. Ownership is intentionally *not*
+/// checked — the bottle prefix is a freshly created subdirectory owned by the
+/// current user regardless of the parent's owner, so the probe write is the
+/// accurate predictor of whether creation will succeed.
+public enum BottleLocationValidation {
+    /// The outcome of validating a prospective bottle location.
+    public enum ValidationResult: Equatable, Sendable {
+        /// The location is usable.
+        case valid
+        /// Neither the location nor its nearest existing parent can be written to.
+        case notWritable(path: String)
+        /// The volume does not have enough free space to create a bottle.
+        case insufficientSpace(availableBytes: Int64, requiredBytes: Int64)
+    }
+
+    /// Minimum free space required to create a bottle. A bare prefix is well
+    /// under 1 GiB; the floor leaves headroom and refuses near-full disks where
+    /// prefix initialization would otherwise fail partway.
+    public static let minimumFreeBytes: Int64 = 2 << 30 // 2 GiB
+
+    /// Validates a prospective bottle parent directory.
+    ///
+    /// - Parameters:
+    ///   - url: The parent directory the user chose (the bottle itself is a
+    ///     not-yet-created subdirectory of this).
+    ///   - minimumFreeBytes: The free-space floor to require. Injectable for tests.
+    ///   - fileManager: The file manager to probe with. Injectable for tests.
+    /// - Returns: ``ValidationResult/valid`` if the location is usable, otherwise
+    ///   the specific reason it is not.
+    public static func validate(
+        at url: URL,
+        minimumFreeBytes: Int64 = BottleLocationValidation.minimumFreeBytes,
+        fileManager: FileManager = .default
+    ) -> ValidationResult {
+        let ancestor = nearestExistingDirectory(for: url, fileManager: fileManager)
+
+        guard isWritable(ancestor, fileManager: fileManager) else {
+            return .notWritable(path: url.path(percentEncoded: false))
+        }
+
+        // Skip the space check (fail open) if capacity can't be read, rather
+        // than blocking creation over an unreadable volume.
+        if let available = availableCapacity(at: ancestor), available < minimumFreeBytes {
+            return .insufficientSpace(availableBytes: available, requiredBytes: minimumFreeBytes)
+        }
+
+        return .valid
+    }
+
+    /// Walks up from `url` to the first existing directory, so writability and
+    /// capacity can be probed even when the chosen path does not exist yet.
+    static func nearestExistingDirectory(for url: URL, fileManager: FileManager) -> URL {
+        var candidate = url.resolvingSymlinksInPath()
+        while !fileManager.fileExists(atPath: candidate.path(percentEncoded: false)) {
+            let parent = candidate.deletingLastPathComponent()
+            // `deletingLastPathComponent()` on "/" returns "/"; stop at the root
+            // rather than looping forever.
+            if parent.path(percentEncoded: false) == candidate.path(percentEncoded: false) {
+                break
+            }
+            candidate = parent
+        }
+        return candidate
+    }
+
+    /// Probes writability by creating and removing a unique temp file.
+    ///
+    /// `FileManager.isWritableFile(atPath:)` and the `isWritable` resource key
+    /// are documented as unreliable on modern macOS, so an attempt-and-clean
+    /// probe is used instead.
+    private static func isWritable(_ directory: URL, fileManager: FileManager) -> Bool {
+        let probe = directory.appendingPathComponent(".whisky-write-probe-\(UUID().uuidString)")
+        guard fileManager.createFile(atPath: probe.path(percentEncoded: false), contents: nil) else {
+            return false
+        }
+        try? fileManager.removeItem(at: probe)
+        return true
+    }
+
+    /// Reads available capacity, preferring the "important usage" figure (which
+    /// counts purgeable space, so it errs optimistic and won't false-positive).
+    private static func availableCapacity(at directory: URL) -> Int64? {
+        let keys: Set<URLResourceKey> = [
+            .volumeAvailableCapacityForImportantUsageKey,
+            .volumeAvailableCapacityKey
+        ]
+        guard let values = try? directory.resourceValues(forKeys: keys) else { return nil }
+        if let important = values.volumeAvailableCapacityForImportantUsage { return important }
+        if let basic = values.volumeAvailableCapacity { return Int64(basic) }
+        return nil
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -22,6 +22,20 @@ import SemanticVersion
 
 private let logger = Logger(subsystem: Bundle.whiskyBundleIdentifier, category: "WhiskyWineInstaller")
 
+/// Errors thrown by ``WhiskyWineInstaller/install(from:)``.
+public enum WhiskyWineInstallError: LocalizedError, Equatable {
+    /// The downloaded tarball was not found at the expected path — typically the
+    /// OS purged the temporary download before installation ran.
+    case tarballNotFound
+
+    public var errorDescription: String? {
+        switch self {
+        case .tarballNotFound:
+            String(localized: "setup.whiskywine.error.tarballMissing")
+        }
+    }
+}
+
 /// Manages the installation and updates of the WhiskyWine runtime.
 ///
 /// `WhiskyWineInstaller` handles downloading, installing, and managing the
@@ -49,7 +63,11 @@ private let logger = Logger(subsystem: Bundle.whiskyBundleIdentifier, category: 
 ///
 /// ```swift
 /// // After downloading the tarball
-/// WhiskyWineInstaller.install(from: downloadedTarballURL)
+/// do {
+///     try WhiskyWineInstaller.install(from: downloadedTarballURL)
+/// } catch {
+///     // Surface the failure cause to the user
+/// }
 /// ```
 ///
 /// ## Topics
@@ -100,29 +118,32 @@ public class WhiskyWineInstaller {
     /// - Parameter from: The URL to the downloaded tarball file.
     /// - Note: The tarball is NOT deleted after extraction. Call ``cleanupTarball(at:)``
     ///   after verifying installation success with ``isWhiskyWineInstalled()``.
+    /// - Throws: ``WhiskyWineInstallError/tarballNotFound`` if the tarball is gone,
+    ///   or a `TarError`/`CocoaError` if extraction or the destination rebuild fails.
+    ///   The cause propagates so callers can surface the specific reason.
     ///
     /// - Important: Ensure the tarball is from a trusted source.
-    public static func install(from: URL) {
-        do {
-            // Verify tarball exists before modifying application folder.
-            // This prevents data loss if the OS has cleaned up the temp file.
-            guard FileManager.default.fileExists(atPath: from.path) else {
-                logger.error("Tarball not found at \(from.path) - cannot install")
-                return
-            }
+    public static func install(from: URL) throws {
+        try install(tarball: from, into: applicationFolder)
+    }
 
-            if !FileManager.default.fileExists(atPath: applicationFolder.path) {
-                try FileManager.default.createDirectory(at: applicationFolder, withIntermediateDirectories: true)
-            } else {
-                // Recreate it
-                try FileManager.default.removeItem(at: applicationFolder)
-                try FileManager.default.createDirectory(at: applicationFolder, withIntermediateDirectories: true)
-            }
-
-            try Tar.untar(tarBall: from, toURL: applicationFolder)
-        } catch {
-            logger.error("Failed to install WhiskyWine: \(error.localizedDescription)")
+    /// Extracts a WhiskyWine tarball into `destination`, replacing any existing
+    /// contents. Factored out of ``install(from:)`` so extraction can be tested
+    /// against a temporary directory without touching the real application
+    /// support folder.
+    static func install(tarball: URL, into destination: URL) throws {
+        // Verify the tarball exists before modifying the destination, so a
+        // purged temp file can't leave the destination half-rebuilt.
+        guard FileManager.default.fileExists(atPath: tarball.path) else {
+            throw WhiskyWineInstallError.tarballNotFound
         }
+
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+
+        try Tar.untar(tarBall: tarball, toURL: destination)
     }
 
     /// Removes the installation tarball after successful installation.

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleLocationValidationTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleLocationValidationTests.swift
@@ -1,0 +1,74 @@
+//
+//  BottleLocationValidationTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+final class BottleLocationValidationTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir {
+            // Restore writability before removal in case a test made it read-only.
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: tempDir.path)
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+    }
+
+    func testValidForWritableDirectoryWithSpace() {
+        XCTAssertEqual(BottleLocationValidation.validate(at: tempDir, minimumFreeBytes: 0), .valid)
+    }
+
+    func testValidForNonexistentSubdirectoryOfWritableParent() {
+        // Mirrors first-run: the chosen parent (e.g. .../Bottles) doesn't exist
+        // yet, so the validator must probe the nearest existing ancestor.
+        let subdir = tempDir.appendingPathComponent("Bottles")
+        XCTAssertEqual(BottleLocationValidation.validate(at: subdir, minimumFreeBytes: 0), .valid)
+    }
+
+    func testNotWritableForReadOnlyDirectory() throws {
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: tempDir.path)
+        let target = tempDir.appendingPathComponent("bottle")
+
+        guard case .notWritable = BottleLocationValidation.validate(at: target, minimumFreeBytes: 0) else {
+            return XCTFail("Expected .notWritable for a read-only directory")
+        }
+    }
+
+    func testInsufficientSpaceWhenFloorExceedsCapacity() {
+        let result = BottleLocationValidation.validate(at: tempDir, minimumFreeBytes: .max)
+
+        guard case let .insufficientSpace(available, required) = result else {
+            return XCTFail("Expected .insufficientSpace, got \(result)")
+        }
+        XCTAssertEqual(required, .max)
+        XCTAssertGreaterThanOrEqual(available, 0)
+    }
+
+    func testNearestExistingDirectoryWalksUpToFirstExistingParent() {
+        let deep = tempDir.appendingPathComponent("a/b/c")
+        let nearest = BottleLocationValidation.nearestExistingDirectory(for: deep, fileManager: .default)
+        XCTAssertEqual(nearest.path, tempDir.resolvingSymlinksInPath().path)
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleLocationValidationTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleLocationValidationTests.swift
@@ -51,8 +51,23 @@ final class BottleLocationValidationTests: XCTestCase {
         try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: tempDir.path)
         let target = tempDir.appendingPathComponent("bottle")
 
-        guard case .notWritable = BottleLocationValidation.validate(at: target, minimumFreeBytes: 0) else {
+        // The carried path must be the original target the user chose (it is
+        // shown to them), not the nearest existing ancestor that was probed.
+        guard case let .notWritable(path) = BottleLocationValidation.validate(at: target, minimumFreeBytes: 0) else {
             return XCTFail("Expected .notWritable for a read-only directory")
+        }
+        XCTAssertEqual(path, target.path(percentEncoded: false))
+    }
+
+    func testNotWritableWhenNearestAncestorIsRegularFile() throws {
+        // If the walk-up lands on a regular file (a malformed location), the
+        // probe write fails and the result is .notWritable rather than a crash.
+        let file = tempDir.appendingPathComponent("not-a-directory")
+        try Data("x".utf8).write(to: file)
+        let target = file.appendingPathComponent("bottle")
+
+        guard case .notWritable = BottleLocationValidation.validate(at: target, minimumFreeBytes: 0) else {
+            return XCTFail("Expected .notWritable when the nearest ancestor is a regular file")
         }
     }
 

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -122,4 +122,58 @@ final class WhiskyWineInstallerTests: XCTestCase {
 
         XCTAssertNil(WhiskyWineInstaller.whiskyWineInfo(at: partialURL))
     }
+
+    // MARK: - install(from:) error propagation
+
+    func testInstallThrowsWhenTarballMissing() {
+        // The guard runs before the destination is touched, so this is safe to
+        // exercise against the real application folder.
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("tar.gz")
+
+        XCTAssertThrowsError(try WhiskyWineInstaller.install(from: missing)) { error in
+            XCTAssertEqual(error as? WhiskyWineInstallError, .tarballNotFound)
+        }
+    }
+
+    func testInstallThrowsOnInvalidArchive() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // A non-tar payload makes the extraction fail; `into:` keeps it off the
+        // real application folder.
+        let badTarball = tempDir.appendingPathComponent("bad").appendingPathExtension("tar.gz")
+        try Data("not a tarball".utf8).write(to: badTarball)
+        let destination = tempDir.appendingPathComponent("dest")
+
+        XCTAssertThrowsError(try WhiskyWineInstaller.install(tarball: badTarball, into: destination))
+    }
+
+    func testInstallExtractsValidArchiveIntoDestination() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Build a tiny source tree and gzip-tar it the way the runtime archive ships.
+        let sourceDir = tempDir.appendingPathComponent("Libraries")
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try Data("marker".utf8).write(to: sourceDir.appendingPathComponent("marker.txt"))
+
+        let tarball = tempDir.appendingPathComponent("archive").appendingPathExtension("tar.gz")
+        let tar = Process()
+        tar.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        tar.currentDirectoryURL = tempDir
+        tar.arguments = ["-czf", tarball.path, "Libraries"]
+        try tar.run()
+        tar.waitUntilExit()
+        try XCTSkipUnless(tar.terminationStatus == 0, "Could not build the tar fixture")
+
+        let destination = tempDir.appendingPathComponent("dest")
+        try WhiskyWineInstaller.install(tarball: tarball, into: destination)
+
+        let extracted = destination.appendingPathComponent("Libraries/marker.txt")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: extracted.path))
+    }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -176,4 +176,39 @@ final class WhiskyWineInstallerTests: XCTestCase {
         let extracted = destination.appendingPathComponent("Libraries/marker.txt")
         XCTAssertTrue(FileManager.default.fileExists(atPath: extracted.path))
     }
+
+    func testInstallReplacesExistingDestinationContents() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let sourceDir = tempDir.appendingPathComponent("Libraries")
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try Data("marker".utf8).write(to: sourceDir.appendingPathComponent("marker.txt"))
+
+        let tarball = tempDir.appendingPathComponent("archive").appendingPathExtension("tar.gz")
+        let tar = Process()
+        tar.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        tar.currentDirectoryURL = tempDir
+        tar.arguments = ["-czf", tarball.path, "Libraries"]
+        try tar.run()
+        tar.waitUntilExit()
+        try XCTSkipUnless(tar.terminationStatus == 0, "Could not build the tar fixture")
+
+        // Pre-existing install with a stale file that the rebuild must remove,
+        // rather than merging the new contents on top of it.
+        let destination = tempDir.appendingPathComponent("dest")
+        let stale = destination.appendingPathComponent("Libraries/stale.txt")
+        try FileManager.default.createDirectory(
+            at: stale.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("stale".utf8).write(to: stale)
+
+        try WhiskyWineInstaller.install(tarball: tarball, into: destination)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stale.path), "Stale contents should be removed")
+        let extracted = destination.appendingPathComponent("Libraries/marker.txt")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: extracted.path))
+    }
 }


### PR DESCRIPTION
Two related first-run robustness fixes — both turn a silent/cryptic failure into a clear, actionable one.

## A. Bottle-location pre-flight

`BottleVM.createBottleTask` now validates the chosen parent location **before** creating anything or running `wineboot`. A new pure, testable `BottleLocationValidation` (WhiskyKit) checks the two conditions that confidently and directly predict failure:

- **Writability** — a probe write on the nearest existing ancestor (`isWritableFile` is documented-unreliable on modern macOS).
- **Free space** — a 2 GiB floor using `volumeAvailableCapacityForImportantUsageKey`.

On failure the user gets a specific localized message up front (e.g. "Whisky can't write to the folder you chose (…). Pick a folder you can modify…") instead of the bottle silently vanishing after a `wine: '…' is not owned by you` failure.

**Deliberately *not* hard-blocked** (kept simple and false-positive-free):
- *Ownership* — the bottle prefix is a freshly created UUID subdirectory owned by the current user regardless of the parent's owner, so `wineboot`'s `st_uid == getuid()` check passes in the normal flow; the probe write is the accurate predictor, and blocking on parent ownership would false-positive a world-writable parent (e.g. `/tmp`) where creation actually succeeds.
- *Network / iCloud* — WARN-class, can't be reliably detected before the path exists, and there's no warn-and-continue UI; blocking risks a worse regression than the bug.

This is a pre-flight follow-up to the bottle-creation diagnostics already shipped for #61 (which is closed) — not a re-close of that issue.

## B. Runtime install error propagation

`WhiskyWineInstaller.install(from:)` now **throws** instead of swallowing its error. A new internal `install(tarball:into:)` makes extraction testable against a temp directory without touching the real application-support folder, and a new `WhiskyWineInstallError.tarballNotFound` distinguishes a purged download from an extraction failure. The setup screen now shows the **specific** cause (missing tarball / disk full / extraction failure) and records it in the diagnostics report, replacing the generic "installation failed". Install + post-install verification both run off the main actor.

## Tests & housekeeping

- New `BottleLocationValidationTests` (valid, non-existent subdir, read-only dir with path assertion, regular-file ancestor, insufficient space, ancestor walk-up).
- New `WhiskyWineInstallerTests` for the throwing paths, a valid-archive extraction, and a destination-rebuild (stale contents removed, not merged).
- 4 localized keys added (the WhiskyKit-emitted one marked `extractionState: manual`); DocC + class-doc examples updated for the throwing signature; CHANGELOG `[Unreleased]`.
- Full suite green (977 WhiskyKit tests); app builds; SwiftFormat + SwiftLint `--strict` clean.

## Note

`install(from:)` gaining `throws` is a source-breaking change for any external WhiskyKit consumer; the only in-repo caller (the setup view) is updated.

## Review

Built understand → design → implement → adversarial-review (5 dimensions, each finding independently refuted/confirmed); the 4 confirmed findings are folded into this branch.