### PR TITLE
fix: keep bottle settings loadable across versions and crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,8 @@ CLAUDE.md
 plans/
 .claude/
 mise.toml
+
+# Secrets — never stage signing keys or exported credentials
+sparkle_ed25519_private.key*
+developer_id.p12*
+*.age

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Bottle settings are now written atomically, so a crash mid-save can no longer
-  leave a truncated `Metadata.plist` that wipes the bottle's configuration.
+- Bottle and per-program settings are now written atomically, so a crash
+  mid-save can no longer leave a truncated settings file that wipes the
+  configuration.
 - Every persisted settings choice — graphics backend, performance and resolution
   presets, Windows version, launcher mode/type/locale and spoofed GPU vendor,
   audio driver/latency/output mode, clipboard and process-cleanup policies, and
@@ -17,11 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Whisky. A single unrecognized choice falls back to its default (per-program
   overrides fall back to inheriting the bottle's choice) instead of failing to
   load the entire bottle's settings.
-- An unreadable settings file is no longer silently overwritten. When a
-  `Metadata.plist` can't be decoded (corruption or an unexpected file version),
-  the original is moved aside to a `Metadata.plist.corrupt-<timestamp>` sibling
-  before defaults are written, so the unreadable data is preserved for recovery
-  rather than destroyed.
+- An unreadable settings file is no longer silently overwritten. When a bottle's
+  `Metadata.plist` or a program's settings plist can't be decoded (corruption or
+  an unexpected file version), the original is moved aside to a
+  `.corrupt-<timestamp>` sibling before defaults are written, so the unreadable
+  data is preserved for recovery rather than destroyed.
 
 ## [3.2.0] - 2026-06-10 (App)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Bottle settings are now written atomically, so a crash mid-save can no longer
   leave a truncated `Metadata.plist` that wipes the bottle's configuration.
-- A bottle, per-program override, or game-database entry that names a graphics
-  backend (or performance/resolution preset) this build doesn't recognize — for
-  example, one written by a newer Whisky — no longer fails to load the settings
-  entirely. The bottle's own backend falls back to the recommended backend;
-  per-program overrides and game-database entries fall back to inheriting the
-  bottle's choice.
+- Every persisted settings choice — graphics backend, performance and resolution
+  presets, Windows version, launcher mode/type/locale and spoofed GPU vendor,
+  audio driver/latency/output mode, clipboard and process-cleanup policies, and
+  the per-program equivalents — now tolerates an unknown value written by a newer
+  Whisky. A single unrecognized choice falls back to its default (per-program
+  overrides fall back to inheriting the bottle's choice) instead of failing to
+  load the entire bottle's settings.
+- An unreadable settings file is no longer silently overwritten. When a
+  `Metadata.plist` can't be decoded (corruption or an unexpected file version),
+  the original is moved aside to a `Metadata.plist.corrupt-<timestamp>` sibling
+  before defaults are written, so the unreadable data is preserved for recovery
+  rather than destroyed.
 
 ## [3.2.0] - 2026-06-10 (App)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Bottle settings are now written atomically, so a crash or power loss mid-save
+  can no longer leave a truncated `Metadata.plist` that wipes the bottle's
+  configuration.
+- A bottle or per-program override that names a graphics backend this build
+  doesn't recognize (for example, one written by a newer Whisky) now falls back
+  to the recommended backend instead of failing to load the bottle's settings
+  entirely. Game-database entries behave the same way.
+
 ## [3.2.0] - 2026-06-10 (App)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Bottle settings are now written atomically, so a crash or power loss mid-save
-  can no longer leave a truncated `Metadata.plist` that wipes the bottle's
-  configuration.
-- A bottle or per-program override that names a graphics backend this build
-  doesn't recognize (for example, one written by a newer Whisky) now falls back
-  to the recommended backend instead of failing to load the bottle's settings
-  entirely. Game-database entries behave the same way.
+- Bottle settings are now written atomically, so a crash mid-save can no longer
+  leave a truncated `Metadata.plist` that wipes the bottle's configuration.
+- A bottle, per-program override, or game-database entry that names a graphics
+  backend (or performance/resolution preset) this build doesn't recognize — for
+  example, one written by a newer Whisky — no longer fails to load the settings
+  entirely. The bottle's own backend falls back to the recommended backend;
+  per-program overrides and game-database entries fall back to inheriting the
+  bottle's choice.
 
 ## [3.2.0] - 2026-06-10 (App)
 

--- a/WhiskyKit/Sources/WhiskyKit/GameDatabase/GameDBEntry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/GameDatabase/GameDBEntry.swift
@@ -226,7 +226,7 @@ public struct GameConfigVariantSettings: Codable, Sendable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.graphicsBackend = container.decodeGraphicsBackendIfPresent(forKey: .graphicsBackend)
+        self.graphicsBackend = container.decodeLenientIfPresent(GraphicsBackend.self, forKey: .graphicsBackend)
         self.dxvk = try container.decodeIfPresent(Bool.self, forKey: .dxvk)
         self.dxvkAsync = try container.decodeIfPresent(Bool.self, forKey: .dxvkAsync)
         // EnhancedSync uses Swift's auto-synthesized Codable (keyed enum, not String raw value).

--- a/WhiskyKit/Sources/WhiskyKit/GameDatabase/GameDBEntry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/GameDatabase/GameDBEntry.swift
@@ -226,7 +226,7 @@ public struct GameConfigVariantSettings: Codable, Sendable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.graphicsBackend = try container.decodeIfPresent(GraphicsBackend.self, forKey: .graphicsBackend)
+        self.graphicsBackend = container.decodeGraphicsBackendIfPresent(forKey: .graphicsBackend)
         self.dxvk = try container.decodeIfPresent(Bool.self, forKey: .dxvk)
         self.dxvkAsync = try container.decodeIfPresent(Bool.self, forKey: .dxvkAsync)
         // EnhancedSync uses Swift's auto-synthesized Codable (keyed enum, not String raw value).

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
@@ -145,7 +145,11 @@ public final class Bottle: ObservableObject, Equatable, Hashable, Identifiable, 
             self.settings = try BottleSettings.decode(from: metadataURL)
         } catch {
             Logger.wineKit.error(
-                "Failed to load settings for bottle `\(metadataURL.path(percentEncoded: false))`: \(error)"
+                """
+                Failed to load settings for bottle \
+                `\(metadataURL.path(percentEncoded: false), privacy: .public)`: \
+                \(String(describing: error), privacy: .public)
+                """
             )
             // Preserve the unreadable file before defaults overwrite it, so a corrupt
             // Metadata.plist is moved aside for diagnosis rather than silently destroyed.

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
@@ -147,6 +147,9 @@ public final class Bottle: ObservableObject, Equatable, Hashable, Identifiable, 
             Logger.wineKit.error(
                 "Failed to load settings for bottle `\(metadataURL.path(percentEncoded: false))`: \(error)"
             )
+            // Preserve the unreadable file before defaults overwrite it, so a corrupt
+            // Metadata.plist is moved aside for diagnosis rather than silently destroyed.
+            BottleSettings.quarantineCorruptedFile(at: metadataURL)
             // Create default settings if decode fails
             self.settings = BottleSettings()
             // Try to create the metadata file with default settings

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleAudioConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleAudioConfig.swift
@@ -141,13 +141,13 @@ public struct BottleAudioConfig: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.audioDriver = try container.decodeIfPresent(
+        self.audioDriver = container.decodeLenientIfPresent(
             AudioDriverMode.self, forKey: .audioDriver
         ) ?? .auto
-        self.latencyPreset = try container.decodeIfPresent(
+        self.latencyPreset = container.decodeLenientIfPresent(
             AudioLatencyPreset.self, forKey: .latencyPreset
         ) ?? .defaultPreset
-        self.outputDeviceMode = try container.decodeIfPresent(
+        self.outputDeviceMode = container.decodeLenientIfPresent(
             OutputDeviceMode.self, forKey: .outputDeviceMode
         ) ?? .followSystem
         self.pinnedDeviceName = try container.decodeIfPresent(

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleCleanupConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleCleanupConfig.swift
@@ -88,7 +88,7 @@ public struct BottleCleanupConfig: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.clipboardPolicy = try container.decodeIfPresent(
+        self.clipboardPolicy = container.decodeLenientIfPresent(
             ClipboardPolicy.self,
             forKey: .clipboardPolicy
         ) ?? .auto
@@ -96,11 +96,11 @@ public struct BottleCleanupConfig: Codable, Equatable {
             Int.self,
             forKey: .clipboardThreshold
         ) ?? ClipboardManager.largeContentThreshold
-        self.killOnQuit = try container.decodeIfPresent(
+        self.killOnQuit = container.decodeLenientIfPresent(
             KillOnQuitPolicy.self,
             forKey: .killOnQuit
         ) ?? .inherit
-        self.closeWithProcessesPolicy = try container.decodeIfPresent(
+        self.closeWithProcessesPolicy = container.decodeLenientIfPresent(
             CloseWithProcessesPolicy.self,
             forKey: .closeWithProcessesPolicy
         ) ?? .ask

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleDisplayConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleDisplayConfig.swift
@@ -106,7 +106,7 @@ public struct BottleDisplayConfig: Codable, Equatable {
         self.virtualDesktopEnabled = try container.decodeIfPresent(
             Bool.self, forKey: .virtualDesktopEnabled
         ) ?? false
-        self.resolutionPreset = try container.decodeIfPresent(
+        self.resolutionPreset = container.decodeLenientIfPresent(
             ResolutionPreset.self, forKey: .resolutionPreset
         ) ?? .r1920x1080
         self.customWidth = try container.decodeIfPresent(

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
@@ -62,6 +62,16 @@ public enum GraphicsBackend: String, Codable, CaseIterable, Equatable, Sendable 
     }
 }
 
+extension KeyedDecodingContainer {
+    /// Decodes a ``GraphicsBackend`` leniently: an unknown or malformed value becomes
+    /// `nil` instead of failing the parent decode, so settings written by a newer
+    /// Whisky (with backends this build doesn't know) still load.
+    func decodeGraphicsBackendIfPresent(forKey key: Key) -> GraphicsBackend? {
+        ((try? decodeIfPresent(String.self, forKey: key)) ?? nil)
+            .flatMap(GraphicsBackend.init(rawValue:))
+    }
+}
+
 /// Stores the graphics backend choice for a bottle.
 ///
 /// This config is serialized alongside other bottle config groups in
@@ -76,6 +86,6 @@ public struct BottleGraphicsConfig: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.backend = try container.decodeIfPresent(GraphicsBackend.self, forKey: .backend) ?? .recommended
+        self.backend = container.decodeGraphicsBackendIfPresent(forKey: .backend) ?? .recommended
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import os.log
 
 /// The graphics translation backend for a Wine bottle.
 ///
@@ -63,20 +64,45 @@ public enum GraphicsBackend: String, Codable, CaseIterable, Equatable, Sendable 
 }
 
 extension KeyedDecodingContainer {
-    /// Decodes a ``GraphicsBackend`` leniently: an unknown or malformed value becomes
-    /// `nil` instead of failing the parent decode, so settings written by a newer
-    /// Whisky (with backends this build doesn't know) still load.
-    func decodeGraphicsBackendIfPresent(forKey key: Key) -> GraphicsBackend? {
-        ((try? decodeIfPresent(String.self, forKey: key)) ?? nil)
-            .flatMap(GraphicsBackend.init(rawValue:))
+    /// Decodes a string-backed enum leniently: an absent key yields `nil`, and an
+    /// unknown or wrong-typed value also yields `nil` (logged) instead of throwing
+    /// out of the parent decode. This keeps settings written by a newer Whisky —
+    /// one that added an enum case this build doesn't know — loadable, instead of
+    /// a single unrecognized value bricking the whole bottle's settings.
+    ///
+    /// Only applies to `String`-raw-value enums; keyed-`Codable` enums
+    /// (e.g. `EnhancedSync`, `DXVKHUD`) are not covered and still decode strictly.
+    func decodeLenientIfPresent<T: RawRepresentable>(
+        _: T.Type,
+        forKey key: Key
+    ) -> T? where T.RawValue == String {
+        let raw: String?
+        do {
+            raw = try decodeIfPresent(String.self, forKey: key)
+        } catch {
+            Logger.wineKit.warning(
+                "Ignoring malformed \(String(describing: T.self)) at `\(key.stringValue, privacy: .public)`: \(error)"
+            )
+            return nil
+        }
+        guard let raw else { return nil }
+        guard let value = T(rawValue: raw) else {
+            Logger.wineKit.warning(
+                "Ignoring unknown \(String(describing: T.self)) value `\(raw, privacy: .public)`; using default"
+            )
+            return nil
+        }
+        return value
     }
 }
 
 /// Stores the graphics backend choice for a bottle.
 ///
 /// This config is serialized alongside other bottle config groups in
-/// ``BottleSettings``. The defensive `init(from:)` ensures unknown or
-/// corrupt values decode gracefully to `.recommended`.
+/// ``BottleSettings``. The defensive `init(from:)` decodes an unknown or
+/// malformed backend value gracefully to `.recommended` (via
+/// ``Swift/KeyedDecodingContainer/decodeLenientIfPresent(_:forKey:)``) rather
+/// than throwing out of the whole settings decode.
 public struct BottleGraphicsConfig: Codable, Equatable {
     /// The selected graphics backend. Defaults to `.recommended`.
     var backend: GraphicsBackend = .recommended
@@ -86,6 +112,6 @@ public struct BottleGraphicsConfig: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.backend = container.decodeGraphicsBackendIfPresent(forKey: .backend) ?? .recommended
+        self.backend = container.decodeLenientIfPresent(GraphicsBackend.self, forKey: .backend) ?? .recommended
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
@@ -108,7 +108,7 @@ extension KeyedDecodingContainer {
             // forward-compat (a newer Whisky added an enum case) — log at .warning.
             Logger.wineKit.warning(
                 """
-                Ignoring unknown \(typeName, privacy: .public) value `\(raw)` at \
+                Ignoring unknown \(typeName, privacy: .public) value `\(raw, privacy: .public)` at \
                 `\(key.stringValue, privacy: .public)` (path: \(path, privacy: .public)); using default
                 """
             )

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
@@ -76,19 +76,41 @@ extension KeyedDecodingContainer {
         _: T.Type,
         forKey key: Key
     ) -> T? where T.RawValue == String {
+        let typeName = String(describing: T.self)
+        let path = codingPath.map(\.stringValue).joined(separator: ".")
         let raw: String?
         do {
             raw = try decodeIfPresent(String.self, forKey: key)
+        } catch let error as DecodingError {
+            // A wrong-typed value (e.g. a number or object where a string was expected) is
+            // corruption — it cannot be produced by any real Whisky build — so log at .error.
+            Logger.wineKit.error(
+                """
+                Ignoring corrupt \(typeName, privacy: .public) at \
+                `\(key.stringValue, privacy: .public)` (path: \(path, privacy: .public)): \
+                \(String(describing: error), privacy: .public)
+                """
+            )
+            return nil
         } catch {
-            Logger.wineKit.warning(
-                "Ignoring malformed \(String(describing: T.self)) at `\(key.stringValue, privacy: .public)`: \(error)"
+            Logger.wineKit.error(
+                """
+                Ignoring malformed \(typeName, privacy: .public) at \
+                `\(key.stringValue, privacy: .public)` (path: \(path, privacy: .public)): \
+                \(String(describing: error), privacy: .public)
+                """
             )
             return nil
         }
         guard let raw else { return nil }
         guard let value = T(rawValue: raw) else {
+            // A well-formed string that this build doesn't recognize is legitimate
+            // forward-compat (a newer Whisky added an enum case) — log at .warning.
             Logger.wineKit.warning(
-                "Ignoring unknown \(String(describing: T.self)) value `\(raw, privacy: .public)`; using default"
+                """
+                Ignoring unknown \(typeName, privacy: .public) value `\(raw)` at \
+                `\(key.stringValue, privacy: .public)` (path: \(path, privacy: .public)); using default
+                """
             )
             return nil
         }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLauncherConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLauncherConfig.swift
@@ -91,11 +91,11 @@ public struct BottleLauncherConfig: Codable, Equatable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.compatibilityMode = try container.decodeIfPresent(Bool.self, forKey: .compatibilityMode) ?? false
-        self.launcherMode = try container.decodeIfPresent(LauncherMode.self, forKey: .launcherMode) ?? .auto
-        self.detectedLauncher = try container.decodeIfPresent(LauncherType.self, forKey: .detectedLauncher)
-        self.launcherLocale = try container.decodeIfPresent(Locales.self, forKey: .launcherLocale) ?? .auto
+        self.launcherMode = container.decodeLenientIfPresent(LauncherMode.self, forKey: .launcherMode) ?? .auto
+        self.detectedLauncher = container.decodeLenientIfPresent(LauncherType.self, forKey: .detectedLauncher)
+        self.launcherLocale = container.decodeLenientIfPresent(Locales.self, forKey: .launcherLocale) ?? .auto
         self.gpuSpoofing = try container.decodeIfPresent(Bool.self, forKey: .gpuSpoofing) ?? true
-        self.gpuVendor = try container.decodeIfPresent(GPUVendor.self, forKey: .gpuVendor) ?? .nvidia
+        self.gpuVendor = container.decodeLenientIfPresent(GPUVendor.self, forKey: .gpuVendor) ?? .nvidia
         self.networkTimeout = try container.decodeIfPresent(Int.self, forKey: .networkTimeout) ?? 60_000
         self.autoEnableDXVK = try container.decodeIfPresent(Bool.self, forKey: .autoEnableDXVK) ?? true
     }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottlePerformanceConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottlePerformanceConfig.swift
@@ -52,8 +52,8 @@ public struct BottlePerformanceConfig: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.performancePreset = try container
-            .decodeIfPresent(PerformancePreset.self, forKey: .performancePreset) ?? .balanced
+        self.performancePreset = container
+            .decodeLenientIfPresent(PerformancePreset.self, forKey: .performancePreset) ?? .balanced
         self.shaderCacheEnabled = try container.decodeIfPresent(Bool.self, forKey: .shaderCacheEnabled) ?? true
         self.gpuMemoryLimit = try container.decodeIfPresent(Int.self, forKey: .gpuMemoryLimit)
         self.forceD3D11 = try container.decodeIfPresent(Bool.self, forKey: .forceD3D11) ?? false

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -692,7 +692,7 @@ public struct BottleSettings: Codable, Equatable {
         var settings = try decoder.decode(BottleSettings.self, from: data)
 
         guard settings.fileVersion == BottleSettings.defaultFileVersion else {
-            Logger.wineKit.warning("Invalid file version `\(settings.fileVersion)`")
+            Logger.wineKit.warning("Invalid file version `\(settings.fileVersion, privacy: .public)`")
             // Preserve the original before defaults overwrite it, so an unexpected file version
             // (which may carry recoverable user data) is not silently destroyed.
             quarantineCorruptedFile(at: metadataURL)
@@ -702,9 +702,20 @@ public struct BottleSettings: Codable, Equatable {
         }
 
         if settings.wineConfig.wineVersion != BottleWineConfig().wineVersion {
-            Logger.wineKit.warning("Bottle has a different wine version `\(settings.wineConfig.wineVersion)`")
+            Logger.wineKit.warning(
+                "Bottle has a different wine version `\(settings.wineConfig.wineVersion, privacy: .public)`"
+            )
             settings.wineConfig.wineVersion = BottleWineConfig().wineVersion
-            try settings.encode(to: metadataURL)
+            do {
+                try settings.encode(to: metadataURL)
+            } catch {
+                // The file decoded fine; only the version-stamp rewrite failed. Propagating
+                // would make the caller quarantine a healthy file and reset it to defaults,
+                // so keep the valid settings and let the stamp retry on the next load.
+                Logger.wineKit.error(
+                    "Failed to update wine version stamp: \(String(describing: error), privacy: .public)"
+                )
+            }
             return settings
         }
 
@@ -726,7 +737,7 @@ public struct BottleSettings: Codable, Equatable {
     /// Moves an unreadable settings file aside before defaults overwrite it, preserving the
     /// original for diagnosis instead of destroying it (silent data loss).
     ///
-    /// The file is renamed to a `Metadata.plist.corrupt-<timestamp>` sibling. The move is
+    /// The file is renamed to a `<filename>.corrupt-<timestamp>-<nonce>` sibling. The move is
     /// best-effort: if the file does not exist there is nothing to preserve, and if the move
     /// itself fails the error is logged and the caller proceeds to write defaults anyway.
     ///
@@ -741,9 +752,12 @@ public struct BottleSettings: Codable, Equatable {
         formatter.timeZone = TimeZone(identifier: "UTC")
         let rawTimestamp = formatter.string(from: Date())
         let timestamp = rawTimestamp.replacingOccurrences(of: ":", with: "-")
+        // Short random suffix so two quarantines within the same second can't collide
+        // (moveItem refuses to overwrite an existing destination, losing the second file).
+        let nonce = UUID().uuidString.prefix(8)
         let quarantineURL = metadataURL
             .deletingLastPathComponent()
-            .appending(path: "\(metadataURL.lastPathComponent).corrupt-\(timestamp)")
+            .appending(path: "\(metadataURL.lastPathComponent).corrupt-\(timestamp)-\(nonce)")
 
         do {
             try fileManager.moveItem(at: metadataURL, to: quarantineURL)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -693,6 +693,9 @@ public struct BottleSettings: Codable, Equatable {
 
         guard settings.fileVersion == BottleSettings.defaultFileVersion else {
             Logger.wineKit.warning("Invalid file version `\(settings.fileVersion)`")
+            // Preserve the original before defaults overwrite it, so an unexpected file version
+            // (which may carry recoverable user data) is not silently destroyed.
+            quarantineCorruptedFile(at: metadataURL)
             settings = BottleSettings()
             try settings.encode(to: metadataURL)
             return settings
@@ -718,6 +721,47 @@ public struct BottleSettings: Codable, Equatable {
         let data = try encoder.encode(self)
         // Atomic so a crash mid-write can't leave a truncated Metadata.plist behind.
         try data.write(to: metadataUrl, options: .atomic)
+    }
+
+    /// Moves an unreadable settings file aside before defaults overwrite it, preserving the
+    /// original for diagnosis instead of destroying it (silent data loss).
+    ///
+    /// The file is renamed to a `Metadata.plist.corrupt-<timestamp>` sibling. The move is
+    /// best-effort: if the file does not exist there is nothing to preserve, and if the move
+    /// itself fails the error is logged and the caller proceeds to write defaults anyway.
+    ///
+    /// - Parameter metadataURL: The URL of the settings file to quarantine.
+    static func quarantineCorruptedFile(at metadataURL: URL) {
+        let fileManager = FileManager.default
+        // Only quarantine when there is actually a file to preserve.
+        guard fileManager.fileExists(atPath: metadataURL.path(percentEncoded: false)) else { return }
+
+        // Filename-safe timestamp (no colons/spaces): e.g. 2026-06-10T14-30-05Z.
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        let rawTimestamp = formatter.string(from: Date())
+        let timestamp = rawTimestamp.replacingOccurrences(of: ":", with: "-")
+        let quarantineURL = metadataURL
+            .deletingLastPathComponent()
+            .appending(path: "\(metadataURL.lastPathComponent).corrupt-\(timestamp)")
+
+        do {
+            try fileManager.moveItem(at: metadataURL, to: quarantineURL)
+            Logger.wineKit.error(
+                """
+                Quarantined unreadable settings file `\(metadataURL.path(percentEncoded: false), privacy: .public)` \
+                to `\(quarantineURL.path(percentEncoded: false), privacy: .public)` before writing defaults
+                """
+            )
+        } catch {
+            Logger.wineKit.error(
+                """
+                Failed to quarantine unreadable settings file \
+                `\(metadataURL.path(percentEncoded: false), privacy: .public)`: \
+                \(String(describing: error), privacy: .public); proceeding to write defaults
+                """
+            )
+        }
     }
 
     // MARK: - EnvironmentBuilder Layer Populators

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -716,7 +716,8 @@ public struct BottleSettings: Codable, Equatable {
         let encoder = PropertyListEncoder()
         encoder.outputFormat = .xml
         let data = try encoder.encode(self)
-        try data.write(to: metadataUrl)
+        // Atomic so a crash mid-write can't leave a truncated Metadata.plist behind.
+        try data.write(to: metadataUrl, options: .atomic)
     }
 
     // MARK: - EnvironmentBuilder Layer Populators

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleWineConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleWineConfig.swift
@@ -62,7 +62,7 @@ public struct BottleWineConfig: Codable, Equatable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.wineVersion = try container.decodeIfPresent(SemanticVersion.self, forKey: .wineVersion) ?? Self
             .defaultWineVersion
-        self.windowsVersion = try container.decodeIfPresent(WinVersion.self, forKey: .windowsVersion) ?? .win10
+        self.windowsVersion = container.decodeLenientIfPresent(WinVersion.self, forKey: .windowsVersion) ?? .win10
         self.enhancedSync = try container.decodeIfPresent(EnhancedSync.self, forKey: .enhancedSync) ?? .msync
         self.avxEnabled = try container.decodeIfPresent(Bool.self, forKey: .avxEnabled) ?? false
     }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Program.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Program.swift
@@ -172,7 +172,11 @@ public final class Program: ObservableObject, Equatable, Hashable, Identifiable 
 
             self.settings = try ProgramSettings.decode(from: settingsUrl)
         } catch {
-            Logger.wineKit.error("Failed to load settings for `\(name)`: \(error)")
+            Logger.wineKit.error(
+                "Failed to load settings for `\(name)`: \(String(describing: error), privacy: .public)"
+            )
+            // Preserve the unreadable file before the next save overwrites it with defaults.
+            BottleSettings.quarantineCorruptedFile(at: settingsUrl)
             self.settings = ProgramSettings()
         }
 
@@ -212,7 +216,11 @@ public final class Program: ObservableObject, Equatable, Hashable, Identifiable 
 
             self.settings = try ProgramSettings.decode(from: settingsUrl)
         } catch {
-            Logger.wineKit.error("Failed to load settings for `\(displayName)`: \(error)")
+            Logger.wineKit.error(
+                "Failed to load settings for `\(displayName)`: \(String(describing: error), privacy: .public)"
+            )
+            // Preserve the unreadable file before the next save overwrites it with defaults.
+            BottleSettings.quarantineCorruptedFile(at: settingsUrl)
             self.settings = ProgramSettings()
         }
     }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramOverrides.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramOverrides.swift
@@ -129,13 +129,13 @@ public struct ProgramOverrides: Codable, Equatable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.graphicsBackend = container.decodeGraphicsBackendIfPresent(forKey: .graphicsBackend)
+        self.graphicsBackend = container.decodeLenientIfPresent(GraphicsBackend.self, forKey: .graphicsBackend)
         self.dxvk = try container.decodeIfPresent(Bool.self, forKey: .dxvk)
         self.dxvkAsync = try container.decodeIfPresent(Bool.self, forKey: .dxvkAsync)
         self.dxvkHud = try container.decodeIfPresent(DXVKHUD.self, forKey: .dxvkHud)
         self.enhancedSync = try container.decodeIfPresent(EnhancedSync.self, forKey: .enhancedSync)
         self.forceD3D11 = try container.decodeIfPresent(Bool.self, forKey: .forceD3D11)
-        self.performancePreset = try container.decodeIfPresent(PerformancePreset.self, forKey: .performancePreset)
+        self.performancePreset = container.decodeLenientIfPresent(PerformancePreset.self, forKey: .performancePreset)
         self.shaderCacheEnabled = try container.decodeIfPresent(Bool.self, forKey: .shaderCacheEnabled)
         self.controllerCompatibilityMode = try container.decodeIfPresent(
             Bool.self, forKey: .controllerCompatibilityMode
@@ -145,7 +145,7 @@ public struct ProgramOverrides: Codable, Equatable, Sendable {
         self.disableControllerMapping = try container.decodeIfPresent(Bool.self, forKey: .disableControllerMapping)
         self.useButtonLabels = try container.decodeIfPresent(Bool.self, forKey: .useButtonLabels)
         self.virtualDesktopEnabled = try container.decodeIfPresent(Bool.self, forKey: .virtualDesktopEnabled)
-        self.resolutionPreset = try container.decodeIfPresent(ResolutionPreset.self, forKey: .resolutionPreset)
+        self.resolutionPreset = container.decodeLenientIfPresent(ResolutionPreset.self, forKey: .resolutionPreset)
         self.customResolutionWidth = try container.decodeIfPresent(Int.self, forKey: .customResolutionWidth)
         self.customResolutionHeight = try container.decodeIfPresent(Int.self, forKey: .customResolutionHeight)
         self.dllOverrides = try container.decodeIfPresent([DLLOverrideEntry].self, forKey: .dllOverrides)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramOverrides.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramOverrides.swift
@@ -129,7 +129,7 @@ public struct ProgramOverrides: Codable, Equatable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.graphicsBackend = try container.decodeIfPresent(GraphicsBackend.self, forKey: .graphicsBackend)
+        self.graphicsBackend = container.decodeGraphicsBackendIfPresent(forKey: .graphicsBackend)
         self.dxvk = try container.decodeIfPresent(Bool.self, forKey: .dxvk)
         self.dxvkAsync = try container.decodeIfPresent(Bool.self, forKey: .dxvkAsync)
         self.dxvkHud = try container.decodeIfPresent(DXVKHUD.self, forKey: .dxvkHud)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramSettings.swift
@@ -178,14 +178,14 @@ public struct ProgramSettings: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.locale = try container.decodeIfPresent(Locales.self, forKey: .locale) ?? .auto
+        self.locale = container.decodeLenientIfPresent(Locales.self, forKey: .locale) ?? .auto
         self.environment = try container.decodeIfPresent(
             [String: String].self,
             forKey: .environment
         ) ?? [:]
         self.arguments = try container.decodeIfPresent(String.self, forKey: .arguments) ?? ""
         self.overrides = try container.decodeIfPresent(ProgramOverrides.self, forKey: .overrides)
-        self.activeWineDebugPreset = try container.decodeIfPresent(
+        self.activeWineDebugPreset = container.decodeLenientIfPresent(
             WineDebugPreset.self,
             forKey: .activeWineDebugPreset
         )

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramSettings.swift
@@ -223,6 +223,7 @@ public struct ProgramSettings: Codable {
         let encoder = PropertyListEncoder()
         encoder.outputFormat = .xml
         let data = try encoder.encode(self)
-        try data.write(to: settingsURL)
+        // Atomic so a crash mid-write can't leave a truncated settings plist behind.
+        try data.write(to: settingsURL, options: .atomic)
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleSettingsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleSettingsTests.swift
@@ -365,10 +365,50 @@ final class BottleSettingsTests: XCTestCase {
 
         // Simulate a Metadata.plist written by a newer Whisky with a backend this build doesn't know.
         let xml = try XCTUnwrap(String(data: data, encoding: .utf8))
-            .replacingOccurrences(of: "<string>dxvk</string>", with: "<string>someFutureBackend</string>")
-        let decoded = try PropertyListDecoder().decode(BottleSettings.self, from: Data(xml.utf8))
+        XCTAssertTrue(xml.contains("<string>dxvk</string>"), "encoding shape changed; test no longer substitutes")
+        let mutated = xml.replacingOccurrences(of: "<string>dxvk</string>", with: "<string>someFutureBackend</string>")
+        let decoded = try PropertyListDecoder().decode(BottleSettings.self, from: Data(mutated.utf8))
 
         XCTAssertEqual(decoded.name, "Forward Compat")
         XCTAssertEqual(decoded.graphicsBackend, .recommended)
+    }
+
+    func testMalformedGraphicsBackendTypeDecodesToRecommended() throws {
+        // A wrong-typed value (number instead of string) must not throw out of
+        // the parent decode — it degrades to the default, same as an unknown value.
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>backend</key>
+            <integer>2</integer>
+        </dict>
+        </plist>
+        """
+        let config = try PropertyListDecoder().decode(BottleGraphicsConfig.self, from: Data(plist.utf8))
+        XCTAssertEqual(config.backend, .recommended)
+    }
+
+    func testUnknownGraphicsBackendRoundTripsAsRecommended() throws {
+        // Decoding an unknown backend yields a persistable value: re-encoding and
+        // decoding again still loads. The future value is intentionally lost — saving
+        // under an older build is a one-way downgrade to .recommended.
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>backend</key>
+            <string>someFutureBackend</string>
+        </dict>
+        </plist>
+        """
+        let decoded = try PropertyListDecoder().decode(BottleGraphicsConfig.self, from: Data(plist.utf8))
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let reencoded = try encoder.encode(decoded)
+        let reloaded = try PropertyListDecoder().decode(BottleGraphicsConfig.self, from: reencoded)
+        XCTAssertEqual(reloaded.backend, .recommended)
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleSettingsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleSettingsTests.swift
@@ -486,4 +486,115 @@ final class BottleSettingsTests: XCTestCase {
         XCTAssertEqual(decoded.name, "WinVersion Forward Compat")
         XCTAssertEqual(decoded.windowsVersion, .win10)
     }
+
+    func testUnknownAudioDriverDecodesToDefaultInWholeSettings() throws {
+        var settings = BottleSettings()
+        settings.name = "Audio Forward Compat"
+        settings.audioDriver = .coreaudio
+
+        let decoded = try decodeSettingsSubstituting(
+            settings,
+            original: "<string>coreaudio</string>",
+            replacement: "<string>someFutureDriver</string>"
+        )
+
+        XCTAssertEqual(decoded.name, "Audio Forward Compat")
+        XCTAssertEqual(decoded.audioDriver, .auto)
+    }
+
+    func testUnknownKillOnQuitPolicyDecodesToDefaultInWholeSettings() throws {
+        var settings = BottleSettings()
+        settings.name = "Cleanup Forward Compat"
+        settings.killOnQuit = .neverKill
+
+        let decoded = try decodeSettingsSubstituting(
+            settings,
+            original: "<string>never</string>",
+            replacement: "<string>someFuturePolicy</string>"
+        )
+
+        XCTAssertEqual(decoded.name, "Cleanup Forward Compat")
+        XCTAssertEqual(decoded.killOnQuit, .inherit)
+    }
+
+    func testUnknownLauncherModeDecodesToDefaultInWholeSettings() throws {
+        var settings = BottleSettings()
+        settings.name = "Launcher Forward Compat"
+        settings.launcherMode = .manual
+
+        let decoded = try decodeSettingsSubstituting(
+            settings,
+            original: "<string>manual</string>",
+            replacement: "<string>someFutureMode</string>"
+        )
+
+        XCTAssertEqual(decoded.name, "Launcher Forward Compat")
+        XCTAssertEqual(decoded.launcherMode, .auto)
+    }
+
+    // MARK: - Decode Recovery
+
+    func testFileVersionMismatchQuarantinesAndResets() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let metadataURL = tempDir.appendingPathComponent("Metadata.plist")
+
+        // A successfully-decodable file whose fileVersion this build doesn't recognize.
+        var settings = BottleSettings()
+        settings.name = "From The Future"
+        settings.fileVersion = SemanticVersion(99, 0, 0)
+        try settings.encode(to: metadataURL)
+        let originalData = try Data(contentsOf: metadataURL)
+
+        let decoded = try BottleSettings.decode(from: metadataURL)
+
+        // The mismatched file must be preserved as a quarantine sibling, not destroyed.
+        let siblings = try FileManager.default.contentsOfDirectory(atPath: tempDir.path)
+        let quarantined = siblings.filter { $0.hasPrefix("Metadata.plist.corrupt-") }
+        XCTAssertEqual(quarantined.count, 1, "expected exactly one quarantined sibling, got \(siblings)")
+        let quarantineURL = try tempDir.appendingPathComponent(XCTUnwrap(quarantined.first))
+        XCTAssertEqual(try Data(contentsOf: quarantineURL), originalData)
+
+        // The caller gets fresh defaults, persisted in the file's place.
+        XCTAssertEqual(decoded.fileVersion, BottleSettings.defaultFileVersion)
+        XCTAssertEqual(decoded.name, BottleSettings().name)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: metadataURL.path))
+    }
+
+    func testWineVersionStampWriteFailureKeepsValidSettings() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let metadataURL = tempDir.appendingPathComponent("Metadata.plist")
+
+        // A healthy file stamped with an older wine version.
+        var settings = BottleSettings()
+        settings.name = "Healthy Bottle"
+        settings.wineVersion = SemanticVersion(1, 2, 3)
+        try settings.encode(to: metadataURL)
+        let originalData = try Data(contentsOf: metadataURL)
+
+        // Make the directory unwritable so the version-stamp rewrite fails.
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: tempDir.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: tempDir.path)
+        }
+
+        // A failed stamp write must not demote a healthy file to quarantine or defaults.
+        let decoded = try BottleSettings.decode(from: metadataURL)
+
+        XCTAssertEqual(decoded.name, "Healthy Bottle")
+        XCTAssertEqual(decoded.wineVersion, BottleWineConfig.defaultWineVersion)
+        XCTAssertEqual(try Data(contentsOf: metadataURL), originalData)
+        let siblings = try FileManager.default.contentsOfDirectory(atPath: tempDir.path)
+        XCTAssertFalse(
+            siblings.contains { $0.contains(".corrupt-") },
+            "a healthy file must not be quarantined when only the stamp write fails"
+        )
+    }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleSettingsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleSettingsTests.swift
@@ -20,6 +20,10 @@ import SemanticVersion
 @testable import WhiskyKit
 import XCTest
 
+// swiftlint:disable file_length
+// Exhaustive settings coverage (defaults, lenient decode, round-trips) requires many cases.
+
+// swiftlint:disable:next type_body_length
 final class BottleSettingsTests: XCTestCase {
     // MARK: - BottleSettings Default Values
 
@@ -410,5 +414,76 @@ final class BottleSettingsTests: XCTestCase {
         let reencoded = try encoder.encode(decoded)
         let reloaded = try PropertyListDecoder().decode(BottleGraphicsConfig.self, from: reencoded)
         XCTAssertEqual(reloaded.backend, .recommended)
+    }
+
+    // MARK: - Settings-Tree Forward Compatibility
+
+    /// Encodes `settings`, swaps `original` for `replacement` in the produced plist XML to
+    /// simulate a value written by a newer Whisky, and decodes the whole `BottleSettings`.
+    private func decodeSettingsSubstituting(
+        _ settings: BottleSettings,
+        original: String,
+        replacement: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> BottleSettings {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(settings)
+        let xml = try XCTUnwrap(String(data: data, encoding: .utf8), file: file, line: line)
+        XCTAssertTrue(
+            xml.contains(original),
+            "encoding shape changed; test no longer substitutes `\(original)`",
+            file: file,
+            line: line
+        )
+        let mutated = xml.replacingOccurrences(of: original, with: replacement)
+        return try PropertyListDecoder().decode(BottleSettings.self, from: Data(mutated.utf8))
+    }
+
+    func testUnknownPerformancePresetDecodesToDefaultInWholeSettings() throws {
+        var settings = BottleSettings()
+        settings.name = "Perf Forward Compat"
+        settings.performancePreset = .performance
+
+        let decoded = try decodeSettingsSubstituting(
+            settings,
+            original: "<string>performance</string>",
+            replacement: "<string>someFuturePreset</string>"
+        )
+
+        // The unknown preset must degrade to the default without taking the rest of settings down.
+        XCTAssertEqual(decoded.name, "Perf Forward Compat")
+        XCTAssertEqual(decoded.performancePreset, .balanced)
+    }
+
+    func testUnknownResolutionPresetDecodesToDefaultInWholeSettings() throws {
+        var settings = BottleSettings()
+        settings.name = "Resolution Forward Compat"
+        settings.resolutionPreset = .r2560x1440
+
+        let decoded = try decodeSettingsSubstituting(
+            settings,
+            original: "<string>r2560x1440</string>",
+            replacement: "<string>r7680x4320</string>"
+        )
+
+        XCTAssertEqual(decoded.name, "Resolution Forward Compat")
+        XCTAssertEqual(decoded.resolutionPreset, .r1920x1080)
+    }
+
+    func testUnknownWindowsVersionDecodesToDefaultInWholeSettings() throws {
+        var settings = BottleSettings()
+        settings.name = "WinVersion Forward Compat"
+        settings.windowsVersion = .win11
+
+        let decoded = try decodeSettingsSubstituting(
+            settings,
+            original: "<string>win11</string>",
+            replacement: "<string>win12</string>"
+        )
+
+        XCTAssertEqual(decoded.name, "WinVersion Forward Compat")
+        XCTAssertEqual(decoded.windowsVersion, .win10)
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleSettingsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleSettingsTests.swift
@@ -336,4 +336,39 @@ final class BottleSettingsTests: XCTestCase {
         XCTAssertEqual(loadedSettings.name, "CustomBottle")
         XCTAssertTrue(loadedSettings.metalHud)
     }
+
+    // MARK: - Graphics Backend Forward Compatibility
+
+    func testUnknownGraphicsBackendDecodesToRecommended() throws {
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>backend</key>
+            <string>someFutureBackend</string>
+        </dict>
+        </plist>
+        """
+        let config = try PropertyListDecoder().decode(BottleGraphicsConfig.self, from: Data(plist.utf8))
+        XCTAssertEqual(config.backend, .recommended)
+    }
+
+    func testSettingsWithUnknownGraphicsBackendStillDecode() throws {
+        var settings = BottleSettings()
+        settings.name = "Forward Compat"
+        settings.graphicsBackend = .dxvk
+
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(settings)
+
+        // Simulate a Metadata.plist written by a newer Whisky with a backend this build doesn't know.
+        let xml = try XCTUnwrap(String(data: data, encoding: .utf8))
+            .replacingOccurrences(of: "<string>dxvk</string>", with: "<string>someFutureBackend</string>")
+        let decoded = try PropertyListDecoder().decode(BottleSettings.self, from: Data(xml.utf8))
+
+        XCTAssertEqual(decoded.name, "Forward Compat")
+        XCTAssertEqual(decoded.graphicsBackend, .recommended)
+    }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleTests.swift
@@ -20,6 +20,9 @@ import Foundation
 @testable import WhiskyKit
 import XCTest
 
+// swiftlint:disable file_length
+// Broad bottle coverage (core, settings recovery, quarantine) lives in one file.
+
 // MARK: - Bottle Core Tests
 
 final class BottleCoreTests: XCTestCase {
@@ -260,6 +263,58 @@ final class BottleCoreTests: XCTestCase {
         // Verify by reloading
         let reloadedBottle = Bottle(bottleUrl: bottleURL)
         XCTAssertEqual(reloadedBottle.settings.name, "Manual Save Test")
+    }
+
+    // MARK: - Corrupt Metadata Quarantine Tests
+
+    @MainActor
+    func testCorruptMetadataIsQuarantinedNotDestroyed() throws {
+        let metadataURL = bottleURL.appending(path: "Metadata.plist")
+
+        // Write a truncated/corrupt plist that cannot decode into BottleSettings.
+        let corruptContents = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist version=\"1.0\"><dict><key>name"
+        try Data(corruptContents.utf8).write(to: metadataURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: metadataURL.path(percentEncoded: false)))
+
+        // Loading the bottle runs the real decode/recovery path.
+        let bottle = Bottle(bottleUrl: bottleURL)
+
+        // (a) Settings come up as defaults rather than throwing out of the load.
+        XCTAssertEqual(bottle.settings.name, "Bottle")
+        XCTAssertEqual(bottle.settings.windowsVersion, .win10)
+
+        // A fresh default Metadata.plist was written in place.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: metadataURL.path(percentEncoded: false)))
+
+        // (b) The original was preserved as a Metadata.plist.corrupt-* sibling, not destroyed.
+        let siblings = try FileManager.default.contentsOfDirectory(
+            at: bottleURL,
+            includingPropertiesForKeys: nil
+        )
+        let quarantined = siblings.filter { $0.lastPathComponent.hasPrefix("Metadata.plist.corrupt-") }
+        XCTAssertEqual(quarantined.count, 1, "expected exactly one quarantined copy of the unreadable settings")
+
+        // The quarantined file still holds the original unreadable bytes (data was preserved).
+        let preserved = try XCTUnwrap(quarantined.first)
+        let preservedContents = try String(contentsOf: preserved, encoding: .utf8)
+        XCTAssertEqual(preservedContents, corruptContents)
+    }
+
+    @MainActor
+    func testValidMetadataIsNotQuarantined() throws {
+        // A bottle that loads cleanly must never produce a quarantine sibling.
+        let bottle = Bottle(bottleUrl: bottleURL)
+        bottle.settings.name = "Healthy"
+        bottle.saveBottleSettings()
+
+        _ = Bottle(bottleUrl: bottleURL)
+
+        let siblings = try FileManager.default.contentsOfDirectory(
+            at: bottleURL,
+            includingPropertiesForKeys: nil
+        )
+        let quarantined = siblings.filter { $0.lastPathComponent.hasPrefix("Metadata.plist.corrupt-") }
+        XCTAssertTrue(quarantined.isEmpty, "a readable settings file must not be quarantined")
     }
 }
 

--- a/WhiskyKit/Tests/WhiskyKitTests/GameDatabaseTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GameDatabaseTests.swift
@@ -482,6 +482,18 @@ final class GameDatabaseTests: XCTestCase {
         // Load returns nil
         XCTAssertNil(GameConfigSnapshot.load(from: tempDir))
     }
+
+    func testVariantSettingsUnknownGraphicsBackendDecodesToNil() throws {
+        let json = """
+        {
+          "graphicsBackend": "someFutureBackend",
+          "dxvk": true
+        }
+        """
+        let settings = try JSONDecoder().decode(GameConfigVariantSettings.self, from: Data(json.utf8))
+        XCTAssertNil(settings.graphicsBackend)
+        XCTAssertEqual(settings.dxvk, true)
+    }
 }
 
 // swiftlint:enable file_length

--- a/WhiskyKit/Tests/WhiskyKitTests/ProgramOverridesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ProgramOverridesTests.swift
@@ -93,10 +93,34 @@ final class ProgramOverridesTests: XCTestCase {
 
         // Simulate overrides written by a newer Whisky with a backend this build doesn't know.
         let xml = try XCTUnwrap(String(data: data, encoding: .utf8))
-            .replacingOccurrences(of: "<string>dxvk</string>", with: "<string>someFutureBackend</string>")
-        let decoded = try PropertyListDecoder().decode(ProgramOverrides.self, from: Data(xml.utf8))
+        XCTAssertTrue(xml.contains("<string>dxvk</string>"), "encoding shape changed; test no longer substitutes")
+        let mutated = xml.replacingOccurrences(of: "<string>dxvk</string>", with: "<string>someFutureBackend</string>")
+        let decoded = try PropertyListDecoder().decode(ProgramOverrides.self, from: Data(mutated.utf8))
 
         XCTAssertNil(decoded.graphicsBackend)
+        XCTAssertEqual(decoded.enhancedSync, .msync)
+    }
+
+    func testUnknownPerformancePresetDecodesToNil() throws {
+        // Lenient decode covers all string-backed enums in the overrides, not just
+        // the graphics backend — an unknown performancePreset must not fail the decode.
+        var overrides = ProgramOverrides()
+        overrides.performancePreset = .balanced
+        overrides.enhancedSync = .msync
+
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(overrides)
+
+        let xml = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(xml.contains("<string>balanced</string>"), "encoding shape changed; test no longer substitutes")
+        let mutated = xml.replacingOccurrences(
+            of: "<string>balanced</string>",
+            with: "<string>someFuturePreset</string>"
+        )
+        let decoded = try PropertyListDecoder().decode(ProgramOverrides.self, from: Data(mutated.utf8))
+
+        XCTAssertNil(decoded.performancePreset)
         XCTAssertEqual(decoded.enhancedSync, .msync)
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/ProgramOverridesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ProgramOverridesTests.swift
@@ -123,4 +123,30 @@ final class ProgramOverridesTests: XCTestCase {
         XCTAssertNil(decoded.performancePreset)
         XCTAssertEqual(decoded.enhancedSync, .msync)
     }
+
+    func testProgramSettingsUnknownLocaleDecodesToAuto() throws {
+        // ProgramSettings has no quarantine wrapper of its own, so a strict-decode
+        // regression here surfaces wherever programs load — pin the lenient path.
+        var settings = ProgramSettings()
+        settings.locale = .japanese
+        settings.arguments = "-windowed"
+
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(settings)
+
+        let xml = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(
+            xml.contains("<string>ja_JP.UTF-8</string>"),
+            "encoding shape changed; test no longer substitutes"
+        )
+        let mutated = xml.replacingOccurrences(
+            of: "<string>ja_JP.UTF-8</string>",
+            with: "<string>tlh_QO.UTF-8</string>"
+        )
+        let decoded = try PropertyListDecoder().decode(ProgramSettings.self, from: Data(mutated.utf8))
+
+        XCTAssertEqual(decoded.locale, .auto)
+        XCTAssertEqual(decoded.arguments, "-windowed")
+    }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/ProgramOverridesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ProgramOverridesTests.swift
@@ -81,4 +81,22 @@ final class ProgramOverridesTests: XCTestCase {
         let decoded = try PropertyListDecoder().decode(BottleSettings.self, from: data)
         XCTAssertTrue(decoded.dllOverrides.isEmpty)
     }
+
+    func testUnknownGraphicsBackendDecodesToNil() throws {
+        var overrides = ProgramOverrides()
+        overrides.graphicsBackend = .dxvk
+        overrides.enhancedSync = .msync
+
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(overrides)
+
+        // Simulate overrides written by a newer Whisky with a backend this build doesn't know.
+        let xml = try XCTUnwrap(String(data: data, encoding: .utf8))
+            .replacingOccurrences(of: "<string>dxvk</string>", with: "<string>someFutureBackend</string>")
+        let decoded = try PropertyListDecoder().decode(ProgramOverrides.self, from: Data(xml.utf8))
+
+        XCTAssertNil(decoded.graphicsBackend)
+        XCTAssertEqual(decoded.enhancedSync, .msync)
+    }
 }


### PR DESCRIPTION
## Summary
- **Atomic settings writes**: `BottleSettings.encode(to:)` used a bare `data.write(to:)`, so a crash or power loss mid-save could leave a truncated `Metadata.plist` and wipe the bottle's configuration. Now writes with `.atomic`.
- **Lenient `GraphicsBackend` decode**: the doc comment on `BottleGraphicsConfig` promised unknown values decode gracefully to `.recommended`, but `decodeIfPresent(GraphicsBackend.self)` actually throws on an unknown raw value — failing the *entire* bottle settings load. A new `decodeGraphicsBackendIfPresent` helper decodes the raw string and falls back (`.recommended` for the bottle config, `nil` for program overrides and game-DB variants). This is forward-compat groundwork: a bottle written by a future Whisky with a new backend still opens on this build.

## Verification
- 4 new regression tests (bottle config, full `BottleSettings` path, `GameConfigVariantSettings`, `ProgramOverrides`) — all reproduced the `dataCorrupted` failure before the fix.
- Full WhiskyKit suite: 1001 tests pass.