### PR TITLE
chore: localize bottle-creation errors; drop dead alert title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   propagates the underlying error (missing tarball, disk full, archive
   extraction failure) instead of swallowing it, so the setup screen shows the
   specific reason and the diagnostics report captures it.
+- Bottle-creation error messages are now localizable instead of English-only,
+  so non-English users see translated text when creation fails.
 
 ### Documentation
 - Landing page (`frankea.github.io/Whisky`) now shows app screenshots, adds an

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -793,6 +793,46 @@
         }
       }
     },
+    "bottle.creation.error.directoryCreationFailed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to create the bottle directory."
+          }
+        }
+      }
+    },
+    "bottle.creation.error.metadataCreationFailed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to create the bottle metadata."
+          }
+        }
+      }
+    },
+    "bottle.creation.error.persistenceSaveFailed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to save the bottle."
+          }
+        }
+      }
+    },
+    "bottle.creation.error.wineVersionChangeFailed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to configure the Windows version."
+          }
+        }
+      }
+    },
     "bottle.creation.failed.copyDiagnostics": {
       "localizations": {
         "en": {

--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -36,13 +36,13 @@ enum BottleCreationError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .directoryCreationFailed:
-            "Failed to create bottle directory"
+            String(localized: "bottle.creation.error.directoryCreationFailed")
         case .metadataCreationFailed:
-            "Failed to create bottle metadata"
+            String(localized: "bottle.creation.error.metadataCreationFailed")
         case .wineVersionChangeFailed:
-            "Failed to configure Windows version"
+            String(localized: "bottle.creation.error.wineVersionChangeFailed")
         case .persistenceSaveFailed:
-            "Failed to save bottle to persistence"
+            String(localized: "bottle.creation.error.persistenceSaveFailed")
         case let .locationUnsuitable(message):
             message
         }
@@ -64,7 +64,6 @@ final class BottleVM: ObservableObject {
 
     struct BottleCreationAlert: Identifiable {
         let id = UUID()
-        let title: String
         let message: String
         let diagnostics: String
     }
@@ -185,7 +184,6 @@ final class BottleVM: ObservableObject {
         bottleVMLogger.error("Failed to create new bottle: \(message)")
         bottleVMLogger.error("\(diagnostics, privacy: .public)")
         bottleCreationAlert = BottleCreationAlert(
-            title: "Bottle Creation Failed",
             message: message,
             diagnostics: diagnostics
         )


### PR DESCRIPTION
Small cleanups flagged during the recent reviews.

## Localize bottle-creation errors
The four `BottleCreationError` cases (`directoryCreationFailed`, `metadataCreationFailed`, `wineVersionChangeFailed`, `persistenceSaveFailed`) returned hardcoded English string literals — the only un-localized user-facing strings in the bottle-creation flow. They now resolve through `String(localized: "bottle.creation.error.*")` with catalog entries, so Crowdin can translate them. (Reworded slightly into proper sentences while at it — e.g. "Failed to save bottle to persistence" → "Failed to save the bottle.")

## Remove the dead alert title
`BottleCreationAlert.title` was always set to the hardcoded English `"Bottle Creation Failed"`, but nothing read it — `ContentView`'s `.alert` uses the `bottle.creation.failed.title` localization key directly. Removed the field and its assignment.

## Verification
App builds; SwiftLint `--strict` + SwiftFormat clean; catalog validates. No behavior change beyond the now-translatable error text.