### PR TITLE
chore: localize the diagnostics-export failure alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The "Failed to Export Diagnostics Report" alert is now localizable instead of
+  English-only, matching the rest of the launcher diagnostics UI.
+
 ## [3.2.0] - 2026-06-10 (App)
 
 ### Added

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -11706,6 +11706,26 @@
         }
       }
     },
+    "launcher.diagnostics.export.error.message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An error occurred while saving the diagnostics report:\n\n%@\n\nPlease try again or choose a different location."
+          }
+        }
+      }
+    },
+    "launcher.diagnostics.export.error.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to Export Diagnostics Report"
+          }
+        }
+      }
+    },
     "launcher.fixes.applied": {
       "localizations": {
         "en": {

--- a/Whisky/Views/Bottle/LauncherConfigSection.swift
+++ b/Whisky/Views/Bottle/LauncherConfigSection.swift
@@ -538,15 +538,12 @@ struct DiagnosticsReportView: View {
 
                 let alert = NSAlert()
                 alert.alertStyle = .warning
-                alert.messageText = "Failed to Export Diagnostics Report"
-                alert.informativeText = """
-                An error occurred while saving the diagnostics report:
-
-                \(error.localizedDescription)
-
-                Please try again or choose a different location.
-                """
-                alert.addButton(withTitle: "OK")
+                alert.messageText = String(localized: "launcher.diagnostics.export.error.title")
+                alert.informativeText = String(
+                    format: String(localized: "launcher.diagnostics.export.error.message"),
+                    error.localizedDescription
+                )
+                alert.addButton(withTitle: String(localized: "button.ok"))
                 alert.runModal()
             }
         }


### PR DESCRIPTION
## Summary
The NSAlert shown when exporting a launcher diagnostics report fails used hardcoded English strings — the last unlocalized user-facing alert. Title and message now route through `launcher.diagnostics.export.error.*` keys (hand-placed at their sorted positions in the catalog) and the OK button reuses the existing `button.ok` key, following the bottle-creation-errors pattern from #97.

## Verification
- `plutil`/JSON validation of the catalog passes; app builds clean.