### PR TITLE
docs: add distribution & discoverability playbook

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -54,7 +54,7 @@ The macOS-gaming audience lives in a few places. Seeding them is the cheapest re
 ## 4. Lower the switching cost
 
 - One-click **File → Migrate from the Original Whisky** imports the original app's bottles in place
-  (landing in PR #84 — confirm it's merged to `main` before citing it as shipped in a launch post).
+  (shipped in 3.1.0).
 - Lead with that in any launch post — "keep your existing bottles, one click" is the message that
   converts archived-app users.
 


### PR DESCRIPTION
Adds `docs/DISTRIBUTION.md` — a concrete, ready-to-run playbook for the discoverability gap (someone googling "Whisky mac" lands on the archived original, not this fork). Covers:

- **Homebrew** (highest leverage): the realistic successor-pointer asks against homebrew-cask, easiest first (a `caveats` pointer → repoint → `disable!`).
- **Search & domain**: custom domain + the single highest-value backlink (a pointer from the archived org / getwhisky.app).
- **Community seeding**: AppleGamingWiki, r/macgaming, a support Discord.
- **Lowering switching cost**: lead with the one-click migration wizard (shipped in 3.1.0).
- **Out of scope**: App Store (Wine needs JIT + unsandboxed access).

A maintainer-facing strategy doc (like `DEPENDENCIES.md`/`GOVERNANCE.md`), so no CHANGELOG entry.

> Note: the other parts of the original "project-polish" branch this came from — the affiliate-link honesty fix, orphaned macOS-14 strings, FUNDING/SECURITY docs — are already on `main` (merged via #83 and others), so this PR is just the new playbook.