### PR TITLE
fix: surface launch errors on the file-open path

### DIFF
--- a/Whisky/Views/ContentView.swift
+++ b/Whisky/Views/ContentView.swift
@@ -117,7 +117,8 @@ struct ContentView: View {
             FileOpenView(
                 fileURL: url,
                 currentBottle: selected,
-                bottles: bottleVM.bottles
+                bottles: bottleVM.bottles,
+                toast: $toast
             )
         }
         .onChange(of: selected) { oldValue, newValue in

--- a/Whisky/Views/FileOpenView.swift
+++ b/Whisky/Views/FileOpenView.swift
@@ -16,13 +16,17 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
+import os.log
 import SwiftUI
 import WhiskyKit
+
+private let logger = Logger(subsystem: Bundle.whiskyBundleIdentifier, category: "FileOpenView")
 
 struct FileOpenView: View {
     var fileURL: URL
     var currentBottle: URL?
     var bottles: [Bottle]
+    @Binding var toast: ToastData?
 
     @State private var selection: URL = .init(filePath: "")
     @Environment(\.dismiss) private var dismiss
@@ -96,7 +100,23 @@ struct FileOpenView: View {
                         try await Wine.runProgram(at: fileURL, bottle: bottle)
                     }
                 } catch {
-                    print(error)
+                    // Surface the failure on the presenting view's toast (the sheet
+                    // dismisses immediately, so a local toast wouldn't be seen) —
+                    // otherwise a launch error here, including DXMT's actionable
+                    // payloadMissing, vanishes silently.
+                    let errDesc = error.localizedDescription
+                    logger.error(
+                        "Failed to launch \(fileURL.lastPathComponent, privacy: .public): \(errDesc, privacy: .public)"
+                    )
+                    await MainActor.run {
+                        withAnimation {
+                            toast = ToastData(
+                                message: String(localized: "status.launchFailed \(errDesc)"),
+                                style: .error,
+                                autoDismiss: false
+                            )
+                        }
+                    }
                 }
             }
             dismiss()

--- a/Whisky/Views/FileOpenView.swift
+++ b/Whisky/Views/FileOpenView.swift
@@ -120,6 +120,11 @@ struct FileOpenView: View {
                 }
             }
             dismiss()
+        } else {
+            // onAppear seeds `selection` from `bottles`, so this should not
+            // happen — but never leave the sheet stuck open on a stale selection.
+            logger.error("Run requested but no bottle matched the selection")
+            dismiss()
         }
     }
 }


### PR DESCRIPTION
## Problem

`FileOpenView.run()` — the "which bottle?" sheet shown when opening a Windows program from Finder — caught launch errors with `catch { print(error) }` and dismissed the sheet unconditionally. Any failure on this path (a missing file, a Wine error, or DXMT's actionable `payloadMissing` now thrown by #110) vanished with no user-visible feedback — `print` isn't surfaced in release builds.

The three other launch paths already surface failures: `BottleView` and `PinView` via an error toast, `WhiskyCmd` via stderr + non-zero exit. This brings the file-open path in line.

## Fix

- Thread the presenting view's toast binding into `FileOpenView` (`ContentView` already owns `toast: ToastData?` + `.toast($toast)`). The sheet dismisses immediately, so a local toast wouldn't be seen — the error shows on the main window, matching `BottleView`.
- On failure: log via `os.Logger` and set a non-auto-dismissing `.error` toast using the existing `status.launchFailed %@` string. **No new localized keys.**

## Context

Spun out of the #110 review (silent-failure pass): #110 makes `enableDXMT` throw a user-actionable error on a non-native runtime, which made this pre-existing swallow worth closing. Pre-dates #110 and applies to all launch errors on this path, so it's its own focused change.

## Verification

- App builds (`BUILD SUCCEEDED`); SwiftFormat + SwiftLint `--strict` clean on both files.
- Reuses `status.launchFailed %@`; no catalog changes.
