### PR TITLE
feat: opt-in anonymous first-run telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   anonymous events covering the first-run funnel — runtime install
   started/succeeded/failed (with a coarse reason), first bottle created, first
   program launch attempted — so install failures in the field become visible.
-  Nothing is sent without explicit consent; no person profile is created, and no
-  personal data, paths, or raw error text is ever included. The full event list,
-  the SDK context that accompanies it, and the IP/GeoIP handling are documented
-  in the README and SECURITY.md.
+  The first-program-launch event now fires from both the programs list and a
+  program's detail view, so no real launch path is missed. Nothing is sent
+  without explicit consent; no person profile is created, and no personal data,
+  paths, or raw error text is ever included. The full event list, the SDK context
+  that accompanies it, and the IP/GeoIP handling are documented in the README and
+  SECURITY.md.
+
+### Fixed
+- The first-run telemetry opt-in is now always reachable: when the Wine runtime
+  is missing, setup no longer skips straight past the welcome screen (the only
+  place the consent checkbox lives) before you can make a choice.
 
 ## [3.2.0] - 2026-06-10 (App)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   setup (off by default, changeable anytime in Settings → Privacy) enables five
   anonymous events covering the first-run funnel — runtime install
   started/succeeded/failed (with a coarse reason), first bottle created, first
-  program launched — so install failures in the field become visible. Nothing
-  is sent without explicit consent; no personal data, paths, or raw error text
-  is ever included. The full event list is documented in the README and
-  SECURITY.md.
+  program launch attempted — so install failures in the field become visible.
+  Nothing is sent without explicit consent; no person profile is created, and no
+  personal data, paths, or raw error text is ever included. The full event list,
+  the SDK context that accompanies it, and the IP/GeoIP handling are documented
+  in the README and SECURITY.md.
 
 ## [3.2.0] - 2026-06-10 (App)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Optional, **opt-in** anonymous usage telemetry. A checkbox during first-run
+  setup (off by default, changeable anytime in Settings → Privacy) enables five
+  anonymous events covering the first-run funnel — runtime install
+  started/succeeded/failed (with a coarse reason), first bottle created, first
+  program launched — so install failures in the field become visible. Nothing
+  is sent without explicit consent; no personal data, paths, or raw error text
+  is ever included. The full event list is documented in the README and
+  SECURITY.md.
+
 ## [3.2.0] - 2026-06-10 (App)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,15 +97,22 @@ funnel, so the maintainer can see where new installs fail:
 | --- | --- |
 | `runtime_install_started` | — |
 | `runtime_install_succeeded` | — |
-| `runtime_install_failed` | `reason`: one of `download_failed`, `verify_failed`, `tarball_missing`, `extract_failed` |
+| `runtime_install_failed` | `reason`: one of `download_failed`, `verify_failed`, `tarball_missing`, `extract_failed`, `runtime_incomplete` |
 | `first_bottle_created` | — |
-| `first_program_launched` | — |
+| `first_program_launch_attempted` | — |
 
-No personal data, file names, paths, or identifiers tied to you are ever sent —
-events carry only a random anonymous ID. The entire integration lives in
-[`Whisky/Utils/Telemetry.swift`](Whisky/Utils/Telemetry.swift), with every
-automatic capture feature of the analytics SDK disabled, so the table above is
-the complete list of what can leave the app.
+`runtime_install_started` is sent once per setup attempt; the `_succeeded` /
+`_failed` events are sent per install attempt (so retries are counted). The two
+`first_…` events are sent at most once per install.
+
+No personal data, file names, paths, raw error text, or identifiers tied to you
+are ever sent. Every event Whisky can send is the list above, and all of it is
+declared in one file, [`Whisky/Utils/Telemetry.swift`](Whisky/Utils/Telemetry.swift),
+with every automatic-capture feature of the analytics SDK disabled and no person
+profile ever created (`identify()` is never called). Each event does carry the
+SDK's standard context — app version, macOS version, device model, locale — and,
+like any HTTPS request, PostHog's ingestion sees the connecting IP (GeoIP
+enrichment is disabled); none of this is tied to your identity.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,29 @@ To switch:
 
 The original app uses a different bundle identifier (`com.franke.Whisky` here vs. `com.isaacmarovitz.Whisky`), which is why bottles aren't shared automatically. The old **Bottle → Export** / **File → Import Bottle** route still works if you'd rather move bottles by hand or onto another Mac. With no critical bottles, you can skip migration entirely — the new app creates a fresh bottle on first launch.
 
+## Telemetry (opt-in)
+
+Whisky sends **no data by default**. During first-run setup you can opt in to
+anonymous usage telemetry — a checkbox that is **off** unless you tick it, and a
+toggle you can change anytime in **Settings → Privacy**.
+
+When (and only when) enabled, Whisky sends five events covering the first-run
+funnel, so the maintainer can see where new installs fail:
+
+| Event | Properties |
+| --- | --- |
+| `runtime_install_started` | — |
+| `runtime_install_succeeded` | — |
+| `runtime_install_failed` | `reason`: one of `download_failed`, `verify_failed`, `tarball_missing`, `extract_failed` |
+| `first_bottle_created` | — |
+| `first_program_launched` | — |
+
+No personal data, file names, paths, or identifiers tied to you are ever sent —
+events carry only a random anonymous ID. The entire integration lives in
+[`Whisky/Utils/Telemetry.swift`](Whisky/Utils/Telemetry.swift), with every
+automatic capture feature of the analytics SDK disabled, so the table above is
+the complete list of what can leave the app.
+
 ## Documentation
 
 - **[Support](docs/SUPPORT.md)** - Where to file bugs and what to expect from a single-maintainer fork

--- a/README.md
+++ b/README.md
@@ -106,13 +106,15 @@ funnel, so the maintainer can see where new installs fail:
 `first_…` events are sent at most once per install.
 
 No personal data, file names, paths, raw error text, or identifiers tied to you
-are ever sent. Every event Whisky can send is the list above, and all of it is
-declared in one file, [`Whisky/Utils/Telemetry.swift`](Whisky/Utils/Telemetry.swift),
-with every automatic-capture feature of the analytics SDK disabled and no person
-profile ever created (`identify()` is never called). Each event does carry the
-SDK's standard context — app version, macOS version, device model, locale — and,
-like any HTTPS request, PostHog's ingestion sees the connecting IP (GeoIP
-enrichment is disabled); none of this is tied to your identity.
+are ever sent. Events carry a random per-install anonymous ID (reset if you opt
+out). Every event Whisky can send is the list above, and all of it is declared in
+one file, [`Whisky/Utils/Telemetry.swift`](Whisky/Utils/Telemetry.swift), with
+every automatic-capture feature of the analytics SDK disabled and no person
+profile ever created (`identify()` is never called). Each event also carries the
+SDK's standard context — app and macOS version, hardware model, locale, and more;
+see [SECURITY.md](SECURITY.md) for the full list. Like any HTTPS request,
+PostHog's ingestion sees the connecting IP (GeoIP enrichment is disabled); none
+of this is tied to your identity.
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,15 +69,25 @@ Whisky sends no data by default. An **opt-in** (default off) first-run checkbox
 — mirrored by a toggle in Settings → Privacy — enables exactly five anonymous
 events: `runtime_install_started`, `runtime_install_succeeded`,
 `runtime_install_failed` (with a coarse `reason` property:
-`download_failed` / `verify_failed` / `tarball_missing` / `extract_failed`),
-`first_bottle_created`, and `first_program_launched`.
+`download_failed` / `verify_failed` / `tarball_missing` / `extract_failed` /
+`runtime_incomplete`), `first_bottle_created`, and
+`first_program_launch_attempted`. The install events are per-attempt (retries
+are counted); the two `first_…` events fire at most once per install.
 
 Events carry a random per-install anonymous ID and never include personal data,
-file names, paths, or raw error text. The full implementation is a single file,
-[`Whisky/Utils/Telemetry.swift`](Whisky/Utils/Telemetry.swift): the analytics
-SDK is configured with all automatic capture (lifecycle events, screen views,
-feature flags, swizzling) disabled and `identify()` is never called. Opting out
-clears the queued events and the anonymous ID.
+file names, paths, or raw error text. Every event Whisky can send is the list
+above, and all of it — plus the SDK configuration — lives in one file,
+[`Whisky/Utils/Telemetry.swift`](Whisky/Utils/Telemetry.swift): all automatic
+capture (lifecycle events, screen views, feature flags, swizzling) is disabled,
+`personProfiles` is `.never`, and `identify()` is never called, so no person
+profile is created. Each event does carry the SDK's standard context (app
+version, macOS version, device model, locale), and PostHog's ingestion sees the
+connecting IP like any HTTPS request, with GeoIP enrichment disabled
+(`$geoip_disable`) — none of it tied to your identity.
+
+Opting out stops all future capture and resets the anonymous ID. Events already
+queued at that moment may still be delivered (the SDK has no public queue-purge),
+but no new events are captured.
 
 ## Security Best Practices for Users
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,8 +71,10 @@ events: `runtime_install_started`, `runtime_install_succeeded`,
 `runtime_install_failed` (with a coarse `reason` property:
 `download_failed` / `verify_failed` / `tarball_missing` / `extract_failed` /
 `runtime_incomplete`), `first_bottle_created`, and
