### PR TITLE
feat: optional menu-bar extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Optional menu-bar extra (**Settings → General → "Show Whisky in the menu
+  bar"**, off by default). When enabled, a menu-bar item lets you launch a
+  bottle's pinned programs, reopen Whisky, or quit without the main window
+  focused — and Whisky keeps running after the window is closed, so it stays
+  reachable from the menu bar and running Wine processes aren't terminated.
+  When disabled, behaviour is unchanged (Closes whisky-app/whisky#571).
+
 ### Changed
 - Scanning a bottle for installed programs now runs off the main thread —
   walking the `Program Files` trees and parsing each executable's metadata no

--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		A1B2C3D4E5F60718A9B0C1D4 /* DLLOverrideConfigSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718A9B0C1D5 /* DLLOverrideConfigSection.swift */; };
 		A1B2C3D4E5F60718A9B0C1D6 /* ProgramOverrideSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718A9B0C1D7 /* ProgramOverrideSettingsView.swift */; };
 		AB0BCABD2B61036E00E21C31 /* RunningProcessesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0BCABC2B61036E00E21C31 /* RunningProcessesView.swift */; };
+		F1A2B3C4E5F61501A9B0C1E2 /* WhiskyMenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4E5F61501A9B0C1E1 /* WhiskyMenuBarView.swift */; };
 		B1A2C3D4E5F60302A9B0C1D3 /* ProcessesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A2C3D4E5F60302A9B0C1D2 /* ProcessesViewModel.swift */; };
 		B1C2D3E4F5A60402A9B0C1E0 /* BackendPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A60402A9B0C1E1 /* BackendPickerView.swift */; };
 		B1C2D3E4F5A60402A9B0C1E2 /* GraphicsConfigSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A60402A9B0C1E3 /* GraphicsConfigSection.swift */; };
@@ -254,6 +255,7 @@
 		AA2516958D60EC8937A2AF71 /* LaunchResult+Toast.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LaunchResult+Toast.swift"; sourceTree = "<group>"; };
 		AA88CFEB38031323229CD377 /* LauncherDiagnostics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LauncherDiagnostics.swift; sourceTree = "<group>"; };
 		AB0BCABC2B61036E00E21C31 /* RunningProcessesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningProcessesView.swift; sourceTree = "<group>"; };
+		F1A2B3C4E5F61501A9B0C1E1 /* WhiskyMenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiskyMenuBarView.swift; sourceTree = "<group>"; };
 		ADA9ADA587AF95DCFEC04F25 /* AudioAlertTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioAlertTracker.swift; sourceTree = "<group>"; };
 		B1A2C3D4E5F60302A9B0C1D2 /* ProcessesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessesViewModel.swift; sourceTree = "<group>"; };
 		B1C2D3E4F5A60402A9B0C1E1 /* BackendPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPickerView.swift; sourceTree = "<group>"; };
@@ -397,6 +399,14 @@
 			path = Programs;
 			sourceTree = "<group>";
 		};
+		F1A2B3C4E5F61501A9B0C1E3 /* MenuBar */ = {
+			isa = PBXGroup;
+			children = (
+				F1A2B3C4E5F61501A9B0C1E1 /* WhiskyMenuBarView.swift */,
+			);
+			path = MenuBar;
+			sourceTree = "<group>";
+		};
 		6E2FB15F2B589A9000E344C6 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
@@ -509,6 +519,7 @@
 				6E6C0CF02A419A5800356232 /* Setup */,
 				6E17B6472AF3FE2E00831173 /* Programs */,
 				6E355E5629D78202002D83BE /* Bottle */,
+				F1A2B3C4E5F61501A9B0C1E3 /* MenuBar */,
 				6E40495529CCA19C006E3F1B /* WhiskyApp.swift */,
 				6E40495729CCA19C006E3F1B /* ContentView.swift */,
 				6E064B1329DD331F00D9A2D2 /* SparkleView.swift */,
