### PR TITLE
docs: correct [Unreleased] changelog for the 3.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole folder instead of just the runtime, destroying unrelated app state —
   including the telemetry queue and anonymous ID, which is why a completed
   install could go missing from the opt-in funnel.
+- A launch error for a Windows program opened from Finder is no longer
+  silently swallowed — it now surfaces as an error notification instead of
+  only being logged while the dialog closes.
 
 ### Changed
-- Wine runtime updated to Libraries v3.1.0, which now bundles DXMT 0.80
-  (Direct3D 11 → Metal). The new backend is dormant in this release; per-bottle
-  selection arrives in 3.4.0. Wine 11.0 and DXVK 1.10.3 are unchanged.
+- Wine runtime updated to Libraries v3.1.1, which ships DXMT 0.80 as the
+  native per-bottle backend (see Added). Wine 11.0 and DXVK 1.10.3 are
+  unchanged from the previous runtime.
 
 ## [3.3.0] - 2026-06-11 (App)
 


### PR DESCRIPTION
Tidies the `[Unreleased]` section so the 3.4.0 release commit is a clean `[Unreleased]` → `[3.4.0]` move:

- **Fixed**: adds the Finder file-open launch-error surfacing (#111), which wasn't listed.
- **Changed**: the runtime line said `v3.1.0` / DXMT "dormant" / "per-bottle selection arrives in 3.4.0" — stale and contradictory now that DXMT *is* this release. Corrected to v3.1.1 with DXMT shipping as the active per-bottle backend.

Docs-only; no code change.