-`first_program_launch_attempted`. The install events are per-attempt (retries
-are counted); the two `first_…` events fire at most once per install.
+`first_program_launch_attempted`. `runtime_install_started` fires once per setup
+pass; `runtime_install_succeeded` / `runtime_install_failed` are per install
+attempt (so retries are counted); the two `first_…` events fire at most once per
+install.
 
 Events carry a random per-install anonymous ID and never include personal data,
 file names, paths, or raw error text. Every event Whisky can send is the list
@@ -80,14 +82,21 @@ above, and all of it — plus the SDK configuration — lives in one file,
 [`Whisky/Utils/Telemetry.swift`](Whisky/Utils/Telemetry.swift): all automatic
 capture (lifecycle events, screen views, feature flags, swizzling) is disabled,
 `personProfiles` is `.never`, and `identify()` is never called, so no person
-profile is created. Each event does carry the SDK's standard context (app
-version, macOS version, device model, locale), and PostHog's ingestion sees the
-connecting IP like any HTTPS request, with GeoIP enrichment disabled
-(`$geoip_disable`) — none of it tied to your identity.
+profile is created.
+
+The PostHog SDK attaches its own standard context to every event. On macOS
+(posthog-ios 3.59.x) this comprises: app name, app version, and app build plus
+the bundle identifier; macOS version; hardware model and a derived hardware
+name; device type (`Desktop`); the device manufacturer (`Apple`); locale;
+timezone; screen width/height; network-type flags (Wi-Fi / cellular); the SDK
+name and version; a per-launch session id; and a few non-personal environment
+flags (install source such as TestFlight or sideloaded, and emulator/Catalyst
+indicators). None of this is tied to your identity. PostHog's ingestion also sees the connecting IP like any HTTPS
+request, with GeoIP enrichment disabled (`$geoip_disable`).
 
 Opting out stops all future capture and resets the anonymous ID. Events already
-queued at that moment may still be delivered (the SDK has no public queue-purge),
-but no new events are captured.
+queued at that moment may still be delivered (posthog-ios 3.59.x has no public
+queue-purge), but no new events are captured.
 
 ## Security Best Practices for Users
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,7 +89,8 @@ The PostHog SDK attaches its own standard context to every event. On macOS
 the bundle identifier; macOS version; hardware model and a derived hardware
 name; device type (`Desktop`); the device manufacturer (`Apple`); locale;
 timezone; screen width/height; network-type flags (Wi-Fi / cellular); the SDK
-name and version; a per-launch session id; and a few non-personal environment
+name and version; a session id created at launch (rotated after 30 minutes of
+inactivity, so a long-running session can span more than one); and a few non-personal environment
 flags (install source such as TestFlight or sideloaded, and emulator/Catalyst
 indicators). None of this is tied to your identity. PostHog's ingestion also sees the connecting IP like any HTTPS
 request, with GeoIP enrichment disabled (`$geoip_disable`).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,6 +63,22 @@ we track it as a runtime-currency concern rather than a closed door:
 If you believe a bundled-runtime vulnerability is being mishandled or under-prioritized in Whisky's
 packaging, report it through the private channel above and say so explicitly.
 
+## Telemetry & Data Collection
+
+Whisky sends no data by default. An **opt-in** (default off) first-run checkbox
+— mirrored by a toggle in Settings → Privacy — enables exactly five anonymous
+events: `runtime_install_started`, `runtime_install_succeeded`,
+`runtime_install_failed` (with a coarse `reason` property:
+`download_failed` / `verify_failed` / `tarball_missing` / `extract_failed`),
+`first_bottle_created`, and `first_program_launched`.
+
+Events carry a random per-install anonymous ID and never include personal data,
+file names, paths, or raw error text. The full implementation is a single file,
+[`Whisky/Utils/Telemetry.swift`](Whisky/Utils/Telemetry.swift): the analytics
+SDK is configured with all automatic capture (lifecycle events, screen views,
+feature flags, swizzling) disabled and `identify()` is never called. Opting out
+clears the queued events and the anonymous ID.
+
 ## Security Best Practices for Users
 
 - Only run trusted Windows applications within Whisky

--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -21,9 +21,11 @@
 		6365C4C32B1AA8CD00AAE1FD /* BottleListEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6365C4C22B1AA8CD00AAE1FD /* BottleListEntry.swift */; };
 		63FFDE862ADF0C7700178665 /* BottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FFDE852ADF0C7700178665 /* BottomBar.swift */; };
 		6763D8F62BC6314100651D27 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6763D8F52BC6314100651D27 /* Constants.swift */; };
+		7A0510A52F5A000000000005 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0510A42F5A000000000004 /* Telemetry.swift */; };
 		67D278512BC5907E006F9A1E /* ActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D278502BC5907E006F9A1E /* ActionView.swift */; };
 		689B4F6DF3B8006E89E1395F /* LauncherDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA88CFEB38031323229CD377 /* LauncherDiagnostics.swift */; };
 		6E064B1229DD32A200D9A2D2 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 6E064B1129DD32A200D9A2D2 /* Sparkle */; };
+		7A0510A32F5A000000000003 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 7A0510A22F5A000000000002 /* PostHog */; };
 		6E064B1429DD331F00D9A2D2 /* SparkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E064B1329DD331F00D9A2D2 /* SparkleView.swift */; };
 		6E17B6462AF3FDC100831173 /* PinView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E17B6452AF3FDC100831173 /* PinView.swift */; };
 		6E17B6492AF4118F00831173 /* EnvironmentArgView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E17B6482AF4118F00831173 /* EnvironmentArgView.swift */; };
@@ -198,6 +200,7 @@
 		6365C4C22B1AA8CD00AAE1FD /* BottleListEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleListEntry.swift; sourceTree = "<group>"; };
 		63FFDE852ADF0C7700178665 /* BottomBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomBar.swift; sourceTree = "<group>"; };
 		6763D8F52BC6314100651D27 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		7A0510A42F5A000000000004 /* Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
 		67D278502BC5907E006F9A1E /* ActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionView.swift; sourceTree = "<group>"; };
 		6E064B1329DD331F00D9A2D2 /* SparkleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleView.swift; sourceTree = "<group>"; };
 		6E17B6452AF3FDC100831173 /* PinView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinView.swift; sourceTree = "<group>"; };
@@ -322,6 +325,7 @@
 			files = (
 				8C2AEFC82AED79B700CB568F /* WhiskyKit in Frameworks */,
 				6E064B1229DD32A200D9A2D2 /* Sparkle in Frameworks */,
+				7A0510A32F5A000000000003 /* PostHog in Frameworks */,
 				EB58FB552A499896002DC184 /* SemanticVersion in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -534,6 +538,7 @@
 				6E70A4A02A9A280C007799E9 /* WhiskyCmd.swift */,
 				6E7C07BD2AAE7B0100F6E66B /* ProgramShortcut.swift */,
 				6763D8F52BC6314100651D27 /* Constants.swift */,
+				7A0510A42F5A000000000004 /* Telemetry.swift */,
 				366E8BD2A51FD444160DFC10 /* LauncherDetection.swift */,
 				AA88CFEB38031323229CD377 /* LauncherDiagnostics.swift */,
 				G1A2B3C4E5F60901A9B0C1D1 /* DependencyManager.swift */,
@@ -704,6 +709,7 @@
 			name = Whisky;
 			packageProductDependencies = (
 				6E064B1129DD32A200D9A2D2 /* Sparkle */,
+				7A0510A22F5A000000000002 /* PostHog */,
 				EB58FB542A499896002DC184 /* SemanticVersion */,
 				8C2AEFC72AED79B700CB568F /* WhiskyKit */,
 			);
@@ -825,6 +831,7 @@
 				6E064B1029DD32A200D9A2D2 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				EB58FB532A499896002DC184 /* XCRemoteSwiftPackageReference "SemanticVersion" */,
 				6E5967682A9A421800D64F70 /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
+				7A0510A12F5A000000000001 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 				8C2AEFC62AED79B700CB568F /* XCLocalSwiftPackageReference "WhiskyKit" */,
 			);
 			productRefGroup = 6E40495329CCA19C006E3F1B /* Products */;
@@ -904,6 +911,7 @@
 			files = (
 				EEA5A2462A31DD65008274AE /* AppDelegate.swift in Sources */,
 				6763D8F62BC6314100651D27 /* Constants.swift in Sources */,
+				7A0510A52F5A000000000005 /* Telemetry.swift in Sources */,
 				6E70A4A12A9A280C007799E9 /* WhiskyCmd.swift in Sources */,
 				6E40495829CCA19C006E3F1B /* ContentView.swift in Sources */,
 				67D278512BC5907E006F9A1E /* ActionView.swift in Sources */,
@@ -1460,6 +1468,14 @@
 				minimumVersion = 1.2.3;
 			};
 		};
+		7A0510A12F5A000000000001 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/PostHog/posthog-ios.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.58.0;
+			};
+		};
 		EB58FB532A499896002DC184 /* XCRemoteSwiftPackageReference "SemanticVersion" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SwiftPackageIndex/SemanticVersion";
@@ -1475,6 +1491,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6E064B1029DD32A200D9A2D2 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		7A0510A22F5A000000000002 /* PostHog */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7A0510A12F5A000000000001 /* XCRemoteSwiftPackageReference "posthog-ios" */;
+			productName = PostHog;
 		};
 		6E59676A2A9A424900D64F70 /* ArgumentParser */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Whisky.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Whisky.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "ffd9c17d25aea8e8b47bc935404cbb34dc8cdb1d67f0b4360ab649cf92aef835",
