### PR TITLE
docs: uninstall guide, #1010 citation, open-PR audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,7 +238,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handler fired continuously on the permanently-readable EOF condition. The
   handler now removes itself on EOF (the final bytes are still drained when the
   process exits), so an idle Wine process no longer spins
-  (Closes whisky-app/whisky#917).
+  (Closes whisky-app/whisky#917, whisky-app/whisky#1010).
 - Moving a bottle no longer wipes its pinned-program list. The `move()` loop
   was shadowing the bottle's `url` with `pin.url`, causing
   `updateParentBottle` to compare a pin path against itself instead of the

--- a/README.md
+++ b/README.md
@@ -84,6 +84,34 @@ To switch:
 
 The original app uses a different bundle identifier (`com.franke.Whisky` here vs. `com.isaacmarovitz.Whisky`), which is why bottles aren't shared automatically. The old **Bottle → Export** / **File → Import Bottle** route still works if you'd rather move bottles by hand or onto another Mac. With no critical bottles, you can skip migration entirely — the new app creates a fresh bottle on first launch.
 
+## Uninstalling
+
+Dragging **Whisky.app** to the Trash (or `brew uninstall --cask frankea/whisky/whisky`) removes the app but leaves the Wine runtime, your bottles, and app data behind — by design, so reinstalling doesn't re-download ~313 MB or lose your bottles.
+
+> ⚠️ **Back up your bottles first if you want to keep them.** Removing the container below deletes every bottle stored in its default location. Bottles you created in a custom folder live wherever you put them — check **Bottle → Reveal in Finder** before deleting anything.
+
+To remove Whisky **completely**, delete the app and then these paths (all under `~/Library`):
+
+```sh
+# 1. The app itself
+rm -rf "/Applications/Whisky.app"          # or: brew uninstall --cask frankea/whisky/whisky
+
+# 2. Bottles + bottle list (default bottle location is inside this container)
+rm -rf ~/Library/Containers/com.franke.Whisky
+rm -rf ~/Library/Containers/com.franke.Whisky.WhiskyThumbnail
+
+# 3. The Wine runtime (~313 MB) and other app support
+rm -rf ~/Library/Application\ Support/com.franke.Whisky
+
+# 4. Caches, logs, preferences, and saved state
+rm -rf ~/Library/Caches/com.franke.Whisky
+rm -rf ~/Library/Logs/com.franke.Whisky
+rm -rf ~/Library/HTTPStorages/com.franke.Whisky
+rm -f  ~/Library/Preferences/com.franke.Whisky.plist
+```
+
+If you also installed bottles in a **custom location**, delete those folders too. Migrated bottles that still belong to the original app live under `~/Library/Containers/com.isaacmarovitz.Whisky` and are left untouched by the steps above.
+
 ## Telemetry (opt-in)
 
 Whisky sends **no data by default**. During first-run setup you can opt in to

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -40,6 +40,25 @@ The in-app Game DB UI surfaces this with:
 When a recipe doesn't work for you, please file an issue against this
 fork (not the archived upstream) so we can refine the entry.
 
+## Open upstream PRs
+
+The issue classifier does **not** look at pull requests. The 9 PRs left open
+when upstream archived were reviewed by hand (2026-06) against this fork's
+current code. Every *bug-fix* PR is resolved — several more thoroughly than the
+upstream patch; the rest are features or docs, tracked individually.
+
+| Upstream PR | Intent | Status in this fork |
+|---|---|---|
+| [#1374](https://github.com/whisky-app/whisky/pull/1374) | Nil the pipe readability handler to stop a high-CPU spin (#917) | **Fixed**, bettered — the handler removes itself on EOF *and* at termination (`Process+Extensions.swift`; Closes #917) |
+| [#1305](https://github.com/whisky-app/whisky/pull/1305) | Stop the 100%-CPU spin in `nextLine` (#1010) | **Fixed** — `nextLine` replaced by a 3-way `nextOutput()` enum that disarms the read source on EOF (Closes #1010) |
+| [#1264](https://github.com/whisky-app/whisky/pull/1264) | Make `WhiskyCmd run` actually launch the program (#1088, #1140) | **Fixed** — the CLI was rearchitected onto awaited `Wine.runProgram`, so the AppleScript-exits-early race and the env-var quote-escaping bug can't occur |
+| [#1339](https://github.com/whisky-app/whisky/pull/1339) | In-app Wine process monitor | **Present**, bettered — a per-bottle Processes page (name / PID / memory + graceful and force quit), not a separate window |
+| [#574](https://github.com/whisky-app/whisky/pull/574) | Async bottle / program-list loading | **Gap** — `updateInstalledPrograms()` still runs synchronously on the `@MainActor`, so opening a large bottle can hitch the UI |
+| [#765](https://github.com/whisky-app/whisky/pull/765) | Custom SwiftUI update UI | **Not adopted** — the fork uses Sparkle's stock update dialog |
+| [#571](https://github.com/whisky-app/whisky/pull/571) | Menu-bar extra (survive window close) | **Not adopted** — no `MenuBarExtra`; the app quits when the last window closes |
+| [#1207](https://github.com/whisky-app/whisky/pull/1207) / [#1206](https://github.com/whisky-app/whisky/issues/1206) | Document a complete uninstall | **Done** — see *Uninstalling* in the [README](../README.md) |
+| [#1375](https://github.com/whisky-app/whisky/pull/1375) | Crowdin translation sync | **N/A** — this fork manages translations through its own Crowdin project, not via PRs |
+
 ## Running the tool
 
 The tool is a single Python 3.12 script that fetches the upstream issue
@@ -95,9 +114,11 @@ Going forward, the workflow is:
   demand.
 - **Label drift.** Upstream labels were inconsistent; categorization is
   best effort.
-- **No upstream-PR correlation.** The tool doesn't trace upstream PRs
-  that closed issues before archival — those are upstream-fixed,
-  separate from "did this fork address it."
+- **No automated upstream-PR correlation.** The tool doesn't trace
+  upstream PRs — neither those that closed issues before archival
+  (upstream-fixed, separate from "did this fork address it") nor the PRs
+  left open at archival. The latter are reviewed by hand in
+  [Open upstream PRs](#open-upstream-prs).
 
 The headline counts are honest about every status's confidence,
 including the size of the `unverified` bucket. That's the point.


### PR DESCRIPTION
First of four follow-ups from the upstream open-issue/PR review. **Docs-only** — so this is also the first real exercise of the docs-skip CI from #115 (the macOS build/test jobs should not run here).

## Changes

- **README — Uninstalling section** (addresses upstream [#1206](https://github.com/whisky-app/whisky/issues/1206)): the original ask was "document how to completely remove Whisky," since trashing the app leaves the Wine runtime, bottles, and app data behind. Adds the exact `~/Library` paths to delete (container/bottles, Application Support runtime, caches/logs/prefs/HTTPStorages, thumbnail extension container), with a back-up-your-bottles warning and a note that custom-location bottles and migrated `com.isaacmarovitz.Whisky` bottles are left untouched. Paths verified against `BottleData.containerDir`, `WhiskyWineInstaller`, and what's actually on disk.

- **CHANGELOG — cite #1010**: the idle-CPU fix shipped in 3.1.0 already closes the famous "100% CPU the entire time" bug, but only cited [#917](https://github.com/whisky-app/whisky/issues/917). Added [#1010](https://github.com/whisky-app/whisky/issues/1010) so the upstream-issue audit credits the fix (it was reading as unaddressed purely for lack of a citation).

- **docs/AUDIT.md — Open upstream PRs section**: the audit tool explicitly listed "no upstream-PR correlation" as a blind spot. This records a hand review of all 9 PRs open at upstream archival. Every bug-fix PR (#1374, #1305, #1264, #1339) is resolved — several more thoroughly than the upstream patch. Remaining items are tracked honestly as gaps/feature-choices (#574 async loading, #765 custom update UI, #571 menu bar) and will flip to "done" as their follow-up PRs land.

No code changes.