### PR TITLE
feat: gentle scheduled update reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer blocks the UI, so opening or switching to a bottle with many installed
   programs no longer hitches. The programs list shows a progress indicator while
   the scan runs (Closes whisky-app/whisky#574).
+- Update checks are now gentler: a scheduled background check that finds a new
+  version no longer interrupts you with a focus-stealing dialog. Instead a Dock
+  badge appears and the "Check for Updates" menu item reads "Install Update…",
+  so you can apply it when ready. User-initiated checks and the install itself
+  are unchanged (Closes whisky-app/whisky#765).
 
 ## [3.4.0] - 2026-06-13 (App)
 

--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		63FFDE862ADF0C7700178665 /* BottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FFDE852ADF0C7700178665 /* BottomBar.swift */; };
 		6763D8F62BC6314100651D27 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6763D8F52BC6314100651D27 /* Constants.swift */; };
 		7A0510A52F5A000000000005 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0510A42F5A000000000004 /* Telemetry.swift */; };
+		F1A2B3C4E5F61601A9B0C1F2 /* SparkleUpdaterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4E5F61601A9B0C1F1 /* SparkleUpdaterDelegate.swift */; };
 		67D278512BC5907E006F9A1E /* ActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D278502BC5907E006F9A1E /* ActionView.swift */; };
 		689B4F6DF3B8006E89E1395F /* LauncherDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA88CFEB38031323229CD377 /* LauncherDiagnostics.swift */; };
 		6E064B1229DD32A200D9A2D2 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 6E064B1129DD32A200D9A2D2 /* Sparkle */; };
@@ -202,6 +203,7 @@
 		63FFDE852ADF0C7700178665 /* BottomBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomBar.swift; sourceTree = "<group>"; };
 		6763D8F52BC6314100651D27 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		7A0510A42F5A000000000004 /* Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
+		F1A2B3C4E5F61601A9B0C1F1 /* SparkleUpdaterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdaterDelegate.swift; sourceTree = "<group>"; };
 		67D278502BC5907E006F9A1E /* ActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionView.swift; sourceTree = "<group>"; };
 		6E064B1329DD331F00D9A2D2 /* SparkleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleView.swift; sourceTree = "<group>"; };
 		6E17B6452AF3FDC100831173 /* PinView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinView.swift; sourceTree = "<group>"; };
@@ -550,6 +552,7 @@
 				6E7C07BD2AAE7B0100F6E66B /* ProgramShortcut.swift */,
 				6763D8F52BC6314100651D27 /* Constants.swift */,
 				7A0510A42F5A000000000004 /* Telemetry.swift */,
+				F1A2B3C4E5F61601A9B0C1F1 /* SparkleUpdaterDelegate.swift */,
 				366E8BD2A51FD444160DFC10 /* LauncherDetection.swift */,
 				AA88CFEB38031323229CD377 /* LauncherDiagnostics.swift */,
 				G1A2B3C4E5F60901A9B0C1D1 /* DependencyManager.swift */,
@@ -923,6 +926,7 @@
 				EEA5A2462A31DD65008274AE /* AppDelegate.swift in Sources */,
 				6763D8F62BC6314100651D27 /* Constants.swift in Sources */,
 				7A0510A52F5A000000000005 /* Telemetry.swift in Sources */,
+				F1A2B3C4E5F61601A9B0C1F2 /* SparkleUpdaterDelegate.swift in Sources */,
 				6E70A4A12A9A280C007799E9 /* WhiskyCmd.swift in Sources */,
 				6E40495829CCA19C006E3F1B /* ContentView.swift in Sources */,
 				67D278512BC5907E006F9A1E /* ActionView.swift in Sources */,

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -3810,6 +3810,16 @@
         }
       }
     },