+  "originHash" : "b912b85f127fe72cded94f3b5a1ab3e591fa845a310c06ad873f4b28bb58f955",
   "pins" : [
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios.git",
+      "state" : {
+        "revision" : "179438b8e0c9a357ab0caf453577f766ffddbcb3",
+        "version" : "3.59.3"
+      }
+    },
     {
       "identity" : "semanticversion",
       "kind" : "remoteSourceControl",

--- a/Whisky/Info.plist
+++ b/Whisky/Info.plist
@@ -53,14 +53,16 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSDocumentsFolderUsageDescription</key>
-	<string>Whisky needs access to this folder to manage Wine bottles and install Windows dependencies.</string>
 	<key>NSDesktopFolderUsageDescription</key>
 	<string>Whisky needs access to Desktop to create shortcuts for Windows programs.</string>
-	<key>NSRemovableVolumesUsageDescription</key>
-	<string>Whisky needs access to removable volumes when bottles are stored on external drives.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>Whisky needs access to this folder to manage Wine bottles and install Windows dependencies.</string>
 	<key>NSNetworkVolumesUsageDescription</key>
 	<string>Whisky needs access to network volumes when bottles are stored on network drives.</string>
+	<key>NSRemovableVolumesUsageDescription</key>
+	<string>Whisky needs access to removable volumes when bottles are stored on external drives.</string>
+	<key>PostHogProjectToken</key>
+	<string>phc_LJiR538eQO7W24OkTeGFyi3m53BzJCVKEY7c46Lodrh</string>
 	<key>SUFeedURL</key>
 	<string>https://frankea.github.io/Whisky/appcast.xml</string>
 	<key>SUPublicEDKey</key>

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -19149,7 +19149,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Optional and off by default. When enabled, Whisky sends five anonymous events covering first-run setup: runtime install started, succeeded, or failed (with a coarse reason), first bottle created, and first program launch attempt. No personal data, file names, or identifiers tied to you are ever sent. You can change this anytime in Settings."
+            "value": "Optional and off by default. When enabled, Whisky sends five anonymous events covering the first-run funnel: runtime install started, succeeded, or failed (with a coarse reason), first bottle created, and first program launch attempt. No personal data, file names, or identifiers tied to you are ever sent. You can change this anytime in Settings."
           }
         }
       }

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -17064,6 +17064,16 @@
         }
       }
     },
+    "settings.privacy": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy"
+          }
+        }
+      }
+    },
     "settings.terminal": {
       "localizations": {
         "en": {
@@ -17206,6 +17216,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Whisky 關閉時終止 Wine 進程"
+          }
+        }
+      }
+    },
+    "settings.toggle.telemetry": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share anonymous usage data"
           }
         }
       }
@@ -19110,6 +19130,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "管理Whisky需要的相依性套件"
+          }
+        }
+      }
+    },
+    "setup.telemetry.consent": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share anonymous usage data to help improve Whisky"
+          }
+        }
+      }
+    },
+    "setup.telemetry.consent.help": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional and off by default. When enabled, Whisky sends five anonymous events covering first-run setup: runtime install started, succeeded, or failed (with a coarse reason), first bottle created, and first program launched. No personal data, file names, or identifiers tied to you are ever sent. You can change this anytime in Settings."
           }
         }
       }

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -19149,7 +19149,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Optional and off by default. When enabled, Whisky sends five anonymous events covering first-run setup: runtime install started, succeeded, or failed (with a coarse reason), first bottle created, and first program launched. No personal data, file names, or identifiers tied to you are ever sent. You can change this anytime in Settings."
+            "value": "Optional and off by default. When enabled, Whisky sends five anonymous events covering first-run setup: runtime install started, succeeded, or failed (with a coarse reason), first bottle created, and first program launch attempt. No personal data, file names, or identifiers tied to you are ever sent. You can change this anytime in Settings."
           }
         }
       }

--- a/Whisky/Utils/Telemetry.swift
+++ b/Whisky/Utils/Telemetry.swift
@@ -19,27 +19,29 @@
 import Foundation
 import os.log
 import PostHog
+import WhiskyKit
 
 private extension Logger {
     static let telemetry = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "com.franke.Whisky",
+        subsystem: Bundle.whiskyBundleIdentifier,
         category: "Telemetry"
     )
 }
 
 /// Whisky's entire telemetry event surface: five anonymous, opt-in-only events
 /// covering the first-run funnel. Every event Whisky can send, and all SDK
-/// configuration, is declared in this file; the UI only calls ``capture(_:)``
+/// configuration, is declared in this file; the app only calls ``capture(_:)``
 /// with these declared events. Keep the event list in sync with the README
 /// table, SECURITY.md, and the `setup.telemetry.consent.help` string.
 ///
 /// Nothing is sent unless the user has explicitly opted in. Every automatic
 /// capture feature of the SDK is disabled, and `personProfiles` is `.never`, so
 /// no person profile is ever created and `identify()` is never called — events