@@ -936,6 +947,7 @@
 				6E182FCA2B0BF64E00AADE81 /* WinetricksView.swift in Sources */,
 				6330DD962B1B0EA4007A625A /* RenameView.swift in Sources */,
 				AB0BCABD2B61036E00E21C31 /* RunningProcessesView.swift in Sources */,
+				F1A2B3C4E5F61501A9B0C1E2 /* WhiskyMenuBarView.swift in Sources */,
 				6E17B6492AF4118F00831173 /* EnvironmentArgView.swift in Sources */,
 				6E6C0CF42A419A7600356232 /* RosettaView.swift in Sources */,
 				6E6C0CF82A419A8C00356232 /* WhiskyWineInstallView.swift in Sources */,

--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -91,7 +91,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        true
+        // When the user opts into the menu-bar extra, keep Whisky running after
+        // the window closes so it stays reachable from the menu bar (and Wine
+        // processes keep running). Otherwise quit on last window close, as usual.
+        !UserDefaults.standard.bool(forKey: "showMenuBarExtra")
     }
 
     private static var appUrl: URL? {

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -12165,6 +12165,46 @@
         }
       }
     },
+    "menubar.bottle.noPins": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No pinned programs"
+          }
+        }
+      }
+    },
+    "menubar.empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No bottles yet"
+          }
+        }
+      }
+    },
+    "menubar.open": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Whisky"
+          }
+        }
+      }
+    },
+    "menubar.quit": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit Whisky"
+          }
+        }
+      }
+    },
     "open.bottle": {
       "localizations": {
         "ar": {
@@ -17236,6 +17276,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "Whisky 關閉時終止 Wine 進程"
+          }
+        }
+      }
+    },
+    "settings.toggle.menubar": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Whisky in the menu bar"
+          }
+        }
+      }
+    },
+    "settings.toggle.menubar.help": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a menu-bar item for launching pinned programs, and keep Whisky running after its window is closed."
           }
         }
       }

