### PR TITLE
runtime: Wine Libraries v3.1.0 with bundled DXMT 0.80

### DIFF
--- a/.github/workflows/RuntimeTrack.yml
+++ b/.github/workflows/RuntimeTrack.yml
@@ -29,10 +29,11 @@ env:
   WINE_PINNED: "11.0_1"
   DXVK_REPO: Gcenx/DXVK-macOS
   DXVK_PINNED: v1.10.3-20230507-repack
-  # DXMT is not bundled yet (informational only until the DXMT runtime ships). When it
-  # ships, set this to the bundled tag (e.g. v0.80) to start flagging drift.
+  # v0.80 is the last MIT-licensed DXMT release (v1.0+ is LGPL); bundled since
+  # runtime v3.1.0. Bumping past it is a deliberate relicensing decision — see
+  # docs/DEPENDENCIES.md — not a routine drift fix.
   DXMT_REPO: 3Shain/dxmt
-  DXMT_PINNED: SET_ME
+  DXMT_PINNED: v0.80
 
 jobs:
   track:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Wine runtime updated to Libraries v3.1.0, which now bundles DXMT 0.80
+  (Direct3D 11 → Metal). The new backend is dormant in this release; per-bottle
+  selection arrives in 3.4.0. Wine 11.0 and DXVK 1.10.3 are unchanged.
+
 ## [3.3.0] - 2026-06-11 (App)
 
 ### Added

--- a/dist/pages/WhiskyWineVersion.plist
+++ b/dist/pages/WhiskyWineVersion.plist
@@ -2,18 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>dxmtVersion</key>
+	<string>0.80</string>
+	<key>dxvkVersion</key>
+	<string>1.10.3</string>
+	<key>sha256</key>
+	<string>86e2d54a60736f27e6ce82cacf2a91e500c20f6d32ae959a16afd912e6b03096</string>
 	<key>version</key>
 	<dict>
 		<key>major</key>
 		<integer>3</integer>
 		<key>minor</key>
-		<integer>0</integer>
+		<integer>1</integer>
 		<key>patch</key>
 		<integer>0</integer>
 	</dict>
-	<key>dxvkVersion</key>
-	<string>1.10.3</string>
-	<key>sha256</key>
-	<string>9c3d2a7d9bb682ae8398d8bae458e3cb52bb9f5a3345fb0830a64d9b6a1025f8</string>
 </dict>
 </plist>

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -9,12 +9,13 @@ See [`ReleaseWorkflow.md`](ReleaseWorkflow.md) for the assembly + publish proced
 [`.github/workflows/RuntimeTrack.yml`](../.github/workflows/RuntimeTrack.yml) for the automation that
 flags when a bundled component falls behind upstream.
 