-/// are anonymous. Note the SDK still attaches its standard context to each
-/// event (app version, macOS version, device model, locale) and PostHog's
-/// ingestion sees the connecting IP like any HTTPS request; GeoIP enrichment is
-/// disabled via `$geoip_disable`. None of this is tied to the user's identity.
+/// are anonymous. Note the SDK still attaches its standard context to each event
+/// (app/macOS version, hardware model, locale, and more); SECURITY.md enumerates
+/// the full list. PostHog's ingestion sees the connecting IP like any HTTPS
+/// request; GeoIP enrichment is disabled via `$geoip_disable`. None of this is
+/// tied to the user's identity.
 enum Telemetry {
     /// Coarse failure classification. Never send raw error text — underlying
     /// messages contain file paths, which are personal data.
@@ -73,7 +75,9 @@ enum Telemetry {
         }
 
         /// Exhaustive (no `default:`) on purpose: a new event case must declare
-        /// its properties and once-policy, and re-sync the docs, before it builds.
+        /// its properties and once-policy before this builds. The compiler can't
+        /// enforce doc re-sync, so re-sync the README, SECURITY.md, and the
+        /// `setup.telemetry.consent.help` string at the same time.
         var properties: [String: Any] {
             switch self {
             case let .runtimeInstallFailed(reason): ["reason": reason.rawValue]
@@ -117,8 +121,8 @@ enum Telemetry {
 
     /// Records the user's choice and starts or stops the SDK accordingly.
     /// Declining stops all future capture and resets the anonymous ID; any
-    /// events already queued at that moment may still be delivered (the SDK has
-    /// no public queue-purge), but no new ones are captured.
+    /// events already queued at that moment may still be delivered (posthog-ios
+    /// 3.59.x exposes no public queue-purge), but no new ones are captured.
     @MainActor
     static func setConsent(granted: Bool) {
         let state: ConsentState = granted ? .granted : .denied
@@ -158,6 +162,10 @@ enum Telemetry {
 
     /// Sets up the SDK with every automatic capture feature disabled: the
     /// explicit `capture(_:)` calls in this file are the only event source.
+    ///
+    /// The SDK-behavior claims below (no public queue-purge, surveys/session
+    /// replay being macOS-unavailable) were verified against posthog-ios 3.59.3;
+    /// re-check them on a package bump.
     @MainActor
     private static func start() {
         guard !started else { return }
@@ -167,15 +175,20 @@ enum Telemetry {
             }
             return
         }
-        let config = PostHogConfig(projectToken: projectToken, host: "https://us.i.posthog.com")
+        let host = "https://us.i.posthog.com"
+        let config = PostHogConfig(projectToken: projectToken, host: host)
         config.captureApplicationLifecycleEvents = false
         config.captureScreenViews = false
         config.enableSwizzling = false
         config.preloadFeatureFlags = false
         config.sendFeatureFlagEvent = false
+        #if DEBUG
+        config.debug = true
+        #endif
         // Explicit, not relying on SDK defaults: never build a person profile, so
         // events stay anonymous even though we never call identify(). (Surveys and
-        // session replay are macOS-unavailable in the SDK and cannot be enabled.)
+        // session replay are macOS-unavailable in posthog-ios 3.59.x and cannot be
+        // enabled.)
         config.personProfiles = .never
         // Disable server-side GeoIP enrichment on every event.
         config.setBeforeSend { event in
@@ -185,5 +198,10 @@ enum Telemetry {
         PostHogSDK.shared.setup(config)
         PostHogSDK.shared.optIn()
         started = true
+        // Success-path log so "telemetry is live" is observable, not just failure.
+        // Only a short token prefix is logged, never the full token.
+        Logger.telemetry.info(
+            "Telemetry started (host \(host, privacy: .public), token \(projectToken.prefix(8), privacy: .public)…)"
+        )
     }
 }

--- a/Whisky/Utils/Telemetry.swift
+++ b/Whisky/Utils/Telemetry.swift
@@ -17,16 +17,29 @@
 //
 
 import Foundation
+import os.log
 import PostHog
 
-/// Whisky's entire telemetry surface: five anonymous, opt-in-only events
-/// covering the first-run funnel. SECURITY.md documents every event and
-/// property — keep that list in sync with ``Event``.
+private extension Logger {
+    static let telemetry = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.franke.Whisky",
+        category: "Telemetry"
+    )
+}
+
+/// Whisky's entire telemetry event surface: five anonymous, opt-in-only events
+/// covering the first-run funnel. Every event Whisky can send, and all SDK
+/// configuration, is declared in this file; the UI only calls ``capture(_:)``
+/// with these declared events. Keep the event list in sync with the README
+/// table, SECURITY.md, and the `setup.telemetry.consent.help` string.
 ///
-/// Nothing is sent unless the user has explicitly opted in, and the SDK is
-/// configured with every automatic capture feature disabled, so the events
-/// declared here are the only data that can ever leave the app. `identify()`
-/// is never called: events carry only a random anonymous ID.
+/// Nothing is sent unless the user has explicitly opted in. Every automatic
+/// capture feature of the SDK is disabled, and `personProfiles` is `.never`, so
+/// no person profile is ever created and `identify()` is never called — events
+/// are anonymous. Note the SDK still attaches its standard context to each
+/// event (app version, macOS version, device model, locale) and PostHog's
+/// ingestion sees the connecting IP like any HTTPS request; GeoIP enrichment is
+/// disabled via `$geoip_disable`. None of this is tied to the user's identity.
 enum Telemetry {
     /// Coarse failure classification. Never send raw error text — underlying
     /// messages contain file paths, which are personal data.
@@ -35,6 +48,9 @@ enum Telemetry {
         case extractFailed = "extract_failed"
         case verifyFailed = "verify_failed"
         case downloadFailed = "download_failed"
+        /// Extraction reported success but the runtime is not actually usable
+        /// afterwards (e.g. the `wine64` binary is missing).
+        case runtimeIncomplete = "runtime_incomplete"
     }
 
     enum Event {
@@ -42,7 +58,7 @@ enum Telemetry {
         case runtimeInstallSucceeded
         case runtimeInstallFailed(reason: InstallFailureReason)
         case firstBottleCreated
-        case firstProgramLaunched
+        case firstProgramLaunchAttempted
 
         var name: String {
             switch self {
@@ -50,22 +66,27 @@ enum Telemetry {
             case .runtimeInstallSucceeded: "runtime_install_succeeded"
             case .runtimeInstallFailed: "runtime_install_failed"
             case .firstBottleCreated: "first_bottle_created"
-            case .firstProgramLaunched: "first_program_launched"
+            // Captured when a launch is initiated, before its outcome is known —
+            // the name says "attempted" so the data isn't read as success.
+            case .firstProgramLaunchAttempted: "first_program_launch_attempted"
             }
         }
 
+        /// Exhaustive (no `default:`) on purpose: a new event case must declare
+        /// its properties and once-policy, and re-sync the docs, before it builds.
         var properties: [String: Any] {
             switch self {
             case let .runtimeInstallFailed(reason): ["reason": reason.rawValue]
-            default: [:]
+            case .runtimeInstallStarted, .runtimeInstallSucceeded,
+                 .firstBottleCreated, .firstProgramLaunchAttempted: [:]
             }
         }
 
         /// "First ever" funnel steps are only reported once per install.
         var oncePerInstall: Bool {
             switch self {
-            case .firstBottleCreated, .firstProgramLaunched: true
-            default: false
+            case .firstBottleCreated, .firstProgramLaunchAttempted: true
+            case .runtimeInstallStarted, .runtimeInstallSucceeded, .runtimeInstallFailed: false
             }
         }
     }
@@ -76,7 +97,9 @@ enum Telemetry {
         case denied
     }
 
-    /// Shared with the `@AppStorage` bindings in WelcomeView and SettingsView.
+    /// The UserDefaults key backing consent. Read it via `@AppStorage` if you
+    /// like, but **never write it directly** — route writes through
+    /// ``setConsent(granted:)`` so the SDK opt-in/opt-out state stays in sync.
     static let consentDefaultsKey = "telemetryConsent"
 
     static var consent: ConsentState {
@@ -93,7 +116,9 @@ enum Telemetry {
     @MainActor private static var started = false
 
     /// Records the user's choice and starts or stops the SDK accordingly.
-    /// Declining clears the queued events and the anonymous ID.
+    /// Declining stops all future capture and resets the anonymous ID; any
+    /// events already queued at that moment may still be delivered (the SDK has
+    /// no public queue-purge), but no new ones are captured.
     @MainActor
     static func setConsent(granted: Bool) {
         let state: ConsentState = granted ? .granted : .denied
@@ -135,16 +160,28 @@ enum Telemetry {
     /// explicit `capture(_:)` calls in this file are the only event source.
     @MainActor
     private static func start() {
-        guard !started, !projectToken.isEmpty else { return }
+        guard !started else { return }
+        guard !projectToken.isEmpty else {
+            if consent == .granted {
+                Logger.telemetry.warning("Telemetry consented but disabled: no PostHogProjectToken in Info.plist")
+            }
+            return
+        }
         let config = PostHogConfig(projectToken: projectToken, host: "https://us.i.posthog.com")
         config.captureApplicationLifecycleEvents = false
         config.captureScreenViews = false
         config.enableSwizzling = false
         config.preloadFeatureFlags = false
         config.sendFeatureFlagEvent = false
-        // Surveys and session replay are unavailable on macOS; personProfiles
-        // stays .identifiedOnly and identify() is never called, so all events
-        // remain anonymous.
+        // Explicit, not relying on SDK defaults: never build a person profile, so
+        // events stay anonymous even though we never call identify(). (Surveys and
+        // session replay are macOS-unavailable in the SDK and cannot be enabled.)
+        config.personProfiles = .never
+        // Disable server-side GeoIP enrichment on every event.
+        config.setBeforeSend { event in
+            event.properties["$geoip_disable"] = true
+            return event
+        }
         PostHogSDK.shared.setup(config)
         PostHogSDK.shared.optIn()
         started = true

--- a/Whisky/Utils/Telemetry.swift
+++ b/Whisky/Utils/Telemetry.swift
@@ -1,0 +1,152 @@
+//
+//  Telemetry.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import PostHog
+
+/// Whisky's entire telemetry surface: five anonymous, opt-in-only events
+/// covering the first-run funnel. SECURITY.md documents every event and
+/// property — keep that list in sync with ``Event``.
+///
+/// Nothing is sent unless the user has explicitly opted in, and the SDK is
+/// configured with every automatic capture feature disabled, so the events
+/// declared here are the only data that can ever leave the app. `identify()`
+/// is never called: events carry only a random anonymous ID.
+enum Telemetry {
+    /// Coarse failure classification. Never send raw error text — underlying
+    /// messages contain file paths, which are personal data.
+    enum InstallFailureReason: String {
+        case tarballMissing = "tarball_missing"
+        case extractFailed = "extract_failed"
+        case verifyFailed = "verify_failed"
+        case downloadFailed = "download_failed"
+    }
+
+    enum Event {
+        case runtimeInstallStarted
+        case runtimeInstallSucceeded
+        case runtimeInstallFailed(reason: InstallFailureReason)
+        case firstBottleCreated
+        case firstProgramLaunched
+
+        var name: String {
+            switch self {
+            case .runtimeInstallStarted: "runtime_install_started"
+            case .runtimeInstallSucceeded: "runtime_install_succeeded"
+            case .runtimeInstallFailed: "runtime_install_failed"
+            case .firstBottleCreated: "first_bottle_created"
+            case .firstProgramLaunched: "first_program_launched"
+            }
+        }
+
+        var properties: [String: Any] {
+            switch self {
+            case let .runtimeInstallFailed(reason): ["reason": reason.rawValue]
+            default: [:]
+            }
+        }
+
+        /// "First ever" funnel steps are only reported once per install.
+        var oncePerInstall: Bool {
+            switch self {
+            case .firstBottleCreated, .firstProgramLaunched: true
+            default: false
+            }
+        }
+    }
+
+    enum ConsentState: String {
+        case undecided
+        case granted
+        case denied
+    }
+
+    /// Shared with the `@AppStorage` bindings in WelcomeView and SettingsView.
+    static let consentDefaultsKey = "telemetryConsent"
+
+    static var consent: ConsentState {
+        UserDefaults.standard.string(forKey: consentDefaultsKey)
+            .flatMap(ConsentState.init(rawValue:)) ?? .undecided
+    }
+
+    /// The PostHog project token (public by design — it can only ingest
+    /// events, not read them). An empty value disables telemetry entirely.
+    private static var projectToken: String {
+        Bundle.main.object(forInfoDictionaryKey: "PostHogProjectToken") as? String ?? ""
+    }
+
+    @MainActor private static var started = false
+
+    /// Records the user's choice and starts or stops the SDK accordingly.
+    /// Declining clears the queued events and the anonymous ID.
+    @MainActor
+    static func setConsent(granted: Bool) {
+        let state: ConsentState = granted ? .granted : .denied
+        UserDefaults.standard.set(state.rawValue, forKey: consentDefaultsKey)
+        if granted {
+            if started {
+                PostHogSDK.shared.optIn()
+            } else {
+                start()
+            }
+        } else if started {
+            PostHogSDK.shared.optOut()
+            PostHogSDK.shared.reset()
+        }
+    }
+
+    /// Call once at app launch; does nothing unless consent was granted.
+    @MainActor
+    static func startIfConsented() {
+        if consent == .granted {
+            start()
+        }
+    }
+
+    @MainActor
+    static func capture(_ event: Event) {
+        guard consent == .granted else { return }
+        start()
+        guard started else { return }
+        if event.oncePerInstall {
+            let onceKey = "telemetryOnce_\(event.name)"
+            guard !UserDefaults.standard.bool(forKey: onceKey) else { return }
+            UserDefaults.standard.set(true, forKey: onceKey)
+        }
+        PostHogSDK.shared.capture(event.name, properties: event.properties)
+    }
+
+    /// Sets up the SDK with every automatic capture feature disabled: the
+    /// explicit `capture(_:)` calls in this file are the only event source.
+    @MainActor
+    private static func start() {
+        guard !started, !projectToken.isEmpty else { return }
+        let config = PostHogConfig(projectToken: projectToken, host: "https://us.i.posthog.com")
+        config.captureApplicationLifecycleEvents = false
+        config.captureScreenViews = false
+        config.enableSwizzling = false
+        config.preloadFeatureFlags = false
+        config.sendFeatureFlagEvent = false
+        // Surveys and session replay are unavailable on macOS; personProfiles
+        // stays .identifiedOnly and identify() is never called, so all events
+        // remain anonymous.
+        PostHogSDK.shared.setup(config)
+        PostHogSDK.shared.optIn()
+        started = true
+    }
+}

--- a/Whisky/Utils/Telemetry.swift
+++ b/Whisky/Utils/Telemetry.swift
@@ -104,6 +104,9 @@ enum Telemetry {
     /// The UserDefaults key backing consent. Read it via `@AppStorage` if you
     /// like, but **never write it directly** — route writes through
     /// ``setConsent(granted:)`` so the SDK opt-in/opt-out state stays in sync.
+    /// Note the SDK state is best-effort only (`reset()` clears the SDK's
+    /// persisted opt-out flag); what actually enforces a denial is the
+    /// app-level consent check in ``capture(_:)``, so that guard must stay.
     static let consentDefaultsKey = "telemetryConsent"
 
     static var consent: ConsentState {

--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -145,6 +145,7 @@ final class BottleVM: ObservableObject {
 
             persistBottleCreation(request: request)
             loadBottles()
+            Telemetry.capture(.firstBottleCreated)
         } catch {
             handleBottleCreationFailure(error, request: request, bottle: bottle)
         }

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -127,7 +127,7 @@ struct BottleView: View {
                                             // persisted before Wine.runProgram() reads them
                                             LauncherDetection.detectAndApplyLauncherFixes(from: url, for: bottle)
 
-                                            Telemetry.capture(.firstProgramLaunched)
+                                            Telemetry.capture(.firstProgramLaunchAttempted)
                                             if url.pathExtension == "bat" {
                                                 try await Wine.runBatchFile(url: url, bottle: bottle)
                                             } else {

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -127,6 +127,7 @@ struct BottleView: View {
                                             // persisted before Wine.runProgram() reads them
                                             LauncherDetection.detectAndApplyLauncherFixes(from: url, for: bottle)
 
+                                            Telemetry.capture(.firstProgramLaunched)
                                             if url.pathExtension == "bat" {
                                                 try await Wine.runBatchFile(url: url, bottle: bottle)
                                             } else {

--- a/Whisky/Views/Bottle/Pins/PinView.swift
+++ b/Whisky/Views/Bottle/Pins/PinView.swift
@@ -109,6 +109,7 @@ struct PinView: View {
 
         // Capture modifier flags synchronously before entering async context
         let useTerminal = NSEvent.modifierFlags.contains(.shift)
+        Telemetry.capture(.firstProgramLaunched)
         Task {
             let result = await program.launchWithUserMode(useTerminal: useTerminal)
             withAnimation {

--- a/Whisky/Views/Bottle/Pins/PinView.swift
+++ b/Whisky/Views/Bottle/Pins/PinView.swift
@@ -109,7 +109,7 @@ struct PinView: View {
 
         // Capture modifier flags synchronously before entering async context
         let useTerminal = NSEvent.modifierFlags.contains(.shift)
-        Telemetry.capture(.firstProgramLaunched)
+        Telemetry.capture(.firstProgramLaunchAttempted)
         Task {
             let result = await program.launchWithUserMode(useTerminal: useTerminal)
             withAnimation {

--- a/Whisky/Views/FileOpenView.swift
+++ b/Whisky/Views/FileOpenView.swift
@@ -84,6 +84,7 @@ struct FileOpenView: View {
                     // persisted before Wine.runProgram() reads them
                     await MainActor.run {
                         LauncherDetection.detectAndApplyLauncherFixes(from: fileURL, for: bottle)
+                        Telemetry.capture(.firstProgramLaunched)
                     }
 
                     if fileURL.pathExtension == "bat" {

--- a/Whisky/Views/FileOpenView.swift
+++ b/Whisky/Views/FileOpenView.swift
@@ -84,7 +84,7 @@ struct FileOpenView: View {
                     // persisted before Wine.runProgram() reads them
                     await MainActor.run {
                         LauncherDetection.detectAndApplyLauncherFixes(from: fileURL, for: bottle)
-                        Telemetry.capture(.firstProgramLaunched)
+                        Telemetry.capture(.firstProgramLaunchAttempted)
                     }
 
                     if fileURL.pathExtension == "bat" {

--- a/Whisky/Views/Programs/ProgramMenuView.swift
+++ b/Whisky/Views/Programs/ProgramMenuView.swift
@@ -26,6 +26,7 @@ struct ProgramMenuView: View {
 
     var body: some View {
         Button("button.run", systemImage: "play") {
+            Telemetry.capture(.firstProgramLaunched)
             program.run()
         }
         .labelStyle(.titleAndIcon)

--- a/Whisky/Views/Programs/ProgramMenuView.swift
+++ b/Whisky/Views/Programs/ProgramMenuView.swift
@@ -26,7 +26,7 @@ struct ProgramMenuView: View {
 
     var body: some View {
         Button("button.run", systemImage: "play") {
-            Telemetry.capture(.firstProgramLaunched)
+            Telemetry.capture(.firstProgramLaunchAttempted)
             program.run()
         }
         .labelStyle(.titleAndIcon)

--- a/Whisky/Views/Programs/ProgramView.swift
+++ b/Whisky/Views/Programs/ProgramView.swift
@@ -167,6 +167,7 @@ struct ProgramView: View {
 
     private func launchProgram() {
         programLoading = true
+        Telemetry.capture(.firstProgramLaunchAttempted)
         // Capture modifier flags synchronously before entering async context
         let useTerminal = NSEvent.modifierFlags.contains(.shift)
         Task {

--- a/Whisky/Views/Programs/ProgramsView.swift
+++ b/Whisky/Views/Programs/ProgramsView.swift
@@ -239,6 +239,7 @@ struct ProgramItemView: View {
 
     private func launchProgram() {
         isLaunching = true
+        Telemetry.capture(.firstProgramLaunchAttempted)
         // Capture modifier flags synchronously before entering async context
         let useTerminal = NSEvent.modifierFlags.contains(.shift)
 

--- a/Whisky/Views/Settings/SettingsView.swift
+++ b/Whisky/Views/Settings/SettingsView.swift
@@ -25,6 +25,16 @@ struct SettingsView: View {
     @AppStorage("checkWhiskyWineUpdates") var checkWhiskyWineUpdates = true
     @AppStorage("defaultBottleLocation") var defaultBottleLocation = BottleData.defaultBottleDir
     @AppStorage("preferredTerminal") var preferredTerminal = "terminal"
+    @AppStorage(Telemetry.consentDefaultsKey) private var telemetryConsentRaw: String = Telemetry.ConsentState
+        .undecided.rawValue
+
+    /// Mirrors the setup-flow opt-in; writing records the explicit choice.
+    private var telemetryOptIn: Binding<Bool> {
+        Binding(
+            get: { telemetryConsentRaw == Telemetry.ConsentState.granted.rawValue },
+            set: { Telemetry.setConsent(granted: $0) }
+        )
+    }
 
     var body: some View {
         Form {
@@ -59,6 +69,10 @@ struct SettingsView: View {
             Section("settings.updates") {
                 Toggle("settings.toggle.whisky.updates", isOn: $whiskyUpdate)
                 Toggle("settings.toggle.whiskywine.updates", isOn: $checkWhiskyWineUpdates)
+            }
+            Section("settings.privacy") {
+                Toggle("settings.toggle.telemetry", isOn: telemetryOptIn)
+                    .help("setup.telemetry.consent.help")
             }
         }
         .formStyle(.grouped)

--- a/Whisky/Views/Setup/SetupView.swift
+++ b/Whisky/Views/Setup/SetupView.swift
@@ -62,9 +62,14 @@ struct SetupView: View {
         .padding()
         .interactiveDismissDisabled()
         .onAppear {
-            // When opened for an update (not first launch), skip the welcome screen
-            // and navigate directly to the download stage.
-            if !firstTime, !WhiskyWineInstaller.isWhiskyWineInstalled() {
+            // Skip the welcome screen and go straight to the download stage only
+            // once telemetry consent is already decided. WelcomeView is the sole
+            // screen carrying the consent toggle, so on a genuine first run (consent
+            // still undecided) we must show it even when the runtime is missing —
+            // otherwise the opt-in would be unreachable. The only call site
+            // (ContentView) always passes `firstTime: false`, so the consent check,
+            // not `firstTime`, is what keeps the welcome screen reachable.
+            if !firstTime, Telemetry.consent != .undecided, !WhiskyWineInstaller.isWhiskyWineInstalled() {
                 path = [.whiskyWineDownload]
             }
         }

--- a/Whisky/Views/Setup/WelcomeView.swift
+++ b/Whisky/Views/Setup/WelcomeView.swift
@@ -80,15 +80,16 @@ struct WelcomeView: View {
                 checkInstallStatus()
             }
             Spacer()
-            if firstTime {
-                Toggle(isOn: telemetryOptIn) {
-                    Text("setup.telemetry.consent")
-                        .font(.caption)
-                }
-                .toggleStyle(.checkbox)
-                .help("setup.telemetry.consent.help")
-                .padding(.bottom, 4)
+            // Shown on the setup welcome (the first-run / runtime-install entry
+            // point) regardless of `firstTime`, which the only call site passes
+            // as false — gating on it would hide the opt-in entirely.
+            Toggle(isOn: telemetryOptIn) {
+                Text("setup.telemetry.consent")
+                    .font(.caption)
             }
+            .toggleStyle(.checkbox)
+            .help("setup.telemetry.consent.help")
+            .padding(.bottom, 4)
             HStack {
                 if let rosettaInstalled,
                    let whiskyWineInstalled {
@@ -116,7 +117,7 @@ struct WelcomeView: View {
                 }
             }
         }
-        .frame(width: 400, height: firstTime ? 230 : 200)
+        .frame(width: 400, height: 230)
     }
 
     func checkInstallStatus() {

--- a/Whisky/Views/Setup/WelcomeView.swift
+++ b/Whisky/Views/Setup/WelcomeView.swift
@@ -23,9 +23,19 @@ struct WelcomeView: View {
     @State var rosettaInstalled: Bool?
     @State var whiskyWineInstalled: Bool?
     @State var shouldCheckInstallStatus: Bool = false
+    @AppStorage(Telemetry.consentDefaultsKey) private var telemetryConsentRaw: String = Telemetry.ConsentState
+        .undecided.rawValue
     @Binding var path: [SetupStage]
     @Binding var showSetup: Bool
     var firstTime: Bool
+
+    /// Opt-in checkbox state; writing records the explicit choice.
+    private var telemetryOptIn: Binding<Bool> {
+        Binding(
+            get: { telemetryConsentRaw == Telemetry.ConsentState.granted.rawValue },
+            set: { Telemetry.setConsent(granted: $0) }
+        )
+    }
 
     var body: some View {
         VStack {
@@ -70,6 +80,15 @@ struct WelcomeView: View {
                 checkInstallStatus()
             }
             Spacer()
+            if firstTime {
+                Toggle(isOn: telemetryOptIn) {
+                    Text("setup.telemetry.consent")
+                        .font(.caption)
+                }
+                .toggleStyle(.checkbox)
+                .help("setup.telemetry.consent.help")
+                .padding(.bottom, 4)
+            }
             HStack {
                 if let rosettaInstalled,
                    let whiskyWineInstalled {
@@ -97,7 +116,7 @@ struct WelcomeView: View {
                 }
             }
         }
-        .frame(width: 400, height: 200)
+        .frame(width: 400, height: firstTime ? 230 : 200)
     }
 
     func checkInstallStatus() {

--- a/Whisky/Views/Setup/WelcomeView.swift
+++ b/Whisky/Views/Setup/WelcomeView.swift
@@ -80,9 +80,9 @@ struct WelcomeView: View {
                 checkInstallStatus()
             }
             Spacer()
-            // Shown on the setup welcome (the first-run / runtime-install entry
-            // point) regardless of `firstTime`, which the only call site passes
-            // as false — gating on it would hide the opt-in entirely.
+            // Shown unconditionally on the welcome screen, which is reached on a
+            // genuine first run: SetupView only skips this screen once telemetry
+            // consent is decided, so a first-run user always sees this opt-in.
             Toggle(isOn: telemetryOptIn) {
                 Text("setup.telemetry.consent")
                     .font(.caption)

--- a/Whisky/Views/Setup/WhiskyWineDownloadFormatting.swift
+++ b/Whisky/Views/Setup/WhiskyWineDownloadFormatting.swift
@@ -70,4 +70,18 @@ extension WhiskyWineDownloadView {
         let remainingTimeInSeconds = Double(remainingBytes) / downloadSpeed
         return Self.remainingTimeFormatter.string(from: remainingTimeInSeconds) ?? ""
     }
+
+    /// A download/verification failure: user-facing message and telemetry reason set together.
+    struct DownloadFailure: Equatable {
+        let message: String
+        let reason: Telemetry.InstallFailureReason
+    }
+
+    /// Sets the failure state and reports the funnel event atomically, so the
+    /// reported reason always matches the surfaced message.
+    @MainActor
+    func setDownloadFailure(_ message: String, reason: Telemetry.InstallFailureReason = .downloadFailed) {
+        downloadFailure = DownloadFailure(message: message, reason: reason)
+        Telemetry.capture(.runtimeInstallFailed(reason: reason))
+    }
 }

--- a/Whisky/Views/Setup/WhiskyWineDownloadFormatting.swift
+++ b/Whisky/Views/Setup/WhiskyWineDownloadFormatting.swift
@@ -57,4 +57,17 @@ extension WhiskyWineDownloadView {
         formatter.unitsStyle = .full
         return formatter
     }()
+
+    func formatBytes(bytes: Int64) -> String {
+        Self.byteCountFormatter.string(fromByteCount: bytes)
+    }
+
+    func formatRemainingTime(remainingBytes: Int64) -> String {
+        // Guard against invalid values that would produce meaningless time estimates.
+        guard remainingBytes > 0, downloadSpeed > 0 else {
+            return ""
+        }
+        let remainingTimeInSeconds = Double(remainingBytes) / downloadSpeed
+        return Self.remainingTimeFormatter.string(from: remainingTimeInSeconds) ?? ""
+    }
 }

--- a/Whisky/Views/Setup/WhiskyWineDownloadFormatting.swift
+++ b/Whisky/Views/Setup/WhiskyWineDownloadFormatting.swift
@@ -77,8 +77,9 @@ extension WhiskyWineDownloadView {
         let reason: Telemetry.InstallFailureReason
     }
 
-    /// Sets the failure state and reports the funnel event atomically, so the
-    /// reported reason always matches the surfaced message.
+    /// Sets the failure state and reports the funnel event together (two
+    /// sequential main-actor statements), so the reported reason always matches
+    /// the surfaced message.
     @MainActor
     func setDownloadFailure(_ message: String, reason: Telemetry.InstallFailureReason = .downloadFailed) {
         downloadFailure = DownloadFailure(message: message, reason: reason)

--- a/Whisky/Views/Setup/WhiskyWineDownloadView.swift
+++ b/Whisky/Views/Setup/WhiskyWineDownloadView.swift
@@ -41,6 +41,9 @@ struct WhiskyWineDownloadView: View {
     /// Expected SHA-256 of the runtime archive, from the version plist. `nil`
     /// when no hash is advertised, in which case verification is skipped.
     @State private var expectedSHA256: String?
+    /// Guards the once-per-setup-attempt `runtime_install_started` capture against
+    /// repeated `onAppear` calls from NavigationStack (mirrors the install view).
+    @State private var hasStartedDownload: Bool = false
     @Binding var tarLocation: URL
     @Binding var path: [SetupStage]
     @Binding var showSetup: Bool
@@ -80,9 +83,14 @@ struct WhiskyWineDownloadView: View {
         }
         .frame(width: 400, height: 200)
         .onAppear {
+            // Guard against multiple onAppear calls from NavigationStack so the
+            // once-per-setup-attempt runtime_install_started capture holds.
+            guard !hasStartedDownload else { return }
+            hasStartedDownload = true
             Task {
                 diagnostics.reset()
                 diagnostics.record("Entered download stage")
+                diagnostics.record("Telemetry consent: \(Telemetry.consent.rawValue)")
                 Telemetry.capture(.runtimeInstallStarted)
                 await fetchVersionAndDownload()
             }

--- a/Whisky/Views/Setup/WhiskyWineDownloadView.swift
+++ b/Whisky/Views/Setup/WhiskyWineDownloadView.swift
@@ -28,7 +28,8 @@ struct WhiskyWineDownloadView: View {
     @State private var fractionProgress: Double = 0
     @State private var completedBytes: Int64 = 0
     @State private var totalBytes: Int64 = 0
-    @State private var downloadSpeed: Double = 0
+    // Internal so the formatting helpers in WhiskyWineDownloadFormatting.swift can read it.
+    @State var downloadSpeed: Double = 0
     @State private var downloadTask: URLSessionDownloadTask?
     @State private var observation: NSKeyValueObservation?
     @State private var startTime: Date?
@@ -37,6 +38,9 @@ struct WhiskyWineDownloadView: View {
     /// Expected SHA-256 of the runtime archive, from the version plist. `nil`
     /// when no hash is advertised, in which case verification is skipped.
     @State private var expectedSHA256: String?
+    /// Set to a more specific reason (e.g. verification) before `downloadError`
+    /// so the failure event carries the right classification.
+    @State private var telemetryFailureReason: Telemetry.InstallFailureReason = .downloadFailed
     @Binding var tarLocation: URL
     @Binding var path: [SetupStage]
     @Binding var showSetup: Bool
@@ -79,8 +83,14 @@ struct WhiskyWineDownloadView: View {
             Task {
                 diagnostics.reset()
                 diagnostics.record("Entered download stage")
+                Telemetry.capture(.runtimeInstallStarted)
                 await fetchVersionAndDownload()
             }
+        }
+        .onChange(of: downloadError) { _, newValue in
+            guard newValue != nil else { return }
+            Telemetry.capture(.runtimeInstallFailed(reason: telemetryFailureReason))
+            telemetryFailureReason = .downloadFailed
         }
     }
 }
@@ -178,22 +188,9 @@ extension WhiskyWineDownloadView {
         }
     }
 
-    private func formatBytes(bytes: Int64) -> String {
-        Self.byteCountFormatter.string(fromByteCount: bytes)
-    }
-
     private func shouldShowEstimate() -> Bool {
         let elapsedTime = Date().timeIntervalSince(startTime ?? Date())
         return Int(elapsedTime.rounded()) > 5 && completedBytes != 0
-    }
-
-    private func formatRemainingTime(remainingBytes: Int64) -> String {
-        // Guard against invalid values that would produce meaningless time estimates.
-        guard remainingBytes > 0, downloadSpeed > 0 else {
-            return ""
-        }
-        let remainingTimeInSeconds = Double(remainingBytes) / downloadSpeed
-        return Self.remainingTimeFormatter.string(from: remainingTimeInSeconds) ?? ""
     }
 
     private func proceed() {
@@ -360,6 +357,7 @@ extension WhiskyWineDownloadView {
             if let failure {
                 diagnostics.record("Integrity check FAILED — \(failure)")
                 WhiskyWineInstaller.cleanupTarball(at: fileURL)
+                telemetryFailureReason = .verifyFailed
                 downloadError = String(
                     localized: "setup.whiskywine.error.checksumMismatch",
                     defaultValue: """

--- a/Whisky/Views/Setup/WhiskyWineDownloadView.swift
+++ b/Whisky/Views/Setup/WhiskyWineDownloadView.swift
@@ -33,14 +33,14 @@ struct WhiskyWineDownloadView: View {
     @State private var downloadTask: URLSessionDownloadTask?
     @State private var observation: NSKeyValueObservation?
     @State private var startTime: Date?
-    @State private var downloadError: String?
+    /// The current failure, if any. Carries the user-facing message and the
+    /// telemetry reason together so the two can never drift apart.
+    /// Internal so the failure helper in WhiskyWineDownloadFormatting.swift can set it.
+    @State var downloadFailure: DownloadFailure?
     @State private var currentDownloadTaskID: UUID?
     /// Expected SHA-256 of the runtime archive, from the version plist. `nil`
     /// when no hash is advertised, in which case verification is skipped.
     @State private var expectedSHA256: String?
-    /// Set to a more specific reason (e.g. verification) before `downloadError`
-    /// so the failure event carries the right classification.
-    @State private var telemetryFailureReason: Telemetry.InstallFailureReason = .downloadFailed
     @Binding var tarLocation: URL
     @Binding var path: [SetupStage]
     @Binding var showSetup: Bool
@@ -68,8 +68,8 @@ struct WhiskyWineDownloadView: View {
                     .foregroundStyle(.secondary)
                 Spacer()
 
-                if let error = downloadError {
-                    errorView(error: error)
+                if let failure = downloadFailure {
+                    errorView(error: failure.message)
                 } else {
                     progressView
                 }
@@ -86,11 +86,6 @@ struct WhiskyWineDownloadView: View {
                 Telemetry.capture(.runtimeInstallStarted)
                 await fetchVersionAndDownload()
             }
-        }
-        .onChange(of: downloadError) { _, newValue in
-            guard newValue != nil else { return }
-            Telemetry.capture(.runtimeInstallFailed(reason: telemetryFailureReason))
-            telemetryFailureReason = .downloadFailed
         }
     }
 }
@@ -171,7 +166,7 @@ extension WhiskyWineDownloadView {
     }
 
     private func retryDownload() {
-        downloadError = nil
+        downloadFailure = nil
         fractionProgress = 0
         completedBytes = 0
         totalBytes = 0
@@ -200,7 +195,7 @@ extension WhiskyWineDownloadView {
     @MainActor
     private func fetchVersionAndDownload() async {
         guard let versionURL = URL(string: DistributionConfig.versionPlistURL) else {
-            downloadError = String(localized: "setup.whiskywine.error.invalidVersionURL")
+            setDownloadFailure(String(localized: "setup.whiskywine.error.invalidVersionURL"))
             return
         }
 
@@ -214,7 +209,7 @@ extension WhiskyWineDownloadView {
                !(200 ... 299).contains(httpResponse.statusCode) {
                 diagnostics.versionHTTPStatus = httpResponse.statusCode
                 diagnostics.record("Version plist HTTP \(httpResponse.statusCode)")
-                downloadError = formatHTTPError(statusCode: httpResponse.statusCode)
+                setDownloadFailure(formatHTTPError(statusCode: httpResponse.statusCode))
                 return
             }
 
@@ -227,7 +222,7 @@ extension WhiskyWineDownloadView {
             diagnostics.record("Resolved version \(versionString)")
 
             guard let downloadURL = URL(string: downloadURLString) else {
-                downloadError = String(localized: "setup.whiskywine.error.invalidDownloadURL")
+                setDownloadFailure(String(localized: "setup.whiskywine.error.invalidDownloadURL"))
                 return
             }
 
@@ -236,10 +231,10 @@ extension WhiskyWineDownloadView {
         } catch {
             let errorMessage = error.localizedDescription
             diagnostics.record("Version fetch failed: \(errorMessage)")
-            downloadError = String(
+            setDownloadFailure(String(
                 format: String(localized: "setup.whiskywine.error.fetchVersionFailed"),
                 errorMessage
-            )
+            ))
         }
     }
 
@@ -307,10 +302,10 @@ extension WhiskyWineDownloadView {
             if (error as NSError).code == NSURLErrorCancelled {
                 return
             }
-            downloadError = String(
+            setDownloadFailure(String(
                 format: String(localized: "setup.whiskywine.error.downloadFailed"),
                 error.localizedDescription
-            )
+            ))
             diagnostics.downloadFinishedAt = Date()
             diagnostics.record("Download failed: \(error.localizedDescription)")
             return
@@ -321,7 +316,7 @@ extension WhiskyWineDownloadView {
             diagnostics.downloadHTTPStatus = httpResponse.statusCode
             diagnostics.downloadFinishedAt = Date()
             diagnostics.record("Download HTTP \(httpResponse.statusCode)")
-            downloadError = formatHTTPError(statusCode: httpResponse.statusCode)
+            setDownloadFailure(formatHTTPError(statusCode: httpResponse.statusCode))
             return
         }
 
@@ -332,7 +327,7 @@ extension WhiskyWineDownloadView {
         } else {
             diagnostics.downloadFinishedAt = Date()
             diagnostics.record("Download completed but no file URL received")
-            downloadError = String(localized: "setup.whiskywine.error.noFileReceived")
+            setDownloadFailure(String(localized: "setup.whiskywine.error.noFileReceived"))
         }
     }
 
@@ -357,13 +352,15 @@ extension WhiskyWineDownloadView {
             if let failure {
                 diagnostics.record("Integrity check FAILED — \(failure)")
                 WhiskyWineInstaller.cleanupTarball(at: fileURL)
-                telemetryFailureReason = .verifyFailed
-                downloadError = String(
-                    localized: "setup.whiskywine.error.checksumMismatch",
-                    defaultValue: """
-                    The downloaded Wine runtime failed its integrity check and was not installed. \
-                    This usually means the download was corrupted. Please try again.
-                    """
+                setDownloadFailure(
+                    String(
+                        localized: "setup.whiskywine.error.checksumMismatch",
+                        defaultValue: """
+                        The downloaded Wine runtime failed its integrity check and was not installed. \
+                        This usually means the download was corrupted. Please try again.
+                        """
+                    ),
+                    reason: .verifyFailed
                 )
                 return
             }

--- a/Whisky/Views/Setup/WhiskyWineInstallView.swift
+++ b/Whisky/Views/Setup/WhiskyWineInstallView.swift
@@ -144,10 +144,9 @@ struct WhiskyWineInstallView: View {
             let capturedTarURL = tarLocation
             diagnostics.record("Invoking WhiskyWineInstaller.install(from:) in detached task")
             let outcome = await Self.performInstall(tarball: capturedTarURL)
-            let installFailureMessage = outcome.failureMessage
             let isInstalled = outcome.installed
-            if let installFailureMessage {
-                diagnostics.record("Install failed: \(installFailureMessage)")
+            if case let .failure(_, message?) = outcome {
+                diagnostics.record("Install failed: \(message)")
             }
             let installStatus = isInstalled ? "installed" : "not installed"
             diagnostics.record(
@@ -177,17 +176,16 @@ struct WhiskyWineInstallView: View {
     /// Reports the funnel event and sets the user-facing error state.
     @MainActor
     private func applyInstallOutcome(_ outcome: InstallOutcome) {
-        if outcome.installed {
+        switch outcome {
+        case .success:
             Telemetry.capture(.runtimeInstallSucceeded)
             installError = nil
-        } else {
-            Telemetry.capture(
-                .runtimeInstallFailed(reason: outcome.tarballMissing ? .tarballMissing : .extractFailed)
-            )
-            if let failureMessage = outcome.failureMessage {
+        case let .failure(reason, message):
+            Telemetry.capture(.runtimeInstallFailed(reason: reason))
+            if let message {
                 installError = String(
                     format: String(localized: "setup.whiskywine.error.installFailed.detail"),
-                    Self.shortened(failureMessage)
+                    Self.shortened(message)
                 )
             } else {
                 installError = String(localized: "setup.whiskywine.error.installFailed")
@@ -195,13 +193,17 @@ struct WhiskyWineInstallView: View {
         }
     }
 
-    /// Outcome of an install attempt: the failure message (`nil` on success),
-    /// whether the runtime is now present, and whether the failure was a
-    /// missing tarball (for coarse telemetry classification).
-    private struct InstallOutcome {
-        let failureMessage: String?
-        let installed: Bool
-        let tarballMissing: Bool
+    /// Outcome of an install attempt. The failure case carries the coarse
+    /// telemetry reason (decided where the error is known) and an optional
+    /// user-facing message; illegal combinations are unrepresentable.
+    private enum InstallOutcome {
+        case success
+        case failure(reason: Telemetry.InstallFailureReason, message: String?)
+
+        var installed: Bool {
+            if case .success = self { return true }
+            return false
+        }
     }
 
     /// Runs the install and post-install verification off the main actor,
@@ -210,17 +212,15 @@ struct WhiskyWineInstallView: View {
         await Task.detached {
             do {
                 try WhiskyWineInstaller.install(from: tarball)
-                return InstallOutcome(
-                    failureMessage: nil,
-                    installed: WhiskyWineInstaller.isWhiskyWineInstalled(),
-                    tarballMissing: false
-                )
+                guard WhiskyWineInstaller.isWhiskyWineInstalled() else {
+                    // Extraction reported success but the runtime isn't usable.
+                    return .failure(reason: .runtimeIncomplete, message: nil)
+                }
+                return .success
             } catch {
-                return InstallOutcome(
-                    failureMessage: error.localizedDescription,
-                    installed: false,
-                    tarballMissing: (error as? WhiskyWineInstallError) == .tarballNotFound
-                )
+                let reason: Telemetry.InstallFailureReason =
+                    (error as? WhiskyWineInstallError) == .tarballNotFound ? .tarballMissing : .extractFailed
+                return .failure(reason: reason, message: error.localizedDescription)
             }
         }.value
     }

--- a/Whisky/Views/Setup/WhiskyWineInstallView.swift
+++ b/Whisky/Views/Setup/WhiskyWineInstallView.swift
@@ -143,7 +143,9 @@ struct WhiskyWineInstallView: View {
 
             let capturedTarURL = tarLocation
             diagnostics.record("Invoking WhiskyWineInstaller.install(from:) in detached task")
-            let (installFailureMessage, isInstalled) = await Self.performInstall(tarball: capturedTarURL)
+            let outcome = await Self.performInstall(tarball: capturedTarURL)
+            let installFailureMessage = outcome.failureMessage
+            let isInstalled = outcome.installed
             if let installFailureMessage {
                 diagnostics.record("Install failed: \(installFailureMessage)")
             }
@@ -162,16 +164,7 @@ struct WhiskyWineInstallView: View {
             diagnostics.record("Install attempt \(attemptNumber) finished (\(attemptResult))")
             diagnostics.record(finishLogMessage)
             installing = false
-            if isInstalled {
-                installError = nil
-            } else if let installFailureMessage {
-                installError = String(
-                    format: String(localized: "setup.whiskywine.error.installFailed.detail"),
-                    Self.shortened(installFailureMessage)
-                )
-            } else {
-                installError = String(localized: "setup.whiskywine.error.installFailed")
-            }
+            applyInstallOutcome(outcome)
             guard isInstalled else { return }
             // Only cleanup tarball after verified successful installation
             // This preserves it for retry attempts if installation fails
@@ -181,16 +174,53 @@ struct WhiskyWineInstallView: View {
         }
     }
 
-    /// Runs the install and post-install verification off the main actor, keeping
-    /// the plist read off the main thread. Returns the (Sendable) failure message
-    /// (`nil` on success) and whether the runtime is now present.
-    private static func performInstall(tarball: URL) async -> (failureMessage: String?, installed: Bool) {
+    /// Reports the funnel event and sets the user-facing error state.
+    @MainActor
+    private func applyInstallOutcome(_ outcome: InstallOutcome) {
+        if outcome.installed {
+            Telemetry.capture(.runtimeInstallSucceeded)
+            installError = nil
+        } else {
+            Telemetry.capture(
+                .runtimeInstallFailed(reason: outcome.tarballMissing ? .tarballMissing : .extractFailed)
+            )
+            if let failureMessage = outcome.failureMessage {
+                installError = String(
+                    format: String(localized: "setup.whiskywine.error.installFailed.detail"),
+                    Self.shortened(failureMessage)
+                )
+            } else {
+                installError = String(localized: "setup.whiskywine.error.installFailed")
+            }
+        }
+    }
+
+    /// Outcome of an install attempt: the failure message (`nil` on success),
+    /// whether the runtime is now present, and whether the failure was a
+    /// missing tarball (for coarse telemetry classification).
+    private struct InstallOutcome {
+        let failureMessage: String?
+        let installed: Bool
+        let tarballMissing: Bool
+    }
+
+    /// Runs the install and post-install verification off the main actor,
+    /// keeping the plist read off the main thread.
+    private static func performInstall(tarball: URL) async -> InstallOutcome {
         await Task.detached {
             do {
                 try WhiskyWineInstaller.install(from: tarball)
-                return (nil, WhiskyWineInstaller.isWhiskyWineInstalled())
+                return InstallOutcome(
+                    failureMessage: nil,
+                    installed: WhiskyWineInstaller.isWhiskyWineInstalled(),
+                    tarballMissing: false
+                )
             } catch {
-                return (error.localizedDescription, false)
+                return InstallOutcome(
+                    failureMessage: error.localizedDescription,
+                    installed: false,
+                    tarballMissing: (error as? WhiskyWineInstallError) == .tarballNotFound
+                )
             }
         }.value
     }

--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -57,6 +57,7 @@ struct WhiskyApp: App {
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
+        Telemetry.startIfConsented()
     }
 
     var body: some Scene {

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,11 @@ coverage:
         # Require new code to have at least 60% coverage
         target: 60%
         threshold: 10%
+        # Same rationale as the project gate: only WhiskyKit has real unit-test
+        # coverage. A diff that is mostly app-target SwiftUI code would otherwise
+        # be judged against best-effort UI-test coverage and fail unavoidably.
+        flags:
+          - whiskykit
 
   # Precision of coverage percentage (2 decimal places)
   precision: 2


### PR DESCRIPTION
## Summary
The tracker has had zero inbound reports since the fork started — no signal on where the ~2000 installs actually fail. This adds a minimal, privacy-first funnel:

- **Strictly opt-in**: a default-OFF checkbox in first-run setup, mirrored by a Settings → Privacy toggle. Existing installs never see the prompt and are never tracked. Declining stops all future capture and resets the anonymous ID (already-queued events may still deliver; the SDK has no public queue-purge).
- **Five events only**: `runtime_install_started` / `_succeeded` / `_failed` (coarse reason enum — `download_failed`, `verify_failed`, `tarball_missing`, `extract_failed`, `runtime_incomplete` — never raw error text, which contains paths), `first_bottle_created`, `first_program_launch_attempted`. `_started` fires once per setup pass; `_succeeded` / `_failed` count retries; the two `first_…` events fire at most once per install.
- PostHog SDK (app target only — WhiskyKit stays network-free) with **all automatic capture disabled**: no lifecycle events, screen views, feature flags, or swizzling. `personProfiles` is `.never`, `identify()` is never called, GeoIP enrichment is disabled (`$geoip_disable`). The whole integration is one file, `Whisky/Utils/Telemetry.swift`.
- Each user-facing failure message is paired with its telemetry reason in one place (`DownloadFailure` struct, `InstallOutcome` enum) so the surfaced error and the reported reason can't drift.
- The project token in `Info.plist` is public by design (ingest-only); an empty value disables telemetry entirely (logged if consent was granted).
- README and SECURITY.md document the exact event list and properties, plus the SDK's standard event context (verified against posthog-ios 3.59.3) and IP handling.

## Review fixes (latest revision)
- **Consent is now actually reachable on first run.** `SetupView` previously skipped the welcome screen — the only place the consent toggle lives — whenever the runtime was missing, which is *every* genuine first run. It now skips only once consent is decided, so first-run users are presented the opt-in before the install funnel runs.
- **Funnel coverage completed**: `first_program_launch_attempted` is now also captured from the programs-list and program-detail launch paths (previously only four of six launch sites).
- **Docs reconciled**: canonical SDK-context enumeration in SECURITY.md, corrected `runtime_install_started` retry semantics, and assorted comment/help-string accuracy fixes.
- **Observability**: a success-path log when telemetry starts, consent state recorded in the setup diagnostics report, and a guard against the download-start event double-firing.

## Verification
- Builds clean (xcodebuild Debug + SwiftLint strict + SwiftFormat).
- Consent gating: `capture` is a hard no-op unless the stored consent state is `granted`; SDK `setup` only happens after consent.