### PR TITLE
release: 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-06-10 (App)
+
 ### Added
 - The Wine runtime download is now verified against a published SHA-256 before
   installation. A corrupted or truncated download is caught and rejected with a

--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -1170,7 +1170,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Whisky/Preview Content\"";
 				DEVELOPMENT_TEAM = Z7JS58F8U3;
@@ -1188,7 +1188,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.franke.Whisky;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1208,7 +1208,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Whisky/Preview Content\"";
 				DEVELOPMENT_TEAM = Z7JS58F8U3;
@@ -1226,7 +1226,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.franke.Whisky;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1294,7 +1294,7 @@
 				CODE_SIGN_ENTITLEMENTS = WhiskyThumbnail/WhiskyThumbnail.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = Z7JS58F8U3;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1310,7 +1310,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.franke.Whisky.WhiskyThumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1329,7 +1329,7 @@
 				CODE_SIGN_ENTITLEMENTS = WhiskyThumbnail/WhiskyThumbnail.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = Z7JS58F8U3;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1345,7 +1345,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.franke.Whisky.WhiskyThumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Version bump + changelog cut for **3.2.0**. This is the prep PR; the DMG build/sign/notarize and the appcast entry follow separately (they need the signed artifact + `sign_update` signature).

## Changes
- `MARKETING_VERSION` 3.1.0 → **3.2.0** (4×) and `CURRENT_PROJECT_VERSION` 46 → **47** (the Sparkle build number; 3.1.0 was 46, 3.0.1 was 45).
- Moved the `[Unreleased]` entries into a new `## [3.2.0] - 2026-06-10 (App)` section.

Verified: the built app reports `CFBundleShortVersionString 3.2.0` / `CFBundleVersion 47`; project file lints OK; app builds; SwiftLint/SwiftFormat clean.

## 3.2.0 contents
- **Added** — SHA-256 verification of the Wine runtime download.
- **Fixed** — bottle-location pre-flight; install-failure cause surfacing; wine64-on-disk install check; localizable bottle-creation errors.
- **Documentation** — landing-page refresh; live Game Configurations links.

## Remaining release steps (after merge — your machine/certs)
1. `scripts/release.sh 3.2.0` → signed + notarized `Whisky-3.2.0.dmg`.
2. `sign_update build/release/Whisky-3.2.0.dmg` → capture `edSignature` + `length`.
3. Add the `dist/pages/appcast.xml` `<item>` for 3.2.0 (paste me the `sign_update` output and I'll do it), commit, push.
4. `git tag -a app-v3.2.0` + `gh release create app-v3.2.0 … Whisky-3.2.0.dmg`.

Runtime (`Libraries.tar.gz`) is unchanged — no Wine Libraries release.