### PR TITLE
feat: describe bottle configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Bottle configuration options now carry inline descriptions explaining what
+  they do. The Wine section (Windows version, build, enhanced sync, DPI, Retina
+  mode) and the DXVK section (DXVK, async, HUD) previously had no explanation;
+  each now shows a one-line caption so you can make an informed choice without
+  hunting through docs (Closes whisky-app/whisky#807).
 - Optional menu-bar extra (**Settings → General → "Show Whisky in the menu
   bar"**, off by default). When enabled, a menu-bar item lets you launch a
   bottle's pinned programs, reopen Whisky, or quit without the main window

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -4332,6 +4332,16 @@
         }
       }
     },
+    "config.buildVersion.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Windows build number Wine reports. Leave unset unless a program needs a specific build."
+          }
+        }
+      }
+    },
     "config.cleanup": {
       "localizations": {
         "en": {
@@ -4740,6 +4750,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "DPI 縮放"
+          }
+        }
+      }
+    },
+    "config.dpi.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the bottle's screen DPI to scale Windows text and interface elements."
           }
         }
       }
@@ -5290,6 +5310,26 @@
         }
       }
     },
+    "config.dxvk.async.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compile shaders in the background to reduce stutter, with a small risk of brief visual glitches."
+          }
+        }
+      }
+    },
+    "config.dxvk.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Translate Direct3D 9–11 to Vulkan via DXVK. Helps some games; D3DMetal is the default elsewhere."
+          }
+        }
+      }
+    },
     "config.dxvkHud": {
       "localizations": {
         "ar": {
@@ -5694,6 +5734,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "全開"
+          }
+        }
+      }
+    },
+    "config.dxvkHud.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overlay DXVK statistics (FPS, version, memory) on top of the running game."
           }
         }
       }
@@ -6238,6 +6288,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "ESync"
+          }
+        }
+      }
+    },
+    "config.enhancedSync.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In-process synchronization for Wine threads. MSync is fastest on macOS; ESync is a fallback; None is most compatible."
           }
         }
       }
@@ -7616,6 +7676,16 @@
         }
       }
     },
+    "config.retinaMode.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Render at full Retina resolution for sharper output. Disable if a game looks tiny or runs slowly."
+          }
+        }
+      }
+    },
     "config.retry": {
       "localizations": {
         "en": {
@@ -8227,6 +8297,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Windows 版本"
+          }
+        }
+      }
+    },
+    "config.winVersion.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Windows version Wine reports to programs. Windows 10 suits most apps."
           }
         }
       }