-## Bundled in runtime `v3.0.0`
+## Bundled in runtime `v3.1.0`
 
 | Component | Bundled version | Upstream source | Notes |
 |-----------|-----------------|-----------------|-------|
 | **Wine** | 11.0 (Gcenx `11.0_1` repack) | [Gcenx/macOS_Wine_builds](https://github.com/Gcenx/macOS_Wine_builds/releases) | Wine ships a new stable each January; 11.0 = Jan 2026. The Gcenx tag is `11.0_1` (a repack of the same Wine 11.0; the bare `11.0` tag was retired) — `RuntimeTrack.yml` pins that exact tag. |
 | **DXVK (macOS)** | 1.10.3 | [Gcenx/DXVK-macOS](https://github.com/Gcenx/DXVK-macOS/releases) | Frozen at 1.10.x **by design** — the DXVK 2.x line needs Vulkan 1.3 features MoltenVK/macOS don't expose. Not stale; do not "upgrade" to upstream 2.x. |
+| **DXMT** | 0.80 | [3Shain/dxmt](https://github.com/3Shain/dxmt/releases) | Direct3D 11 → Metal. Bundled from the project's prebuilt v0.80 release — the **last MIT-licensed** build (v1.0+ is LGPL; bumping past 0.80 is a deliberate relicensing decision, not routine drift). Lives in `Libraries/DXMT/` (x64/x32 DLLs + LICENSE) with `winemetal.so` in Wine's unix lib tree; **inert until enabled per-bottle (app ≥ 3.4.0)**. Assembled via `scripts/assemble-runtime.sh` from the maintainer-held provenance archive. |
 | **D3DMetal** | from Apple Game Porting Toolkit | [Apple GPTK](https://developer.apple.com/games/game-porting-toolkit/) | **Apple-proprietary. Extracted, never built.** Redistribution is governed by Apple's GPTK license — review terms before bumping. The default backend for most titles. |
 | **MoltenVK** | (confirm against published archive) | [KhronosGroup/MoltenVK](https://github.com/KhronosGroup/MoltenVK/releases) | Vulkan→Metal; underpins the DXVK path. |
 | **msync** | (confirm against published archive) | [marzent/wine-msync](https://github.com/marzent/wine-msync) | Mach-based synchronization patch in the Gcenx build. |
@@ -26,6 +27,7 @@ flags when a bundled component falls behind upstream.
 
 | Artifact | SHA-256 |
 |----------|---------|
+| `Libraries.tar.gz` (`v3.1.0`) | `86e2d54a60736f27e6ce82cacf2a91e500c20f6d32ae959a16afd912e6b03096` |
 | `Libraries.tar.gz` (`v3.0.0`) | `9c3d2a7d9bb682ae8398d8bae458e3cb52bb9f5a3345fb0830a64d9b6a1025f8` |
 
 The same digest is published in
@@ -35,12 +37,6 @@ mismatch (a corrupted or truncated download is the common cause). This is an int
 substitute for HTTPS transport trust. When cutting a runtime release, compute the digest of the exact
 published asset (`shasum -a 256 Libraries.tar.gz`) and update **both** this table and the plist — an
 incorrect value will block every fresh install.
-
-## Planned additions
-
-| Component | Target version | Upstream source | Notes |
-|-----------|----------------|-----------------|-------|
-| **DXMT** | 0.80 | [3Shain/dxmt](https://github.com/3Shain/dxmt/releases) | Direct3D→Metal, production-stable as of Apr 2026 and shipping in CrossOver 26. Bundle the project's **prebuilt release** (no from-source build) and expose as a per-game graphics backend. Benchmark vs. DXVK 1.10.3 on lower-spec Macs before defaulting. |
 
 ## Tracking cadence
 

--- a/scripts/assemble-runtime.sh
+++ b/scripts/assemble-runtime.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Assembles a Wine Libraries runtime release from the previous published
+# release plus the locally archived DXMT payload. Produces Libraries.tar.gz
+# and prints its SHA-256 plus the follow-up checklist.
+#
+# Usage: scripts/assemble-runtime.sh <new-version>   e.g. 3.1.0
+#
+# The base release is downloaded from GitHub and digest-verified before use;
+# the DXMT payload is verified against the archive's SHA256SUMS. Both checks
+# fail closed.
+set -euo pipefail
+
+NEW_VERSION="${1:?usage: assemble-runtime.sh <new-version>, e.g. 3.1.0}"
+
+# ---- pinned inputs ----------------------------------------------------------
+BASE_TAG="v3.0.0"
+BASE_SHA256="9c3d2a7d9bb682ae8398d8bae458e3cb52bb9f5a3345fb0830a64d9b6a1025f8"
+DXMT_VERSION="0.80"
+DXMT_ARCHIVE_DIR="${DXMT_ARCHIVE_DIR:-$HOME/Projects/Whisky-runtime-archive/dxmt-v$DXMT_VERSION}"
+DXVK_VERSION="1.10.3"   # carried over unchanged from the base runtime
+REPO="frankea/Whisky"
+# -----------------------------------------------------------------------------
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$NEW_VERSION"
+[[ "${MAJOR}${MINOR}${PATCH}" =~ ^[0-9]+$ ]] || { echo "error: version must be X.Y.Z" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d /tmp/whisky-runtime-XXXXXX)"
+echo "Workdir: $WORKDIR"
+
+# 1. Verify and unpack the DXMT payload first — it's the cheap local check,
+#    so a bad archive fails fast before the multi-hundred-MB base download.
+( cd "$DXMT_ARCHIVE_DIR" && shasum -a 256 -c SHA256SUMS --ignore-missing ) \
+  || { echo "error: DXMT archive digest mismatch" >&2; exit 1; }
+mkdir -p "$WORKDIR/dxmt"
+tar -xzf "$DXMT_ARCHIVE_DIR/dxmt-v$DXMT_VERSION-builtin.tar.gz" -C "$WORKDIR/dxmt"
+DXMT_SRC="$WORKDIR/dxmt/v$DXMT_VERSION"
+[ -d "$DXMT_SRC/x86_64-windows" ] || { echo "error: unexpected DXMT payload layout" >&2; exit 1; }
+
+# 2. Fetch and verify the base runtime.
+gh release download "$BASE_TAG" --repo "$REPO" --pattern 'Libraries.tar.gz' --dir "$WORKDIR"
+echo "$BASE_SHA256  $WORKDIR/Libraries.tar.gz" | shasum -a 256 -c - \
+  || { echo "error: base runtime digest mismatch" >&2; exit 1; }
+
+# 3. Unpack the base runtime.
+tar -xzf "$WORKDIR/Libraries.tar.gz" -C "$WORKDIR"
+LIB="$WORKDIR/Libraries"
+[ -x "$LIB/Wine/bin/wine64" ] || { echo "error: base runtime missing Wine/bin/wine64" >&2; exit 1; }
+
+# 4. Place DXMT: Windows DLLs mirror the DXVK x64/x32 convention; the unix
+#    bridge is additive in Wine's own lib tree (no builtin collision, inert
+#    until the app activates the DXMT DLLs per-bottle).
+UNIXLIB="$LIB/Wine/lib/wine/x86_64-unix"
+[ -d "$UNIXLIB" ] || { echo "error: $UNIXLIB not found; Wine layout changed?" >&2; exit 1; }
+mkdir -p "$LIB/DXMT/x64" "$LIB/DXMT/x32"
+cp "$DXMT_SRC/x86_64-windows/"*.dll "$LIB/DXMT/x64/"
+cp "$DXMT_SRC/i386-windows/"*.dll   "$LIB/DXMT/x32/"
+cp "$DXMT_SRC/x86_64-unix/winemetal.so" "$UNIXLIB/winemetal.so"
+cp "$DXMT_ARCHIVE_DIR/LICENSE" "$LIB/DXMT/LICENSE"   # MIT: text must ship with the binaries
+xattr -rc "$LIB/DXMT" "$UNIXLIB/winemetal.so"
+
+# 5. Rewrite the inner version plist. No sha256 key inside the archive —
+#    only the published Pages plist advertises the digest.
+PLIST="$LIB/WhiskyWineVersion.plist"
+PB=/usr/libexec/PlistBuddy
+"$PB" -c "Set :version:major $MAJOR" -c "Set :version:minor $MINOR" -c "Set :version:patch $PATCH" "$PLIST"
+"$PB" -c "Delete :dxvkVersion" "$PLIST" 2>/dev/null || true
+"$PB" -c "Add :dxvkVersion string $DXVK_VERSION" "$PLIST"
+"$PB" -c "Delete :dxmtVersion" "$PLIST" 2>/dev/null || true
+"$PB" -c "Add :dxmtVersion string $DXMT_VERSION" "$PLIST"
+"$PB" -c "Delete :sha256" "$PLIST" 2>/dev/null || true
+plutil -lint "$PLIST"
+
+# 6. Repack. COPYFILE_DISABLE avoids ._ AppleDouble entries; --no-xattrs keeps
+#    quarantine and other xattrs out of the shipped archive.
+OUT="$WORKDIR/Libraries-v$NEW_VERSION.tar.gz"
+rm -f "$WORKDIR/Libraries.tar.gz"
+( cd "$WORKDIR" && COPYFILE_DISABLE=1 tar --no-xattrs -czf "$OUT" Libraries )
+
+DIGEST="$(shasum -a 256 "$OUT" | awk '{print $1}')"
+cat <<SUMMARY
+
+Assembled: $OUT
+SHA-256:   $DIGEST
+
+Follow-ups (see docs/ReleaseWorkflow.md "Wine Libraries release"):
+  1. Smoke test: install this archive locally, verify bottles + DXVK still work.
+  2. gh release create v$NEW_VERSION --repo $REPO --title "Wine Libraries v$NEW_VERSION" \\
+       --notes "Adds DXMT $DXMT_VERSION (inert until enabled per-bottle)." "$OUT#Libraries.tar.gz"
+  3. Update dist/pages/WhiskyWineVersion.plist: version $NEW_VERSION, sha256 $DIGEST, dxmtVersion $DXMT_VERSION.
+  4. Update docs/DEPENDENCIES.md (bundled table + integrity row) and RuntimeTrack DXMT_PINNED.
+SUMMARY

--- a/scripts/assemble-runtime.sh
+++ b/scripts/assemble-runtime.sh
@@ -84,8 +84,12 @@ SHA-256:   $DIGEST
 
 Follow-ups (see docs/ReleaseWorkflow.md "Wine Libraries release"):
   1. Smoke test: install this archive locally, verify bottles + DXVK still work.
-  2. gh release create v$NEW_VERSION --repo $REPO --title "Wine Libraries v$NEW_VERSION" \\
-       --notes "Adds DXMT $DXMT_VERSION (inert until enabled per-bottle)." "$OUT#Libraries.tar.gz"
+  2. cp "$OUT" "$WORKDIR/Libraries.tar.gz" && \\
+     gh release create v$NEW_VERSION --repo $REPO --title "Wine Libraries v$NEW_VERSION" \\
+       --notes "..." "$WORKDIR/Libraries.tar.gz"
+     # The asset FILENAME must be exactly Libraries.tar.gz — the app downloads
+     # releases/download/vX.Y.Z/Libraries.tar.gz by name. gh's "path#label"
+     # syntax only sets a display label and keeps the wrong filename.
   3. Update dist/pages/WhiskyWineVersion.plist: version $NEW_VERSION, sha256 $DIGEST, dxmtVersion $DXMT_VERSION.
   4. Update docs/DEPENDENCIES.md (bundled table + integrity row) and RuntimeTrack DXMT_PINNED.
 SUMMARY


### PR DESCRIPTION
## What

Publishes runtime **v3.1.0**: the verified v3.0.0 runtime plus an **inert DXMT 0.80 payload**, and adds the assembly script that produced it.

- `scripts/assemble-runtime.sh` — reproducible assembly: digest-verifies the previous published release and the DXMT archive (both fail closed), injects DXMT (`Libraries/DXMT/x64|x32` mirroring the DXVK layout, MIT license text included, `winemetal.so` additively in Wine's unix lib tree), rewrites the inner version plist, repacks without xattrs/AppleDouble.
- `dist/pages/WhiskyWineVersion.plist` → 3.1.0 + new sha256 + `dxmtVersion`. **This is the rollout switch**: it ships when the Pages workflow deploys after merge; from then on fresh installs download v3.1.0 and 3.3.0 users get the runtime-update prompt.
- `RuntimeTrack.yml`: `DXMT_PINNED: v0.80` (last MIT release — v1.0+ is LGPL; bumping is a deliberate relicensing decision).
- `docs/DEPENDENCIES.md`: DXMT moves Planned → Bundled; v3.1.0 integrity row added.

DXMT is **dormant** until the per-bottle backend ships in app 3.4.0 — v3.1.0 is behavior-identical for current users (no builtin collision: `winemetal.so`/`winemetal.dll` are additive, the conflicting d3d11/dxgi DLLs stay quarantined in `Libraries/DXMT/`).

## Release artifact

[Wine Libraries v3.1.0](https://github.com/frankea/Whisky/releases/tag/v3.1.0), asset `Libraries.tar.gz`
SHA-256 `86e2d54a60736f27e6ce82cacf2a91e500c20f6d32ae959a16afd912e6b03096` — round-trip verified byte-identical after upload.

## Verification

- Archive structure: 6 x64 + 4 x32 DXMT DLLs, LICENSE, `winemetal.so` in `Wine/lib/wine/x86_64-unix/`, no AppleDouble entries; inner plist 3.1.0 / dxvk 1.10.3 / dxmt 0.80, no self-referential `sha256` key.
- Local install smoke test: setup gate passes (plist decodes, `wine64` present), bottle with default D3DMetal path launches a program (visible Wine window), bottle with DXVK enabled launches (exercises `enableDXVK` copy from the new runtime).
- `shellcheck` clean; fail-fast paths tested (bad DXMT dir aborts before the base download).