### PR TITLE
ci: bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/AutoAssign.yml
+++ b/.github/workflows/AutoAssign.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign to maintainers
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
     name: SwiftLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: SwiftLint
         uses: norio-nomura/action-swiftlint@3.2.1
         with:
@@ -50,7 +50,7 @@ jobs:
     name: SwiftFormat
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install SwiftFormat
         run: |
           # Install SwiftFormat via pre-built binary
@@ -79,7 +79,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -89,7 +89,7 @@ jobs:
       # Cache includes WhiskyKit/.build for consistency with test job cache paths
       # (swift build creates artifacts there, xcodebuild uses DerivedData)
       - name: Cache SPM Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData/*/SourcePackages
@@ -126,7 +126,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -134,7 +134,7 @@ jobs:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Cache SPM Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData/*/SourcePackages
@@ -184,7 +184,7 @@ jobs:
       - name: Upload app-target coverage to Codecov
         if: always()
         continue-on-error: true
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage-app.xml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Upload xcresult bundle on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ui-test-xcresult
           path: TestResults.xcresult
@@ -208,7 +208,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -218,7 +218,7 @@ jobs:
       # Cache includes WhiskyKit/.build because swift build/test creates
       # build artifacts there (unlike xcodebuild which uses DerivedData)
       - name: Cache SPM Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData/*/SourcePackages
@@ -316,7 +316,7 @@ jobs:
           fi
       
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: WhiskyKit/coverage.lcov
@@ -326,7 +326,7 @@ jobs:
       
       - name: Upload Coverage Report (Artifact)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: WhiskyKit/coverage.lcov

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -37,7 +37,7 @@ jobs:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Cache SPM Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData/*/SourcePackages
@@ -66,7 +66,7 @@ jobs:
           ls -la docs/
 
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
@@ -80,4 +80,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/SecretScan.yml
+++ b/.github/workflows/SecretScan.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full history so trufflehog can compare base..head on PRs and
           # HEAD~1..HEAD on direct pushes. Interpolated values below are


### PR DESCRIPTION
## Why

GitHub Actions runners begin defaulting to **Node 24 on 2026-06-16** (Node 20 reached EOL April 2026) — [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Actions still bundling Node 20 will emit deprecation warnings and eventually break. This bumps the Node-based actions to their Node-24 majors.

## Changes

| Action | From → To | Notes |
|---|---|---|
| `actions/checkout` | v4 → **v6** | Node 24; drop-in for default usage |
| `actions/cache` | v4 → **v5** | Node 24 |
| `actions/upload-artifact` | v4 → **v7** | Node 24; verified no input changes for our usage (name/path/if-no-files-found) |
| `actions/github-script` | v7 → **v9** | Node 24; our script just calls `issues.addAssignees` (stable) |
| `actions/upload-pages-artifact` | v3 → **v5** | Node 24; paired with deploy-pages |
| `actions/deploy-pages` | v4 → **v5** | Node 24; compatible with upload-pages-artifact v3+ |
| `codecov/codecov-action` | v5 → **v7** | Composite action (not Node, technically unaffected); bumped for currency, all inputs (token/files/flags/fail_ci_if_error/verbose) verified present in v7 |

**Left as-is:** `maxim-lobanov/setup-xcode@v1` already runs on `node24` (v1.7.0); `trufflesecurity/trufflehog@main` and `norio-nomura/action-swiftlint@3.2.1` are Docker actions (no Node runtime).

**Runner compatibility:** Node 24 drops macOS ≤13.4; our runners are `macos-15` (CI) and `macos-14` (Documentation) — both fine.

## Verification

- This PR's CI exercises checkout@v6, cache@v5, upload-artifact@v7, codecov@v7 (CI.yml) and github-script@v9 (AutoAssign on PR-open) directly — breakage shows red here.
- **Not** exercised by this PR: the Pages pair in `Documentation.yml` (path-filtered to `WhiskyKit/**` + `dist/pages/**`). After merge I'll trigger it via `workflow_dispatch` to confirm the appcast still deploys before relying on it.