### PR TITLE
runtime: advertise Wine Libraries v3.1.1 (native DXMT)

### DIFF
--- a/dist/pages/WhiskyWineVersion.plist
+++ b/dist/pages/WhiskyWineVersion.plist
@@ -7,7 +7,7 @@
 	<key>dxvkVersion</key>
 	<string>1.10.3</string>
 	<key>sha256</key>
-	<string>86e2d54a60736f27e6ce82cacf2a91e500c20f6d32ae959a16afd912e6b03096</string>
+	<string>01f3a1b43b98065fe20c529c1023b61dd79a6d2ad93bba6040865f646481ccf3</string>
 	<key>version</key>
 	<dict>
 		<key>major</key>
@@ -15,7 +15,7 @@
 		<key>minor</key>
 		<integer>1</integer>
 		<key>patch</key>
-		<integer>0</integer>
+		<integer>1</integer>
 	</dict>
 </dict>
 </plist>

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -9,7 +9,7 @@ See [`ReleaseWorkflow.md`](ReleaseWorkflow.md) for the assembly + publish proced
 [`.github/workflows/RuntimeTrack.yml`](../.github/workflows/RuntimeTrack.yml) for the automation that
 flags when a bundled component falls behind upstream.
 
-## Bundled in runtime `v3.1.0`
+## Bundled in runtime `v3.1.1`
 
 | Component | Bundled version | Upstream source | Notes |
 |-----------|-----------------|-----------------|-------|
@@ -27,6 +27,7 @@ flags when a bundled component falls behind upstream.
 
 | Artifact | SHA-256 |
 |----------|---------|
+| `Libraries.tar.gz` (`v3.1.1`) | `01f3a1b43b98065fe20c529c1023b61dd79a6d2ad93bba6040865f646481ccf3` |
 | `Libraries.tar.gz` (`v3.1.0`) | `86e2d54a60736f27e6ce82cacf2a91e500c20f6d32ae959a16afd912e6b03096` |
 | `Libraries.tar.gz` (`v3.0.0`) | `9c3d2a7d9bb682ae8398d8bae458e3cb52bb9f5a3345fb0830a64d9b6a1025f8` |
 


### PR DESCRIPTION
## ⚠️ Merge ordering — read first

**Do not merge this PR until the `v3.1.1` GitHub release asset (`Libraries.tar.gz`, sha256 `01f3a1b43b98065fe20c529c1023b61dd79a6d2ad93bba6040865f646481ccf3`) is published.** Merging deploys the Pages version manifest advertising v3.1.1; if the release isn't live, every fresh install and update will **404** trying to download `releases/download/v3.1.1/Libraries.tar.gz`.

Correct sequence:
1. `gh release create v3.1.1 …` (asset named exactly `Libraries.tar.gz`) — see notes below.
2. Then merge this PR.

## What

Bumps the runtime version metadata to **v3.1.1**, the re-cut runtime that ships DXMT's **native** per-prefix trio — activating the per-bottle DXMT backend whose app code merged in #110 (and which is gated off on the v3.1.0 builtin-variant payload).

- `dist/pages/WhiskyWineVersion.plist`: version `3.1.1`, sha256 `01f3a1b4…ccf3` (dxmtVersion/dxvkVersion unchanged).
- `docs/DEPENDENCIES.md`: bundled-runtime header → `v3.1.1`, new integrity row for the v3.1.1 archive (v3.1.0/v3.0.0 rows retained).

Wine 11.0 (Gcenx `11.0_1`) and DXVK 1.10.3 are unchanged from v3.1.0; only DXMT's on-disk layout changed (native trio + winemetal builtin), produced by the updated `scripts/assemble-runtime.sh`.

## Release notes to use for `gh release create v3.1.1`

> **Wine Libraries v3.1.1 — activates the per-bottle DXMT backend**
>
> Re-cut of the macOS Wine runtime. Wine 11.0 (Gcenx `11.0_1`) and DXVK 1.10.3 are unchanged from v3.1.0; the only change is how DXMT v0.80 is laid out:
> - The D3D translation trio (`d3d11`/`dxgi`/`d3d10core`) now ships as DXMT's **native per-prefix variant**, so Whisky 3.4+ selects DXMT per bottle (deployed like DXVK) without disturbing the shared D3DMetal/wined3d builtins.
> - `winemetal.dll` is paired into both Wine windows trees as its builtin (its `winemetal.so` unixlib bridge requires it).
>
> DXMT is Experimental and requires Whisky ≥ 3.4.
>
> SHA-256: `01f3a1b43b98065fe20c529c1023b61dd79a6d2ad93bba6040865f646481ccf3`

## Verification
- `plutil -lint` passes; manifest reads version 3.1.1 / sha256 `01f3a1b4…ccf3` / dxmtVersion 0.80.
- sha256 matches the locally-built + smoke-tested `Libraries-v3.1.1.tar.gz` (60/60-frame DXMT render verified end-to-end through the app on Apple M4 Pro).
