### PR TITLE
perf: scan installed programs off the main actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Scanning a bottle for installed programs now runs off the main thread —
+  walking the `Program Files` trees and parsing each executable's metadata no
+  longer blocks the UI, so opening or switching to a bottle with many installed
+  programs no longer hitches. The programs list shows a progress indicator while
+  the scan runs (Closes whisky-app/whisky#574).
+
 ## [3.4.0] - 2026-06-13 (App)
 
 ### Added

--- a/Whisky/Extensions/Bottle+Extensions.swift
+++ b/Whisky/Extensions/Bottle+Extensions.swift
@@ -60,41 +60,6 @@ func nextDuplicateName(baseName: String, existingNames: [String]) -> String {
 private var wineUsernameCache: [URL: String] = [:]
 
 extension Bottle {
-    /// Lower-case basenames of known helper/crash-reporter executables that
-    /// pollute the installed-programs list. Filtered before the user's
-    /// `blocklist` so the visible list stays clean by default.
-    /// Conservative: only unambiguously-noise binaries (helpers, crash
-    /// reporters, redistributables). Generic `setup.exe`/`installer.exe`
-    /// are not included because users still need to launch installers.
-    fileprivate static let noiseExeNames: Set<String> = [
-        "steamerrorreporter.exe",
-        "steamerrorreporter64.exe",
-        "steamservice.exe",
-        "steamwebhelper.exe",
-        "steam_monitor.exe",
-        "steamsysinfo.exe",
-        "steamxboxutil.exe",
-        "crashreporter.exe",
-        "crashhandler.exe",
-        "crashpad_handler.exe",
-        "gameoverlayui.exe",
-        "gameoverlayui64.exe",
-        "fossilize-replay.exe",
-        "fossilize-replay64.exe",
-        "gldriverquery.exe",
-        "gldriverquery64.exe",
-        "hardwareupdater.exe",
-        "secure_desktop_capture.exe",
-        "writeminidump.exe",
-        "vc_redist.x86.exe",
-        "vc_redist.x64.exe",
-        "vcredist_x86.exe",
-        "vcredist_x64.exe",
-        "ueprereqsetup_x86.exe",
-        "ueprereqsetup_x64.exe",
-        "crossover html engine.exe"
-    ]
-
     /// The detected Wine username for this bottle.
     ///
     /// Wine creates user profile directories in `drive_c/users/`. This property
@@ -240,30 +205,38 @@ extension Bottle {
         return startMenuPrograms
     }
 
-    func updateInstalledPrograms() {
+    /// Rescans the bottle for installed programs and repopulates ``programs``.
+    ///
+    /// The expensive work — walking the `Program Files` trees and parsing each
+    /// executable's PE header — runs off the main actor so switching to or
+    /// opening a large bottle no longer hitches the UI. ``programsLoading`` is
+    /// set for the duration so views can show a progress indicator. A scan
+    /// already in flight is coalesced (a redundant concurrent call returns
+    /// early) — the in-flight scan publishes fresh results.
+    @MainActor
+    func updateInstalledPrograms() async {
+        guard !programsLoading else { return }
+        programsLoading = true
+        defer { programsLoading = false }
+
         let driveC = url.appending(path: "drive_c")
-        var programs: [Program] = []
+        // Snapshot main-actor state before crossing to the background task.
+        let blocklist = Set(settings.blocklist)
+
+        // Walk Program Files and parse each PE off the main actor (PEFile is Sendable).
+        let scanned: [(url: URL, peFile: PEFile?)] = await Task.detached(priority: .userInitiated) {
+            Bottle.discoverInstalledExecutables(driveC: driveC, blocklist: blocklist)
+                .map { (url: $0, peFile: try? PEFile(url: $0)) }
+        }.value
+
         var foundURLS: Set<URL> = []
-
-        for folderName in ["Program Files", "Program Files (x86)"] {
-            let folderURL = driveC.appending(path: folderName)
-            let enumerator = FileManager.default.enumerator(
-                at: folderURL, includingPropertiesForKeys: [.isExecutableKey], options: [.skipsHiddenFiles]
-            )
-
-            while let url = enumerator?.nextObject() as? URL {
-                guard !url.hasDirectoryPath, url.pathExtension == "exe" else { continue }
-                // Skip ClickOnce cache executables (noisy internal artifacts)
-                guard !url.path.contains("/Apps/2.0/") else { continue }
-                // Skip known launcher helpers and crash reporters that pollute the list
-                guard !Self.noiseExeNames.contains(url.lastPathComponent.lowercased()) else { continue }
-                guard !settings.blocklist.contains(url) else { continue }
-                foundURLS.insert(url)
-                programs.append(Program(url: url, bottle: self))
-            }
+        var programs: [Program] = []
+        for entry in scanned {
+            foundURLS.insert(entry.url)
+            programs.append(Program(url: entry.url, bottle: self, peFile: entry.peFile))
         }
 
-        // Detect ClickOnce applications
+        // Detect ClickOnce applications (small scan, kept on the main actor).
         let clickOnceApps = ClickOnceManager.shared.detectAppRefFile(in: self, wineUsername: wineUsername)
         for appRefURL in clickOnceApps {
             let displayName = ClickOnceManager.shared.displayName(for: appRefURL)

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -166,9 +166,7 @@ struct BottleView: View {
                                         programLoading = false
                                     }
                                 }
-                                await MainActor.run {
-                                    updateStartMenu()
-                                }
+                                await updateStartMenu()
                             }
                         }
                     }
@@ -183,8 +181,8 @@ struct BottleView: View {
                 }
                 .padding()
             }
-            .onAppear {
-                updateStartMenu()
+            .task {
+                await updateStartMenu()
             }
             .disabled(!bottle.isAvailable)
             .navigationTitle(bottle.settings.name)
@@ -271,8 +269,8 @@ struct BottleView: View {
         }
     }
 
-    private func updateStartMenu() {
-        bottle.updateInstalledPrograms()
+    private func updateStartMenu() async {
+        await bottle.updateInstalledPrograms()
 
         let startMenuPrograms = bottle.getStartMenuPrograms()
         for startMenuProgram in startMenuPrograms {

--- a/Whisky/Views/Bottle/Pins/PinCreationView.swift
+++ b/Whisky/Views/Bottle/Pins/PinCreationView.swift
@@ -114,7 +114,7 @@ struct PinCreationView: View {
         bottle.settings.pins.append(PinnedProgram(name: newPinName, url: newPinURL))
 
         // Trigger a reload
-        bottle.updateInstalledPrograms()
+        Task { await bottle.updateInstalledPrograms() }
         dismiss()
     }
 }

--- a/Whisky/Views/ContentView.swift
+++ b/Whisky/Views/ContentView.swift
@@ -92,7 +92,7 @@ struct ContentView: View {
                 Button {
                     bottleVM.loadBottles()
                     if let bottle = bottleVM.bottles.first(where: { $0.url == selected }) {
-                        bottle.updateInstalledPrograms()
+                        Task { await bottle.updateInstalledPrograms() }
                     }
                     triggerRefresh.toggle()
                     withAnimation(.default) {

--- a/Whisky/Views/Programs/ProgramMenuView.swift
+++ b/Whisky/Views/Programs/ProgramMenuView.swift
@@ -66,7 +66,7 @@ struct ProgramMenuView: View {
                     role: .destructive
                 ) {
                     try? FileManager.default.removeItem(at: program.url)
-                    program.bottle.updateInstalledPrograms()
+                    Task { await program.bottle.updateInstalledPrograms() }
                 }
                 .labelStyle(.titleAndIcon)
             }

--- a/Whisky/Views/Programs/ProgramsView.swift
+++ b/Whisky/Views/Programs/ProgramsView.swift
@@ -117,16 +117,23 @@ struct ProgramsView: View {
         .searchable(text: $searchText)
         .toolbar {
             ToolbarItem(placement: .automatic) {
-                Button {
-                    bottle.updateInstalledPrograms()
-                    loadData()
-                } label: {
-                    Label(
-                        String(localized: "program.clickonce.rescan"),
-                        systemImage: "arrow.clockwise"
-                    )
+                if bottle.programsLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Button {
+                        Task {
+                            await bottle.updateInstalledPrograms()
+                            loadData()
+                        }
+                    } label: {
+                        Label(
+                            String(localized: "program.clickonce.rescan"),
+                            systemImage: "arrow.clockwise"
+                        )
+                    }
+                    .help("program.clickonce.rescan")
                 }
-                .help("program.clickonce.rescan")
             }
         }
         .toast($toast)
@@ -135,6 +142,9 @@ struct ProgramsView: View {
         }
         .onChange(of: resortPrograms) {
             loadPrograms()
+        }
+        .onChange(of: bottle.programs) {
+            loadData()
         }
         .onChange(of: bottle.settings) {
             loadData()

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
@@ -93,6 +93,12 @@ public final class Bottle: ObservableObject, Equatable, Hashable, Identifiable, 
     @Published public var programs: [Program] = []
     /// Indicates whether the bottle is currently being created or modified.
     @Published public var inFlight: Bool = false
+    /// Indicates whether the installed-programs list is currently being scanned.
+    ///
+    /// Set while ``programs`` is being repopulated by an off-main-actor directory
+    /// walk, so the UI can show a loading indicator instead of hitching the main
+    /// thread on a large bottle.
+    @Published public var programsLoading: Bool = false
     /// Indicates whether the bottle's directory exists and is accessible.
     public var isAvailable: Bool = false
 
@@ -208,6 +214,80 @@ public final class Bottle: ObservableObject, Equatable, Hashable, Identifiable, 
                 "Failed to encode settings for bottle `\(self.metadataURL.path(percentEncoded: false))`: \(error)"
             )
         }
+    }
+
+    // MARK: - Program discovery
+
+    /// Lower-cased basenames of helper / crash-reporter / redistributable
+    /// executables that pollute the installed-programs list. Filtered before the
+    /// user's `blocklist` so the visible list stays clean by default.
+    ///
+    /// Conservative: only unambiguously-noise binaries (helpers, crash reporters,
+    /// redistributables). Generic `setup.exe`/`installer.exe` are intentionally
+    /// excluded because users still need to launch installers.
+    public nonisolated static let noiseExecutableNames: Set<String> = [
+        "steamerrorreporter.exe",
+        "steamerrorreporter64.exe",
+        "steamservice.exe",
+        "steamwebhelper.exe",
+        "steam_monitor.exe",
+        "steamsysinfo.exe",
+        "steamxboxutil.exe",
+        "crashreporter.exe",
+        "crashhandler.exe",
+        "crashpad_handler.exe",
+        "gameoverlayui.exe",
+        "gameoverlayui64.exe",
+        "fossilize-replay.exe",
+        "fossilize-replay64.exe",
+        "gldriverquery.exe",
+        "gldriverquery64.exe",
+        "hardwareupdater.exe",
+        "secure_desktop_capture.exe",
+        "writeminidump.exe",
+        "vc_redist.x86.exe",
+        "vc_redist.x64.exe",
+        "vcredist_x86.exe",
+        "vcredist_x64.exe",
+        "ueprereqsetup_x86.exe",
+        "ueprereqsetup_x64.exe",
+        "crossover html engine.exe"
+    ]
+
+    /// Walks the bottle's `Program Files` directories and returns the URLs of
+    /// installed `.exe` files, excluding ClickOnce cache artifacts, known noise
+    /// executables, and anything in `blocklist`.
+    ///
+    /// This is a pure filesystem read with no actor-isolated state, so callers
+    /// can run it off the main actor — it's the heavy part of repopulating
+    /// ``programs`` for a large bottle.
+    ///
+    /// - Parameters:
+    ///   - driveC: The bottle's `drive_c` directory.
+    ///   - blocklist: User-blocked program URLs to omit.
+    /// - Returns: Discovered executable URLs in filesystem-enumeration order.
+    public nonisolated static func discoverInstalledExecutables(
+        driveC: URL,
+        blocklist: Set<URL>
+    ) -> [URL] {
+        var found: [URL] = []
+        for folderName in ["Program Files", "Program Files (x86)"] {
+            let folderURL = driveC.appending(path: folderName)
+            let enumerator = FileManager.default.enumerator(
+                at: folderURL, includingPropertiesForKeys: [.isExecutableKey], options: [.skipsHiddenFiles]
+            )
+
+            while let url = enumerator?.nextObject() as? URL {
+                guard !url.hasDirectoryPath, url.pathExtension == "exe" else { continue }
+                // Skip ClickOnce cache executables (noisy internal artifacts)
+                guard !url.path.contains("/Apps/2.0/") else { continue }
+                // Skip known launcher helpers and crash reporters that pollute the list
+                guard !noiseExecutableNames.contains(url.lastPathComponent.lowercased()) else { continue }
+                guard !blocklist.contains(url) else { continue }
+                found.append(url)
+            }
+        }
+        return found
     }
 
     // MARK: - Equatable

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Program.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Program.swift
@@ -151,7 +151,22 @@ public final class Program: ObservableObject, Equatable, Hashable, Identifiable 
     /// - Parameters:
     ///   - url: The URL to the Windows executable (.exe) file.
     ///   - bottle: The ``Bottle`` that contains this program.
-    public init(url: URL, bottle: Bottle) {
+    public convenience init(url: URL, bottle: Bottle) {
+        self.init(url: url, bottle: bottle, peFile: try? PEFile(url: url))
+    }
+
+    /// Creates a new program instance from an already-parsed PE file.
+    ///
+    /// Use this when the PE file was parsed off the main actor (e.g. during a
+    /// bulk installed-programs scan), so the executable isn't re-read on the main
+    /// thread. Settings are still loaded here; that's a small per-program plist
+    /// read. Pass `nil` for `peFile` when the file isn't a parseable PE.
+    ///
+    /// - Parameters:
+    ///   - url: The URL to the Windows executable (.exe) file.
+    ///   - bottle: The ``Bottle`` that contains this program.
+    ///   - peFile: The pre-parsed PE metadata, or `nil` if it couldn't be parsed.
+    public init(url: URL, bottle: Bottle, peFile: PEFile?) {
         let name = url.lastPathComponent
         self.bottle = bottle
         self.url = url
@@ -180,11 +195,7 @@ public final class Program: ObservableObject, Equatable, Hashable, Identifiable 
             self.settings = ProgramSettings()
         }
 
-        do {
-            self.peFile = try PEFile(url: url)
-        } catch {
-            self.peFile = nil
-        }
+        self.peFile = peFile
     }
 
     /// Creates a new program instance for a ClickOnce application reference file.

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleProgramDiscoveryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleProgramDiscoveryTests.swift
@@ -1,0 +1,122 @@
+//
+//  BottleProgramDiscoveryTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WhiskyKit
+import XCTest
+
+/// Covers `Bottle.discoverInstalledExecutables`, the pure off-main-actor program
+/// scan that powers the async installed-programs loading (whisky-app/whisky#574).
+final class BottleProgramDiscoveryTests: XCTestCase {
+    private var driveC: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        driveC = FileManager.default.temporaryDirectory
+            .appending(path: "program_discovery_\(UUID().uuidString)")
+            .appending(path: "drive_c")
+        try FileManager.default.createDirectory(at: driveC, withIntermediateDirectories: true)
+        // The temp dir lives under /var, a symlink to /private/var. FileManager's
+        // directory enumerator canonicalises to /private/var, while URL/NSString
+        // `resolvingSymlinksInPath` strip /private back off — so they never agree.
+        // Use POSIX realpath to pin `driveC` to the same canonical form the
+        // enumerator returns, so constructed and discovered URLs (and the
+        // blocklist entry, compared by URL equality inside the helper) match.
+        // Real bottles live under ~/Library/Containers, which isn't symlinked.
+        driveC = Self.canonicalize(driveC)
+    }
+
+    /// Resolves a directory URL to its canonical filesystem path via `realpath`.
+    private static func canonicalize(_ url: URL) -> URL {
+        guard let resolved = realpath(url.path(percentEncoded: false), nil) else { return url }
+        defer { free(resolved) }
+        return URL(filePath: String(cString: resolved))
+    }
+
+    override func tearDownWithError() throws {
+        if let root = driveC?.deletingLastPathComponent() {
+            try? FileManager.default.removeItem(at: root)
+        }
+        try super.tearDownWithError()
+    }
+
+    /// Creates an empty file at `drive_c/<relativePath>`, making parent dirs.
+    @discardableResult
+    private func touch(_ relativePath: String) throws -> URL {
+        let url = driveC.appending(path: relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        XCTAssertTrue(FileManager.default.createFile(atPath: url.path(percentEncoded: false), contents: Data()))
+        return url
+    }
+
+    func testDiscoversExecutablesAcrossBothProgramFilesTrees() throws {
+        let game = try touch("Program Files/Game/game.exe")
+        let tool = try touch("Program Files (x86)/Tools/tool.exe")
+
+        let found = Bottle.discoverInstalledExecutables(driveC: driveC, blocklist: [])
+
+        XCTAssertEqual(Set(found), [game, tool])
+    }
+
+    func testIgnoresNonExecutableFiles() throws {
+        let game = try touch("Program Files/Game/game.exe")
+        try touch("Program Files/Game/readme.txt")
+        try touch("Program Files/Game/data.dll")
+
+        let found = Bottle.discoverInstalledExecutables(driveC: driveC, blocklist: [])
+
+        XCTAssertEqual(found, [game])
+    }
+
+    func testExcludesClickOnceCacheExecutables() throws {
+        let real = try touch("Program Files/App/app.exe")
+        try touch("Program Files/App/Apps/2.0/ABCDEF/cached.exe")
+
+        let found = Bottle.discoverInstalledExecutables(driveC: driveC, blocklist: [])
+
+        XCTAssertEqual(found, [real])
+    }
+
+    func testExcludesKnownNoiseExecutablesCaseInsensitively() throws {
+        let game = try touch("Program Files/Game/game.exe")
+        try touch("Program Files/Game/crashpad_handler.exe")
+        // The match lower-cases the basename, so mixed-case noise is still excluded.
+        try touch("Program Files/Game/SteamWebHelper.exe")
+
+        let found = Bottle.discoverInstalledExecutables(driveC: driveC, blocklist: [])
+
+        XCTAssertEqual(found, [game])
+    }
+
+    func testExcludesBlocklistedExecutables() throws {
+        let keep = try touch("Program Files/Game/game.exe")
+        let blocked = try touch("Program Files/Game/blocked.exe")
+
+        let found = Bottle.discoverInstalledExecutables(driveC: driveC, blocklist: [blocked])
+
+        XCTAssertEqual(found, [keep])
+    }
+
+    func testReturnsEmptyWhenNoProgramFilesPresent() {
+        let found = Bottle.discoverInstalledExecutables(driveC: driveC, blocklist: [])
+
+        XCTAssertTrue(found.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes the last performance gap from the upstream PR review: **upstream [#574](https://github.com/whisky-app/whisky/pull/574) "Async bottle loading."**

## Problem

`updateInstalledPrograms()` walked both `Program Files` trees **and** parsed every executable's PE header synchronously on the `@MainActor`-isolated `Bottle`. Opening or switching to a bottle with many installed programs hitched the UI while it scanned. (The audit flagged this as the one still-open item from #574.)

## Change

Move the heavy work off the main actor, following the existing `duplicate()`/`exportAsArchive()` pattern in the same file:

- **`Bottle.discoverInstalledExecutables(driveC:blocklist:)`** — a new `nonisolated static` helper (in WhiskyKit) that does the `Program Files` walk + filtering (exe extension, ClickOnce cache, noise executables, blocklist). Pure and unit-tested. `noiseExecutableNames` moved into WhiskyKit alongside it.
- **PE parsing offloaded too** — `PEFile` is `Sendable`, so the detached task parses each executable and returns `(URL, PEFile?)`. A new `Program(url:bottle:peFile:)` initializer builds the program on the main actor from the pre-parsed struct (the existing `init(url:bottle:)` is now a convenience initializer that parses then delegates — all existing call sites unchanged).
- **`programsLoading`** `@Published` flag drives a progress indicator: the programs-list toolbar shows a spinner in place of the rescan button while a scan runs, and the list refreshes when results publish.
- All callers (`BottleView` start-menu scan via `.task`, the rescan button, `ContentView`, `ProgramMenuView`, `PinCreationView`) updated to `await` the now-async scan. A re-entrancy guard coalesces redundant concurrent calls.

## Tests

New `BottleProgramDiscoveryTests` (6 cases) covering the pure helper: cross-tree discovery, non-exe exclusion, ClickOnce-cache exclusion, case-insensitive noise exclusion, blocklist exclusion, empty result.

## Verification

- `swift test --package-path WhiskyKit` — new tests pass.
- `xcodebuild ... -scheme Whisky` — **BUILD SUCCEEDED**.
- `swiftformat --lint .` and `swiftlint lint --strict` — clean.