--- a/Whisky/Views/Bottle/DXVKConfigSection.swift
+++ b/Whisky/Views/Bottle/DXVKConfigSection.swift
@@ -26,17 +26,33 @@ struct DXVKConfigSection: View {
     var body: some View {
         Section("config.title.dxvk", isExpanded: $isExpanded) {
             Toggle(isOn: $bottle.settings.dxvk) {
-                Text("config.dxvk")
+                VStack(alignment: .leading) {
+                    Text("config.dxvk")
+                    Text("config.dxvk.info")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             Toggle(isOn: $bottle.settings.dxvkAsync) {
-                Text("config.dxvk.async")
+                VStack(alignment: .leading) {
+                    Text("config.dxvk.async")
+                    Text("config.dxvk.async.info")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             .disabled(!bottle.settings.dxvk)
-            Picker("config.dxvkHud", selection: $bottle.settings.dxvkHud) {
-                Text("config.dxvkHud.full").tag(DXVKHUD.full)
-                Text("config.dxvkHud.partial").tag(DXVKHUD.partial)
-                Text("config.dxvkHud.fps").tag(DXVKHUD.fps)
-                Text("config.dxvkHud.off").tag(DXVKHUD.off)
+            VStack(alignment: .leading, spacing: 2) {
+                Picker("config.dxvkHud", selection: $bottle.settings.dxvkHud) {
+                    Text("config.dxvkHud.full").tag(DXVKHUD.full)
+                    Text("config.dxvkHud.partial").tag(DXVKHUD.partial)
+                    Text("config.dxvkHud.fps").tag(DXVKHUD.fps)
+                    Text("config.dxvkHud.off").tag(DXVKHUD.off)
+                }
+                Text("config.dxvkHud.info")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             .disabled(!bottle.settings.dxvk)
         }

--- a/Whisky/Views/Bottle/SettingItemView.swift
+++ b/Whisky/Views/Bottle/SettingItemView.swift
@@ -27,6 +27,9 @@ enum LoadingState: Equatable {
 
 struct SettingItemView<Content: View>: View {
     let title: String.LocalizationValue
+    /// Optional one-line explanation shown beneath the title, so users can make
+    /// an informed choice without external docs.
+    var description: String.LocalizationValue?
     let loadingState: LoadingState
     var onRetry: (() -> Void)?
     @ViewBuilder var content: () -> Content
@@ -36,9 +39,18 @@ struct SettingItemView<Content: View>: View {
 
     var body: some View {
         HStack {
-            Text(String(localized: title))
-                .multilineTextAlignment(.leading)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: title))
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if let description {
+                    Text(String(localized: description))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
 
             HStack {
                 switch loadingState {

--- a/Whisky/Views/Bottle/WineConfigSection.swift
+++ b/Whisky/Views/Bottle/WineConfigSection.swift
@@ -42,7 +42,11 @@ struct WineConfigSection: View {
 
     var body: some View {
         Section("config.title.wine", isExpanded: $isExpanded) {
-            SettingItemView(title: "config.winVersion", loadingState: winVersionLoadingState) {
+            SettingItemView(
+                title: "config.winVersion",
+                description: "config.winVersion.info",
+                loadingState: winVersionLoadingState
+            ) {
                 Picker("config.winVersion", selection: $bottle.settings.windowsVersion) {
                     ForEach(WinVersion.allCases.reversed(), id: \.self) {
                         Text($0.pretty())
@@ -51,6 +55,7 @@ struct WineConfigSection: View {
             }
             SettingItemView(
                 title: "config.buildVersion",
+                description: "config.buildVersion.info",
                 loadingState: buildVersionLoadingState,
                 onRetry: onRetryBuildVersion
             ) {
@@ -78,6 +83,7 @@ struct WineConfigSection: View {
             }
             SettingItemView(
                 title: "config.retinaMode",
+                description: "config.retinaMode.info",
                 loadingState: retinaModeLoadingState,
                 onRetry: onRetryRetinaMode
             ) {
@@ -113,13 +119,20 @@ struct WineConfigSection: View {
                     }
                 }
             }
-            Picker("config.enhancedSync", selection: $bottle.settings.enhancedSync) {
-                Text("config.enhancedSync.none").tag(EnhancedSync.none)
-                Text("config.enhancedSync.esync").tag(EnhancedSync.esync)
-                Text("config.enhancedSync.msync").tag(EnhancedSync.msync)
+            VStack(alignment: .leading, spacing: 2) {
+                Picker("config.enhancedSync", selection: $bottle.settings.enhancedSync) {
+                    Text("config.enhancedSync.none").tag(EnhancedSync.none)
+                    Text("config.enhancedSync.esync").tag(EnhancedSync.esync)
+                    Text("config.enhancedSync.msync").tag(EnhancedSync.msync)
+                }
+                Text("config.enhancedSync.info")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             SettingItemView(
                 title: "config.dpi",
+                description: "config.dpi.info",
                 loadingState: dpiConfigLoadingState,
                 onRetry: onRetryDpi
             ) {


### PR DESCRIPTION
Implements **upstream [#807](https://github.com/whisky-app/whisky/issues/807) "Describe bottle configuration options"** — users couldn't tell what options like "Retina mode" or "Enhanced sync" actually do.

## What

The Performance, Graphics, and Input sections already show an inline caption under each option, but the **Wine** and **DXVK** sections didn't. This adds the same one-line caption to every bare option:

- **Wine:** Windows version, build version, enhanced sync, DPI, Retina mode
- **DXVK:** DXVK toggle, async, HUD

`SettingItemView` gains an optional `description` rendered beneath the title (used by the Wine rows, which are `SettingItemView`-based); the DXVK toggles/picker use the existing `VStack { title; caption }` idiom.

## Notes

- 8 new EN strings added to `Localizable.xcstrings` at their sorted neighbors (Crowdin handles translations) — matching the existing `config.*.info` keys like `config.forceD3D11.info`.
- No behavior change — descriptions only.

## Verification
- `xcodebuild ... -scheme Whisky` — **BUILD SUCCEEDED**
- `swiftformat --lint` / `swiftlint lint --strict` — clean
- catalog validated as JSON