### PR TITLE
fix: require wine64 on disk to consider the runtime installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   propagates the underlying error (missing tarball, disk full, archive
   extraction failure) instead of swallowing it, so the setup screen shows the
   specific reason and the diagnostics report captures it.
+- A half-installed Wine runtime is no longer mistaken for a working one. The
+  install check now requires the `wine64` binary on disk, not just the version
+  file, so a partial extraction or removal prompts a clean re-install instead of
+  leaving every bottle to fail with cryptic Wine errors.
 
 ### Documentation
 - Landing page (`frankea.github.io/Whisky`) now shows app screenshots, adds an

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -104,11 +104,29 @@ public class WhiskyWineInstaller {
     /// This folder contains `wine64`, `wineserver`, and other Wine executables.
     public static let binFolder: URL = libraryFolder.appending(path: "Wine").appending(path: "bin")
 
-    /// Checks whether WhiskyWine is currently installed.
+    /// Checks whether WhiskyWine is currently installed and usable.
     ///
-    /// - Returns: `true` if WhiskyWine is installed and has a valid version file.
+    /// Requires both a readable version plist *and* the `wine64` binary on disk:
+    /// a half-extracted or partially-removed runtime can leave the plist behind
+    /// without the binary, and reporting that as "installed" makes every bottle
+    /// fail confusingly instead of prompting a re-install.
+    ///
+    /// - Returns: `true` only if the runtime is present and runnable.
     public static func isWhiskyWineInstalled() -> Bool {
-        whiskyWineVersion() != nil
+        isRuntimePresent(inLibraryFolder: libraryFolder)
+    }
+
+    /// Whether a usable runtime exists under `folder` — both the version plist
+    /// and the `wine64` binary the app actually executes. Factored out of
+    /// ``isWhiskyWineInstalled()`` so it can be tested against a temp directory.
+    static func isRuntimePresent(inLibraryFolder folder: URL) -> Bool {
+        let versionPlist = folder.appending(path: "WhiskyWineVersion").appendingPathExtension("plist")
+        guard whiskyWineInfo(at: versionPlist) != nil else { return false }
+
+        // Mirrors `Wine.wineBinary` (binFolder/wine64), the executable used to
+        // launch every program — if it's missing the runtime isn't usable.
+        let wineBinary = folder.appending(path: "Wine").appending(path: "bin").appending(path: "wine64")
+        return FileManager.default.fileExists(atPath: wineBinary.path(percentEncoded: false))
     }
 
     /// Installs WhiskyWine from a downloaded tarball.

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -124,6 +124,55 @@ final class WhiskyWineInstallerTests: XCTestCase {
         XCTAssertNil(WhiskyWineInstaller.whiskyWineInfo(at: partialURL))
     }
 
+    // MARK: - isRuntimePresent (plist + wine64)
+
+    /// Builds a runtime tree under `folder` with an optional version plist and an
+    /// optional `wine64` binary, mirroring the layout the installer extracts.
+    private func makeRuntime(in folder: URL, plist: Bool, wine64: Bool) throws {
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        if plist {
+            let plistURL = folder.appending(path: "WhiskyWineVersion").appendingPathExtension("plist")
+            let contents: [String: Any] = ["version": ["major": 3, "minor": 0, "patch": 0]]
+            let data = try PropertyListSerialization.data(fromPropertyList: contents, format: .xml, options: 0)
+            try data.write(to: plistURL)
+        }
+        if wine64 {
+            let binDir = folder.appending(path: "Wine").appending(path: "bin")
+            try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+            try Data("#!/bin/sh\n".utf8).write(to: binDir.appending(path: "wine64"))
+        }
+    }
+
+    func testRuntimePresentWhenPlistAndBinaryExist() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try makeRuntime(in: tempDir, plist: true, wine64: true)
+
+        XCTAssertTrue(WhiskyWineInstaller.isRuntimePresent(inLibraryFolder: tempDir))
+    }
+
+    func testRuntimeNotPresentWhenBinaryMissing() throws {
+        // The #63 case: a half-extracted runtime keeps the plist but loses wine64.
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try makeRuntime(in: tempDir, plist: true, wine64: false)
+
+        XCTAssertFalse(WhiskyWineInstaller.isRuntimePresent(inLibraryFolder: tempDir))
+    }
+
+    func testRuntimeNotPresentWhenPlistMissing() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try makeRuntime(in: tempDir, plist: false, wine64: true)
+
+        XCTAssertFalse(WhiskyWineInstaller.isRuntimePresent(inLibraryFolder: tempDir))
+    }
+
+    func testRuntimeNotPresentWhenFolderEmpty() {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        XCTAssertFalse(WhiskyWineInstaller.isRuntimePresent(inLibraryFolder: tempDir))
+    }
+
     // MARK: - install(from:) error propagation
 
     func testInstallThrowsWhenTarballMissing() {


### PR DESCRIPTION
## What

`WhiskyWineInstaller.isWhiskyWineInstalled()` only checked for the version plist (`whiskyWineVersion() != nil`). A half-extracted or partially-removed runtime can leave the plist behind without the `wine64` binary — and the app then reports "installed" while every bottle fails with cryptic Wine errors (no clear path to recovery).

The check now requires **both** the version plist **and** the `wine64` binary on disk, so a broken runtime prompts a clean re-install instead.

## Why

Completes the first-run robustness theme of the recently merged integrity check (#94) and bottle-location pre-flight (#95), and closes the "wine64 missing / detection mismatch" symptom called out for #63.

## How

- Extracted a testable `isRuntimePresent(inLibraryFolder:)` (mirrors the pattern used for `install(tarball:into:)`) that requires the plist *and* `binFolder/wine64` — the exact binary `Wine.wineBinary` executes to launch every program (verified against the real `v3.0.0` runtime layout: `Libraries/Wine/bin/wine64`).
- `isWhiskyWineInstalled()` routes through it. The version-comparison paths (`shouldUpdateWhiskyWine`, etc.) call `whiskyWineVersion()` directly and are unaffected.

## Tests

Four cases on `isRuntimePresent`: plist + binary → present; plist-only (the #63 case) → absent; binary-only → absent; empty → absent. Full WhiskyKit suite green; app builds; SwiftLint `--strict` + SwiftFormat clean.

## Safety note

No false-bricking of healthy installs: the checked path (`binFolder/wine64`) is exactly what the app already executes and exactly what the runtime tarball ships, so a valid install always satisfies it.