### PR TITLE
docs: add release download badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
   ![](https://img.shields.io/github/actions/workflow/status/frankea/Whisky/CI.yml?style=for-the-badge&label=CI)
   [![](https://img.shields.io/codecov/c/github/frankea/Whisky?style=for-the-badge&logo=codecov&label=Coverage)](https://codecov.io/gh/frankea/Whisky)
+  [![](https://img.shields.io/github/downloads/frankea/Whisky/total?style=for-the-badge&logo=github&label=Downloads)](https://github.com/frankea/Whisky/releases)
+  [![](https://img.shields.io/github/downloads/frankea/Whisky/latest/total?style=for-the-badge&label=Latest)](https://github.com/frankea/Whisky/releases/latest)
   [![](https://img.shields.io/github/issues/frankea/Whisky?style=for-the-badge)](https://github.com/frankea/Whisky/issues)
   [![Documentation](https://img.shields.io/badge/Documentation-DocC-blue?style=for-the-badge)](https://frankea.github.io/Whisky/documentation/whiskykit/)
 </div>


### PR DESCRIPTION
Adds two auto-updating [shields.io](https://shields.io) download badges to the README badge row:

- **Downloads** — `github/downloads/frankea/Whisky/total` — all-time total across every release asset (currently ~7.2k). This is the same headline figure the [github-release-stats](https://tooomm.github.io/github-release-stats/?username=frankea&repository=Whisky) site reports; note it sums **both** app DMGs and the `Libraries.tar.gz` runtime tarball each install pulls once.
- **Latest** — `github/downloads/frankea/Whisky/latest/total` — downloads of the current release (GitHub flags `app-v3.4.0` as latest, so this tracks current-app uptake and rolls forward automatically each app release).

Both update live with no infra. Cumulative-only is a GitHub API limitation — the Releases API exposes no time-series history, so these show running totals, not a trend.