### PR TITLE
test: stabilize the create-bottle UITest

### DIFF
--- a/Whisky/Views/ContentView.swift
+++ b/Whisky/Views/ContentView.swift
@@ -157,6 +157,11 @@ struct ContentView: View {
                 }
             }
 
+            // Skip the first-launch setup sheet and update check under UI testing:
+            // tests run without a runtime, so this would otherwise drop a modal
+            // sheet over the main window and race every toolbar interaction.
+            guard !WhiskyApp.isUITesting else { return }
+
             if !WhiskyWineInstaller.isWhiskyWineInstalled() {
                 showSetup = true
             }

--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -27,6 +27,13 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.fran
 @main
 // swiftlint:disable:next type_body_length
 struct WhiskyApp: App {
+    /// True when launched by the UI test harness (the `-WhiskyUITestMode` launch
+    /// argument set in `WhiskyUITests`). UI tests run without a Wine runtime
+    /// installed, which would otherwise auto-present the first-launch setup sheet
+    /// over the main window and race every toolbar interaction; this lets that
+    /// auto-presentation (and the update check) be skipped in tests.
+    static let isUITesting = ProcessInfo.processInfo.arguments.contains("-WhiskyUITestMode")
+
     @State var showSetup: Bool = false
     @State private var showMigrate: Bool = false
     @State private var showDiagnosticsSheet: Bool = false

--- a/WhiskyUITests/WhiskyUITests.swift
+++ b/WhiskyUITests/WhiskyUITests.swift
@@ -27,6 +27,9 @@ final class WhiskyUITests: XCTestCase {
         app = XCUIApplication()
         app.launchArguments += ["-WhiskyUITestMode", "1"]
         app.launch()
+        // Frontmost before interacting: a non-key window makes toolbar elements
+        // unhittable — the usual source of "element missing" flakiness.
+        app.activate()
     }
 
     override func tearDownWithError() throws {
@@ -51,6 +54,28 @@ final class WhiskyUITests: XCTestCase {
             line: line
         )
         return element
+    }
+
+    /// Wait up to `timeout` for an element to become *hittable* (interactive),
+    /// not merely present — a click before a control is hittable silently no-ops.
+    @discardableResult
+    private func waitUntilHittable(
+        _ element: XCUIElement,
+        _ description: String,
+        timeout: TimeInterval = 5,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Bool {
+        let predicate = NSPredicate(format: "isHittable == true")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        XCTAssertEqual(
+            result, .completed,
+            "Element never became hittable: \(description)",
+            file: file,
+            line: line
+        )
+        return result == .completed
     }
 
     /// Walk every visible static text label and return any that look like raw localization keys.
@@ -327,22 +352,27 @@ final class WhiskyUITests: XCTestCase {
         // same identifier. Click the first match, which is the hittable wrapper.
         let createButton = require(
             app.buttons.matching(identifier: "toolbar.createBottle").firstMatch,
-            "+ toolbar button", timeout: 5
+            "+ toolbar button", timeout: 10
         )
-        createButton.click()
 
-        // Wait for the sheet to materialize before querying its inner controls.
-        // The sheet's Cancel toolbar button is the most reliable signal that the
-        // sheet has fully rendered; SwiftUI Form-rendered TextFields can lag the
-        // AX tree by a beat on slow CI runners, so probing for the name field
-        // first races the sheet animation.
-        require(app.buttons["create.cancelButton"], "create-bottle sheet", timeout: 5)
+        // Opening the sheet is the historically flaky step (a click before the
+        // button is hittable, or the Form sheet lagging the AX tree). Wait for
+        // hittable, click, wait generously, and retry the click once — guarded on
+        // the button still being hittable so we never click behind an open sheet.
+        waitUntilHittable(createButton, "+ toolbar button", timeout: 10)
+        let cancelButton = app.buttons["create.cancelButton"]
+        createButton.click()
+        if !cancelButton.waitForExistence(timeout: 15) {
+            if createButton.isHittable {
+                createButton.click()
+            }
+            require(cancelButton, "create-bottle sheet", timeout: 15)
+        }
 
         let nameField = require(
             app.textFields["create.nameField"],
             "create-bottle name field"
         )
-        XCTAssertTrue(app.buttons["create.cancelButton"].exists, "Cancel button missing")
         // Create button should start disabled (empty name)
         XCTAssertFalse(
             app.buttons["create.createButton"].isEnabled,


### PR DESCRIPTION
`testCreateBottleSheetOpensAndCancels` has been intermittently failing CI (it flaked the 3.1.0 release, and bit two PRs this cycle even *through* the 3-iteration retry). Root cause + three fixes:

## Root cause
On a runner with no Wine runtime installed, `ContentView.onAppear` auto-presents the first-launch **setup sheet** as a `.sheet` over the main window. That modal races every toolbar interaction — sometimes it's up when the test clicks the create-bottle button, so the click no-ops and the create-bottle sheet never opens → "create-bottle sheet missing". The `-WhiskyUITestMode` launch argument the test harness already passed (`setUp`) was **never read by the app**.

## Fixes (root cause first)
1. **App** — `WhiskyApp.isUITesting` reads `-WhiskyUITestMode`; `ContentView.onAppear` now skips the auto setup sheet + update check under UI testing, so the main window is unobstructed. Gated entirely on the launch arg, so production behavior is unchanged.
2. **Test setUp** — `app.activate()` so the window is key/frontmost before interaction.
3. **Test** — wait for the toolbar button to be *hittable* (not just present), wait generously for the sheet, and retry the click once (guarded so it never clicks behind an open sheet).

## Verification
Verified on CI rather than locally: a local container with a real runtime + bottles isn't a valid reproduction of the empty CI-runner state that triggers the flake. App + WhiskyKit build, SwiftLint `--strict` + SwiftFormat clean. I'll run the UITest job several times on this PR to confirm it's reliably green before recommending merge.

No user-facing change (the app behavior change is test-only, gated on the launch arg) — no CHANGELOG entry.