### PR TITLE
ci: skip macOS build/test jobs for docs-only changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,27 @@
 name: CI
 
 on:
+  # Docs-only changes can't affect the Swift build or tests, so skip the whole
+  # workflow (the macOS build/test/UI jobs are billed at a 10x minute multiplier).
+  # paths-ignore skips a run only when *every* changed file matches, so a PR that
+  # also touches code still runs the full suite.
+  #
+  # NOTE: `main` has no required status checks today, so a skipped docs PR simply
+  # reports no checks and stays mergeable. If branch protection is ever added that
+  # *requires* these checks by name, switch from this workflow-level paths-ignore
+  # to a job-level gate (a cheap `changes` detection job + `if: needs.changes...`
+  # on the macOS jobs) — otherwise a skipped docs PR would sit stuck "waiting for
+  # status to be reported".
   push:
     branches: [main]
+    paths-ignore: &docs-paths
+      - '**.md'
+      - 'docs/**'
+      - 'images/**'
+      - 'LICENSE'
   pull_request:
     branches: [main]
+    paths-ignore: *docs-paths
   workflow_dispatch:
 
 # Shared environment variables for consistency across jobs


### PR DESCRIPTION
## Problem

Every PR — including pure documentation changes like a README badge — runs the full CI matrix: three `build` jobs (Whisky/WhiskyCmd/WhiskyThumbnail), `Run Tests`, and `WhiskyUITests`, all on `macos-15`. GitHub bills macOS runner minutes at a **10× multiplier**, so a one-line README edit costs ~5 macOS jobs (~12 min of billed-at-10× time) for zero build relevance.

## Change

Adds `paths-ignore` to the `push` and `pull_request` triggers so the workflow is skipped when **every** changed file is documentation:

```yaml
paths-ignore:
  - '**.md'      # README, CHANGELOG, docs/*.md, CONTRIBUTING, SECURITY, …
  - 'docs/**'
  - 'images/**'  # README screenshots / demo gifs
  - 'LICENSE'
```

`paths-ignore` skips a run only when *all* changed files match, so a PR that touches any Swift/project/script/config file still runs the full suite. The cheap ubuntu `SecretScan` workflow is intentionally left running on everything (it's a security control, not billed at the macOS multiplier).

## Safety note

`main` currently has **no required status checks** (no branch protection / rulesets), so a skipped docs PR just reports no checks and stays mergeable — no "waiting for status" deadlock. A comment in the workflow documents that if required checks are ever added, this should move to a job-level `if:` gate (a `changes` detection job) so skipped docs PRs report the checks as neutral instead of blocking the merge.

This PR itself touches a workflow file (not docs), so the full suite runs here as expected — validating the workflow still parses and builds.