--- a/Whisky/Views/MenuBar/WhiskyMenuBarView.swift
+++ b/Whisky/Views/MenuBar/WhiskyMenuBarView.swift
@@ -1,0 +1,82 @@
+//
+//  WhiskyMenuBarView.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import WhiskyKit
+
+/// Content for the optional menu-bar extra (whisky-app/whisky#571).
+///
+/// Lets the user reopen Whisky, launch a bottle's pinned programs, and quit
+/// without the main window focused — and, paired with the "stay running"
+/// lifecycle, after the window has been closed entirely.
+struct WhiskyMenuBarView: View {
+    @EnvironmentObject private var bottleVM: BottleVM
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button("menubar.open") {
+            openMainWindow()
+        }
+        SettingsLink()
+
+        let bottles = bottleVM.bottles.filter(\.isAvailable)
+        Divider()
+        if bottles.isEmpty {
+            Text("menubar.empty")
+        } else {
+            ForEach(bottles) { bottle in
+                bottleMenu(bottle)
+            }
+        }
+
+        Divider()
+        Button("kill.bottles") {
+            WhiskyApp.killBottles()
+        }
+        Button("menubar.quit") {
+            NSApplication.shared.terminate(nil)
+        }
+    }
+
+    /// Submenu of a bottle's pinned programs, each launchable directly.
+    private func bottleMenu(_ bottle: Bottle) -> some View {
+        Menu(bottle.settings.name) {
+            let pinned = bottle.pinnedPrograms
+            if pinned.isEmpty {
+                Text("menubar.bottle.noPins")
+            } else {
+                ForEach(pinned, id: \.id) { entry in
+                    Button(entry.program.name) {
+                        Task { _ = await entry.program.launchWithUserMode(useTerminal: false) }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Brings an existing Whisky window forward, or opens a fresh one when the
+    /// window was closed while the app stayed running in the menu bar.
+    private func openMainWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+        if let window = NSApp.windows.first(where: { $0.canBecomeMain && $0.contentViewController != nil }) {
+            window.makeKeyAndOrderFront(nil)
+        } else {
+            openWindow(id: WhiskyApp.mainWindowID)
+        }
+    }
+}

--- a/Whisky/Views/Settings/SettingsView.swift
+++ b/Whisky/Views/Settings/SettingsView.swift
@@ -22,6 +22,7 @@ import WhiskyKit
 struct SettingsView: View {
     @AppStorage("SUEnableAutomaticChecks") var whiskyUpdate = true
     @AppStorage("killOnTerminate") var killOnTerminate = true
+    @AppStorage("showMenuBarExtra") var showMenuBarExtra = false
     @AppStorage("checkWhiskyWineUpdates") var checkWhiskyWineUpdates = true
     @AppStorage("defaultBottleLocation") var defaultBottleLocation = BottleData.defaultBottleDir
     @AppStorage("preferredTerminal") var preferredTerminal = "terminal"
@@ -40,6 +41,8 @@ struct SettingsView: View {
         Form {
             Section("settings.general") {
                 Toggle("settings.toggle.kill.on.terminate", isOn: $killOnTerminate)
+                Toggle("settings.toggle.menubar", isOn: $showMenuBarExtra)
+                    .help("settings.toggle.menubar.help")
                 Picker("settings.terminal", selection: $preferredTerminal) {
                     // installedTerminals should always include Terminal.app on macOS,
                     // but fall back to showing just Terminal if somehow empty

--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -34,6 +34,12 @@ struct WhiskyApp: App {
     /// auto-presentation (and the update check) be skipped in tests.
     static let isUITesting = ProcessInfo.processInfo.arguments.contains("-WhiskyUITestMode")
 
+    /// Scene id for the main window, used to reopen it from the menu-bar extra.
+    static let mainWindowID = "main"
+
+    /// Opt-in: show a menu-bar extra and keep Whisky running after the main
+    /// window closes (see `AppDelegate.applicationShouldTerminateAfterLastWindowClosed`).
+    @AppStorage("showMenuBarExtra") private var showMenuBarExtra = false
     @State var showSetup: Bool = false
     @State private var showMigrate: Bool = false
     @State private var showDiagnosticsSheet: Bool = false
@@ -61,7 +67,7 @@ struct WhiskyApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: Self.mainWindowID) {
             ContentView(showSetup: $showSetup)
                 .frame(minWidth: ViewWidth.large, minHeight: 316)
                 .environmentObject(BottleVM.shared)
@@ -195,6 +201,10 @@ struct WhiskyApp: App {
         }
         Settings {
             SettingsView()
+        }
+        MenuBarExtra("Whisky", systemImage: "wineglass", isInserted: $showMenuBarExtra) {
+            WhiskyMenuBarView()
+                .environmentObject(BottleVM.shared)
         }
     }
 

--- a/strix_runs/whisky_c5e3/run.json
+++ b/strix_runs/whisky_c5e3/run.json
@@ -1,0 +1,52 @@
+{
+  "run_id": "whisky_c5e3",
+  "run_name": "whisky_c5e3",
+  "start_time": "2026-06-13T21:47:30.840897+00:00",
+  "end_time": null,
+  "status": "running",
+  "targets_info": [
+    {
+      "type": "local_code",
+      "details": {
+        "target_path": "/Users/afranke/Projects/Whisky",
+        "workspace_subdir": "Whisky"
+      },
+      "original": "/Users/afranke/Projects/Whisky"
+    }
+  ],
+  "llm_usage": {
+    "requests": 0,
+    "input_tokens": 0,
+    "input_tokens_details": [
+      {
+        "cached_tokens": 0
+      }
+    ],
+    "output_tokens": 0,
+    "output_tokens_details": [
+      {
+        "reasoning_tokens": 0
+      }
+    ],
+    "total_tokens": 0,
+    "request_usage_entries": [],
+    "cost": 0.0,
+    "cost_source": "litellm_estimate",
+    "agents": []
+  },
+  "scan_mode": "deep",
+  "instruction": "",
+  "non_interactive": false,
+  "local_sources": [
+    {
+      "source_path": "/Users/afranke/Projects/Whisky",
+      "workspace_subdir": "Whisky"
+    }
+  ],
+  "diff_scope": {
+    "active": false,
+    "mode": "full"
+  },
+  "scope_mode": "full",
+  "diff_base": null
+}

--- a/strix_runs/whisky_c5e3/strix.log
+++ b/strix_runs/whisky_c5e3/strix.log
@@ -1,0 +1,8 @@
+2026-06-13 17:47:36.824 INFO    whisky_c5e3 - strix.core.runner: Starting Strix scan whisky_c5e3 (image=ghcr.io/usestrix/strix-sandbox:1.0.0, max_turns=500, interactive=True, run_dir=/Users/afranke/Projects/Whisky/strix_runs/whisky_c5e3)
+2026-06-13 17:47:36.824 INFO    whisky_c5e3 - strix.core.runner: LLM model resolved: litellm/deepseek/deepseek-v4-pro
+2026-06-13 17:47:36.825 INFO    whisky_c5e3 - strix.core.runner: Bringing up sandbox session for scan whisky_c5e3
+2026-06-13 17:47:36.825 DEBUG   whisky_c5e3 - strix.runtime.backends: Selected sandbox backend: docker
+2026-06-13 17:47:36.825 INFO    whisky_c5e3 - strix.runtime.session_manager: Creating sandbox session for scan whisky_c5e3 (backend=docker, image=ghcr.io/usestrix/strix-sandbox:1.0.0)
+2026-06-13 17:47:36.897 DEBUG   whisky_c5e3 - strix.runtime.docker_client: Creating sandbox container: image=ghcr.io/usestrix/strix-sandbox:1.0.0 caps=['NET_ADMIN', 'NET_RAW'] exposed_ports=[48080]
+2026-06-13 17:47:36.986 INFO    whisky_c5e3 - strix.runtime.docker_client: Sandbox container created: id=cc1a1a967583 image=ghcr.io/usestrix/strix-sandbox:1.0.0
+2026-06-13 17:47:37.311 DEBUG   - - strix.runtime.session_manager: cleanup(whisky_c5e3): no cached session


### PR DESCRIPTION
Implements **upstream [#571](https://github.com/whisky-app/whisky/pull/571) "Add menu bar."**

## What

An **opt-in** menu-bar extra, controlled by a single new setting (**Settings → General → "Show Whisky in the menu bar"**, off by default):

- **Off (default):** behaviour unchanged — no menu-bar item, and Whisky quits when the last window closes.
- **On:** a menu-bar item appears, and Whisky keeps running after the main window closes (so it stays reachable and running Wine processes aren't killed). The menu offers:
  - **Open Whisky** — brings the window forward, or reopens it if it was closed.
  - **Settings…** (`SettingsLink`).
  - Each available bottle as a submenu of its **pinned programs**, launchable directly (`launchWithUserMode`).
  - **Kill running bottles** and **Quit Whisky**.

## Design notes

- Opt-in rather than always-on, because keeping the app alive on window close (the premise of the upstream PR) is a behaviour change users shouldn't get unannounced. One toggle gates both the menu-bar item and the stay-running lifecycle, so it's all-or-nothing and discoverable.
- The lifecycle hook reads the same `showMenuBarExtra` default: `applicationShouldTerminateAfterLastWindowClosed` returns `false` only when the menu bar is enabled.
- Menu UI lives in its own `WhiskyMenuBarView` (`WhiskyApp` is already at its `type_body_length`/`file_length` ceiling).
- New EN strings added to `Localizable.xcstrings` at their sorted positions (translations via Crowdin).

## Verification

- `xcodebuild ... -scheme Whisky` — **BUILD SUCCEEDED**.
- `swiftformat --lint .` and `swiftlint lint --strict` — clean.
- `Localizable.xcstrings` validated as JSON.