### PR TITLE
fix: stop runtime installs from wiping the Application Support folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Installing or updating the Wine runtime no longer erases the rest of
+  Whisky's Application Support folder. Previously the installer wiped the
+  whole folder instead of just the runtime, destroying unrelated app state —
+  including the telemetry queue and anonymous ID, which is why a completed
+  install could go missing from the opt-in funnel.
+
 ### Changed
 - Wine runtime updated to Libraries v3.1.0, which now bundles DXMT 0.80
   (Direct3D 11 → Metal). The new backend is dormant in this release; per-bottle

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -147,9 +147,15 @@ public class WhiskyWineInstaller {
     }
 
     /// Extracts a WhiskyWine tarball into `destination`, replacing any existing
-    /// contents. Factored out of ``install(from:)`` so extraction can be tested
-    /// against a temporary directory without touching the real application
-    /// support folder.
+    /// `Libraries/` runtime there. Factored out of ``install(from:)`` so
+    /// extraction can be tested against a temporary directory without touching
+    /// the real application support folder.
+    ///
+    /// Only the `Libraries` subfolder is removed before extraction. The
+    /// destination is the live Application Support folder, which also holds
+    /// unrelated app state (e.g. the analytics SDK's anonymous ID and queued
+    /// events) — wiping the whole folder destroyed that state on every runtime
+    /// install and update.
     static func install(tarball: URL, into destination: URL) throws {
         // Verify the tarball exists before modifying the destination, so a
         // purged temp file can't leave the destination half-rebuilt.
@@ -157,8 +163,9 @@ public class WhiskyWineInstaller {
             throw WhiskyWineInstallError.tarballNotFound
         }
 
-        if FileManager.default.fileExists(atPath: destination.path) {
-            try FileManager.default.removeItem(at: destination)
+        let existingRuntime = destination.appending(path: "Libraries")
+        if FileManager.default.fileExists(atPath: existingRuntime.path) {
+            try FileManager.default.removeItem(at: existingRuntime)
         }
         try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
 

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -16,6 +16,7 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
+// swiftlint:disable file_length
 import CryptoKit
 import SemanticVersion
 @testable import WhiskyKit
@@ -258,6 +259,57 @@ final class WhiskyWineInstallerTests: XCTestCase {
         try WhiskyWineInstaller.install(tarball: tarball, into: destination)
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: stale.path), "Stale contents should be removed")
+        let extracted = destination.appendingPathComponent("Libraries/marker.txt")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: extracted.path))
+    }
+
+    func testInstallPreservesDestinationSiblingsOutsideLibraries() throws {
+        // The destination is the live Application Support folder: besides the
+        // runtime it holds unrelated app state (the analytics SDK's storage with
+        // its anonymous ID and queued events, and anything added later). A
+        // runtime install must replace only Libraries/, never its siblings —
+        // wiping the whole folder silently destroys that state on every
+        // install/update.
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let sourceDir = tempDir.appendingPathComponent("Libraries")
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try Data("marker".utf8).write(to: sourceDir.appendingPathComponent("marker.txt"))
+
+        let tarball = tempDir.appendingPathComponent("archive").appendingPathExtension("tar.gz")
+        let tar = Process()
+        tar.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        tar.currentDirectoryURL = tempDir
+        tar.arguments = ["-czf", tarball.path, "Libraries"]
+        try tar.run()
+        tar.waitUntilExit()
+        try XCTSkipUnless(tar.terminationStatus == 0, "Could not build the tar fixture")
+
+        // A destination that already has a stale runtime AND an unrelated
+        // sibling directory with a file in it.
+        let destination = tempDir.appendingPathComponent("dest")
+        let stale = destination.appendingPathComponent("Libraries/stale.txt")
+        try FileManager.default.createDirectory(
+            at: stale.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("stale".utf8).write(to: stale)
+        let sibling = destination.appendingPathComponent("analytics-store/queued-event.json")
+        try FileManager.default.createDirectory(
+            at: sibling.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("{}".utf8).write(to: sibling)
+
+        try WhiskyWineInstaller.install(tarball: tarball, into: destination)
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: sibling.path),
+            "Install must not delete unrelated state next to Libraries/ in the destination"
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stale.path), "Stale runtime contents are replaced")
         let extracted = destination.appendingPathComponent("Libraries/marker.txt")
         XCTAssertTrue(FileManager.default.fileExists(atPath: extracted.path))
     }


### PR DESCRIPTION
## What

`WhiskyWineInstaller.install(tarball:into:)` deleted the **entire destination folder** before extracting. The destination is the live Application Support directory, which also holds the analytics SDK's storage (anonymous ID + queued events) and any future app state. Scope the pre-extraction cleanup to `Libraries/` only.

## Impact of the bug (introduced in #95, shipped in 3.3.0)

Every runtime install or update silently destroyed the telemetry identity and queue:

- `runtime_install_succeeded`/`failed` are captured immediately **after** the wipe, into the just-deleted SDK storage → lost for every completed install. This is why the opt-in funnel has zero success events: a fresh install that completed setup could not report it.
- `first_bottle_created` / `first_program_launch_attempted` captured in the same post-install session also died — while their once-per-install flags (UserDefaults, which survives) were already burned, so those users can never emit them again.
- The anonymous ID rotates on next launch, splitting one install across multiple persons.

Bottles and their registry are unaffected (they live under `~/Library/Containers/<bundle-id>/`, not Application Support).

Reproduced live: a fresh-install run on a consented machine produced a verified 3.1.0 runtime on disk and **no install events**, with the SDK storage directory confirmed deleted mid-session.

## Fix

Remove only `destination/Libraries` before untarring. New regression test `testInstallPreservesDestinationSiblingsOutsideLibraries` (fails on the old code) proves a sibling directory with contents survives an install while the stale runtime is still fully replaced.

All 1030 WhiskyKit tests pass; `swiftlint --strict` clean.