+    "check.updates.available": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install Update…"
+          }
+        }
+      }
+    },
     "cleanup.zombies.toast": {
       "localizations": {
         "en": {

--- a/Whisky/Utils/SparkleUpdaterDelegate.swift
+++ b/Whisky/Utils/SparkleUpdaterDelegate.swift
@@ -1,0 +1,83 @@
+//
+//  SparkleUpdaterDelegate.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import AppKit
+import Sparkle
+
+/// Adds gentle scheduled-update reminders on top of Sparkle's standard user
+/// driver (whisky-app/whisky#765, lighter-touch variant).
+///
+/// Sparkle's default behaviour pops a focus-stealing update dialog the moment a
+/// scheduled background check finds a new version. With this delegate, when the
+/// app isn't already active the reminder is *deferred*: a Dock-tile badge appears
+/// and `updateAvailable` flips on so the in-app "Check for Updates" item reads
+/// "Install Update…", letting the user act when ready. User-initiated checks and
+/// the actual download / install / relaunch still use Sparkle's proven standard
+/// UI unchanged.
+///
+/// `@unchecked Sendable` follows the project's singleton convention (see
+/// `ProcessRegistry`): the type carries mutable UI state but every access is on
+/// the main thread — Sparkle invokes these `SPUStandardUserDriverDelegate`
+/// callbacks on the main thread, so each one hops through `MainActor` before
+/// touching `NSApp` or the published flag.
+final class SparkleUpdaterDelegate: NSObject, ObservableObject, SPUStandardUserDriverDelegate, @unchecked Sendable {
+    static let shared = SparkleUpdaterDelegate()
+
+    /// True when a scheduled check found an update whose modal alert we deferred.
+    /// Drives the in-app "Install Update…" affordance.
+    @Published var updateAvailable = false
+
+    /// Opt into handling our own gentle reminders for scheduled updates.
+    var supportsGentleScheduledUpdateReminders: Bool {
+        true
+    }
+
+    func standardUserDriverShouldHandleShowingScheduledUpdate(
+        _ update: SUAppcastItem,
+        andInState state: SPUUserUpdateState
+    ) -> Bool {
+        // Let Sparkle show its standard alert immediately when the user is already
+        // looking at Whisky; otherwise defer to the gentle in-app reminder below.
+        MainActor.assumeIsolated { NSApp.isActive }
+    }
+
+    func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool,
+        forUpdate update: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        // When Sparkle isn't showing the alert itself (we deferred), raise the
+        // gentle indicator instead of stealing focus with a modal.
+        guard !handleShowingUpdate else { return }
+        MainActor.assumeIsolated { self.setUpdateAvailable(true) }
+    }
+
+    func standardUserDriverDidReceiveUserAttention(forUpdate update: SUAppcastItem) {
+        MainActor.assumeIsolated { self.setUpdateAvailable(false) }
+    }
+
+    func standardUserDriverWillFinishUpdateSession() {
+        MainActor.assumeIsolated { self.setUpdateAvailable(false) }
+    }
+
+    @MainActor
+    private func setUpdateAvailable(_ value: Bool) {
+        updateAvailable = value
+        NSApp.dockTile.badgeLabel = value ? "1" : ""
+    }
+}

--- a/Whisky/Views/SparkleView.swift
+++ b/Whisky/Views/SparkleView.swift
@@ -21,6 +21,7 @@ import SwiftUI
 
 struct SparkleView: View {
     @ObservedObject private var checkForUpdatesViewModel: CheckForUpdatesViewModel
+    @ObservedObject private var updaterDelegate = SparkleUpdaterDelegate.shared
     private let updater: SPUUpdater
 
     init(updater: SPUUpdater) {
@@ -29,8 +30,13 @@ struct SparkleView: View {
     }
 
     var body: some View {
-        Button("check.updates", action: updater.checkForUpdates)
-            .disabled(!checkForUpdatesViewModel.canCheckForUpdates)
+        // When a scheduled check has gently flagged an update, relabel the menu
+        // item so the deferred update is easy to act on.
+        Button(
+            updaterDelegate.updateAvailable ? "check.updates.available" : "check.updates",
+            action: updater.checkForUpdates
+        )
+        .disabled(!checkForUpdatesViewModel.canCheckForUpdates)
     }
 }
 

--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -61,7 +61,7 @@ struct WhiskyApp: App {
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: nil,
-            userDriverDelegate: nil
+            userDriverDelegate: SparkleUpdaterDelegate.shared
         )
         Telemetry.startIfConsented()
     }


### PR DESCRIPTION
Closes the last gap from the upstream review: **upstream [#765](https://github.com/whisky-app/whisky/pull/765) "Create a Custom Update UI"** — implemented as the **lighter-touch** variant (per discussion), keeping Sparkle's proven update mechanism rather than replacing its user driver wholesale.

## Problem

Sparkle's default behaviour pops a focus-stealing update dialog the instant a scheduled background check finds a new version — the abrupt UX the upstream PR set out to improve.

## Change

A `SPUStandardUserDriverDelegate` (`SparkleUpdaterDelegate`) that opts into Sparkle's **gentle scheduled reminders**:

- When a scheduled check finds an update and the app **isn't** active, the modal is deferred: a **Dock-tile badge** appears and `updateAvailable` flips on, so the in-app **Check for Updates** menu item reads **"Install Update…"**. The user applies it when ready.
- When the app **is** active, or the user initiated the check, Sparkle shows its standard alert as before.
- The actual download / install / relaunch flow is **unchanged** — still Sparkle's standard, battle-tested UI. This is the key reason for the lighter-touch approach: the parts that can't be CI-verified are left exactly as they are today.

## Notes

- `@unchecked Sendable` singleton follows the project convention (`ProcessRegistry`); Sparkle invokes the delegate on the main thread, so each callback hops through `MainActor` before touching `NSApp`/`@Published` (required under the project's Swift 6 complete-concurrency setting).
- New `SparkleUpdaterDelegate.swift` registered in `project.pbxproj`; `check.updates.available` EN string added to the catalog (Crowdin handles translations).

## Verification

- `xcodebuild ... -scheme Whisky` — **BUILD SUCCEEDED** (verified with `set -o pipefail`).
- `swiftformat --lint` / `swiftlint lint --strict` — clean.
- Fully CI-buildable; no live-update path was replaced, so nothing here depends on an un-testable update server interaction.