### PR TITLE
fix: harden menu-bar extra, update reminders, and program scanning

### DIFF
--- a/Whisky/Extensions/Bottle+Extensions.swift
+++ b/Whisky/Extensions/Bottle+Extensions.swift
@@ -213,9 +213,10 @@ extension Bottle {
     /// set for the duration so views can show a progress indicator.
     ///
     /// Concurrent callers are coalesced via ``Bottle/coalesceProgramScan(_:)``:
-    /// a redundant call awaits the in-flight scan rather than dropping, so a
+    /// a redundant call awaits the in-flight scan rather than dropping it, so a
     /// caller that reads ``programs`` right after (e.g. the Start Menu auto-pin)
-    /// always sees the fresh list, never a stale one.
+    /// sees that scan's completed results instead of a half-populated or empty
+    /// list.
     @MainActor
     func updateInstalledPrograms() async {
         await coalesceProgramScan { [self] in

--- a/Whisky/Extensions/Bottle+Extensions.swift
+++ b/Whisky/Extensions/Bottle+Extensions.swift
@@ -210,48 +210,52 @@ extension Bottle {
     /// The expensive work — walking the `Program Files` trees and parsing each
     /// executable's PE header — runs off the main actor so switching to or
     /// opening a large bottle no longer hitches the UI. ``programsLoading`` is
-    /// set for the duration so views can show a progress indicator. A scan
-    /// already in flight is coalesced (a redundant concurrent call returns
-    /// early) — the in-flight scan publishes fresh results.
+    /// set for the duration so views can show a progress indicator.
+    ///
+    /// Concurrent callers are coalesced via ``Bottle/coalesceProgramScan(_:)``:
+    /// a redundant call awaits the in-flight scan rather than dropping, so a
+    /// caller that reads ``programs`` right after (e.g. the Start Menu auto-pin)
+    /// always sees the fresh list, never a stale one.
     @MainActor
     func updateInstalledPrograms() async {
-        guard !programsLoading else { return }
-        programsLoading = true
-        defer { programsLoading = false }
+        await coalesceProgramScan { [self] in
+            programsLoading = true
+            defer { programsLoading = false }
 
-        let driveC = url.appending(path: "drive_c")
-        // Snapshot main-actor state before crossing to the background task.
-        let blocklist = Set(settings.blocklist)
+            let driveC = url.appending(path: "drive_c")
+            // Snapshot main-actor state before crossing to the background task.
+            let blocklist = Set(settings.blocklist)
 
-        // Walk Program Files and parse each PE off the main actor (PEFile is Sendable).
-        let scanned: [(url: URL, peFile: PEFile?)] = await Task.detached(priority: .userInitiated) {
-            Bottle.discoverInstalledExecutables(driveC: driveC, blocklist: blocklist)
-                .map { (url: $0, peFile: try? PEFile(url: $0)) }
-        }.value
+            // Walk Program Files and parse each PE off the main actor (PEFile is Sendable).
+            let scanned: [(url: URL, peFile: PEFile?)] = await Task.detached(priority: .userInitiated) {
+                Bottle.discoverInstalledExecutables(driveC: driveC, blocklist: blocklist)
+                    .map { (url: $0, peFile: try? PEFile(url: $0)) }
+            }.value
 
-        var foundURLS: Set<URL> = []
-        var programs: [Program] = []
-        for entry in scanned {
-            foundURLS.insert(entry.url)
-            programs.append(Program(url: entry.url, bottle: self, peFile: entry.peFile))
+            var foundURLS: Set<URL> = []
+            var programs: [Program] = []
+            for entry in scanned {
+                foundURLS.insert(entry.url)
+                programs.append(Program(url: entry.url, bottle: self, peFile: entry.peFile))
+            }
+
+            // Detect ClickOnce applications (small scan, kept on the main actor).
+            let clickOnceApps = ClickOnceManager.shared.detectAppRefFile(in: self, wineUsername: wineUsername)
+            for appRefURL in clickOnceApps {
+                let displayName = ClickOnceManager.shared.displayName(for: appRefURL)
+                let program = Program(appRefURL: appRefURL, bottle: self, displayName: displayName)
+                programs.append(program)
+            }
+
+            // Add missing programs from pins
+            for pin in settings.pins {
+                guard let url = pin.url else { continue }
+                guard !foundURLS.contains(url) else { continue }
+                programs.append(Program(url: url, bottle: self))
+            }
+
+            self.programs = programs.sorted { $0.name.lowercased() < $1.name.lowercased() }
         }
-
-        // Detect ClickOnce applications (small scan, kept on the main actor).
-        let clickOnceApps = ClickOnceManager.shared.detectAppRefFile(in: self, wineUsername: wineUsername)
-        for appRefURL in clickOnceApps {
-            let displayName = ClickOnceManager.shared.displayName(for: appRefURL)
-            let program = Program(appRefURL: appRefURL, bottle: self, displayName: displayName)
-            programs.append(program)
-        }
-
-        // Add missing programs from pins
-        for pin in settings.pins {
-            guard let url = pin.url else { continue }
-            guard !foundURLS.contains(url) else { continue }
-            programs.append(Program(url: url, bottle: self))
-        }
-
-        self.programs = programs.sorted { $0.name.lowercased() < $1.name.lowercased() }
     }
 
     @MainActor

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -12265,6 +12265,17 @@
         }
       }
     },
+    "menubar.launchFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't launch %@"
+          }
+        }
+      }
+    },
     "menubar.open": {
       "localizations": {
         "en": {

--- a/Whisky/Utils/SparkleUpdaterDelegate.swift
+++ b/Whisky/Utils/SparkleUpdaterDelegate.swift
@@ -23,12 +23,13 @@ import Sparkle
 /// driver (whisky-app/whisky#765, lighter-touch variant).
 ///
 /// Sparkle's default behaviour pops a focus-stealing update dialog the moment a
-/// scheduled background check finds a new version. With this delegate, when the
-/// app isn't already active the reminder is *deferred*: a Dock-tile badge appears
-/// and `updateAvailable` flips on so the in-app "Check for Updates" item reads
-/// "Install Update…", letting the user act when ready. User-initiated checks and
-/// the actual download / install / relaunch still use Sparkle's proven standard
-/// UI unchanged.
+/// scheduled background check finds a new version. With this delegate, when
+/// Sparkle wouldn't show the update in immediate focus — i.e. the user is mid-task
+/// rather than just having launched the app or left the system idle — the reminder
+/// is *deferred*: a Dock-tile badge appears and `updateAvailable` flips on so the
+/// in-app "Check for Updates" item reads "Install Update…", letting the user act
+/// when ready. User-initiated checks and the actual download / install / relaunch
+/// still use Sparkle's proven standard UI unchanged.
 ///
 /// `@unchecked Sendable` follows the project's singleton convention (see
 /// `ProcessRegistry`): the type carries mutable UI state but every access is on
@@ -54,9 +55,11 @@ final class SparkleUpdaterDelegate: NSObject, ObservableObject, SPUStandardUserD
         // Selector matters: Sparkle's real delegate method is
         // `…ShouldHandleShowingScheduledUpdate:andInImmediateFocus:`. An earlier
         // `…andInState:` signature didn't match, so it was never called and the
-        // deferral below was dead. Let Sparkle show its standard alert immediately
-        // when it would appear in focus (the app is active); otherwise defer to the
-        // gentle in-app reminder.
+        // deferral was dead. Returning `immediateFocus` is Sparkle's canonical
+        // gentle-reminder gate: it's true when Sparkle would show the update in
+        // immediate, utmost focus (the app was launched recently or the system has
+        // been idle a while) — let the standard alert show then; otherwise return
+        // false to defer to the gentle in-app reminder while the user is mid-task.
         immediateFocus
     }
 

--- a/Whisky/Utils/SparkleUpdaterDelegate.swift
+++ b/Whisky/Utils/SparkleUpdaterDelegate.swift
@@ -49,11 +49,15 @@ final class SparkleUpdaterDelegate: NSObject, ObservableObject, SPUStandardUserD
 
     func standardUserDriverShouldHandleShowingScheduledUpdate(
         _ update: SUAppcastItem,
-        andInState state: SPUUserUpdateState
+        andInImmediateFocus immediateFocus: Bool
     ) -> Bool {
-        // Let Sparkle show its standard alert immediately when the user is already
-        // looking at Whisky; otherwise defer to the gentle in-app reminder below.
-        MainActor.assumeIsolated { NSApp.isActive }
+        // Selector matters: Sparkle's real delegate method is
+        // `…ShouldHandleShowingScheduledUpdate:andInImmediateFocus:`. An earlier
+        // `…andInState:` signature didn't match, so it was never called and the
+        // deferral below was dead. Let Sparkle show its standard alert immediately
+        // when it would appear in focus (the app is active); otherwise defer to the
+        // gentle in-app reminder.
+        immediateFocus
     }
 
     func standardUserDriverWillHandleShowingUpdate(

--- a/Whisky/Views/MenuBar/WhiskyMenuBarView.swift
+++ b/Whisky/Views/MenuBar/WhiskyMenuBarView.swift
@@ -16,6 +16,7 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
+import os.log
 import SwiftUI
 import WhiskyKit
 
@@ -54,26 +55,71 @@ struct WhiskyMenuBarView: View {
     }
 
     /// Submenu of a bottle's pinned programs, each launchable directly.
+    ///
+    /// Reads `settings.pins` directly rather than `bottle.pinnedPrograms`: the
+    /// latter resolves pins against `bottle.programs`, which stays empty until a
+    /// bottle view scans it. On a fresh launch (no bottle ever opened) that would
+    /// make every bottle wrongly report "no pinned programs". Pins live in
+    /// settings and are always loaded, so they're the right source here.
     private func bottleMenu(_ bottle: Bottle) -> some View {
         Menu(bottle.settings.name) {
-            let pinned = bottle.pinnedPrograms
-            if pinned.isEmpty {
+            let pins = bottle.settings.pins.filter { pin in
+                guard let path = pin.url?.path(percentEncoded: false) else { return false }
+                return FileManager.default.fileExists(atPath: path)
+            }
+            if pins.isEmpty {
                 Text("menubar.bottle.noPins")
             } else {
-                ForEach(pinned, id: \.id) { entry in
-                    Button(entry.program.name) {
-                        Task { _ = await entry.program.launchWithUserMode(useTerminal: false) }
-                    }
+                ForEach(pins, id: \.url) { pin in
+                    Button(pin.name) { launch(pin, in: bottle) }
                 }
             }
         }
+    }
+
+    /// Launches a pinned program, surfacing failures the user would otherwise
+    /// never see.
+    ///
+    /// The `Program` is built from the pin so this doesn't depend on a prior
+    /// bottle scan. Failures are reported via an `NSAlert` rather than a view
+    /// toast because the menu-bar extra can be the app's only surface (the main
+    /// window may be closed), so there's no toast presenter to reach.
+    @MainActor
+    private func launch(_ pin: PinnedProgram, in bottle: Bottle) {
+        guard let url = pin.url else { return }
+        let program = Program(url: url, bottle: bottle)
+        Task {
+            let result = await program.launchWithUserMode(useTerminal: false)
+            guard case let .launchFailed(_, errorDescription) = result else { return }
+            Logger.wineKit.error(
+                "Menu-bar launch failed for \(pin.name, privacy: .public): \(errorDescription, privacy: .public)"
+            )
+            presentLaunchFailure(programName: pin.name, error: errorDescription)
+        }
+    }
+
+    @MainActor
+    private func presentLaunchFailure(programName: String, error: String) {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "menubar.launchFailed \(programName)")
+        alert.informativeText = error
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: String(localized: "button.ok"))
+        NSApp.activate(ignoringOtherApps: true)
+        alert.runModal()
     }
 
     /// Brings an existing Whisky window forward, or opens a fresh one when the
     /// window was closed while the app stayed running in the menu bar.
     private func openMainWindow() {
         NSApp.activate(ignoringOtherApps: true)
-        if let window = NSApp.windows.first(where: { $0.canBecomeMain && $0.contentViewController != nil }) {
+        // Match only windows from the main WindowGroup (identifier
+        // "main-AppWindow-N"). The Settings window also `canBecomeMain`, so the
+        // old predicate could bring *it* forward — or, when Settings was the only
+        // open window, leave the main window unopened — on "Open Whisky".
+        if let window = NSApp.windows.first(where: {
+            $0.identifier?.rawValue.hasPrefix(WhiskyApp.mainWindowID) == true && $0.canBecomeMain
+        }) {
             window.makeKeyAndOrderFront(nil)
         } else {
             openWindow(id: WhiskyApp.mainWindowID)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
@@ -102,6 +102,10 @@ public final class Bottle: ObservableObject, Equatable, Hashable, Identifiable, 
     /// Indicates whether the bottle's directory exists and is accessible.
     public var isAvailable: Bool = false
 
+    /// The in-flight program scan, if any, used to coalesce concurrent rescans.
+    /// See ``coalesceProgramScan(_:)``.
+    private var programScanTask: Task<Void, Never>?
+
     // MARK: - Cross-actor access (nonisolated members on @MainActor Bottle)
 
     /// The unique identifier for this bottle.
@@ -288,6 +292,29 @@ public final class Bottle: ObservableObject, Equatable, Hashable, Identifiable, 
             }
         }
         return found
+    }
+
+    /// Runs a program rescan, coalescing concurrent callers onto one scan.
+    ///
+    /// If a scan is already in flight this awaits *that* scan instead of starting
+    /// a duplicate or returning early. The distinction matters: a caller that
+    /// returns early would read a stale ``programs`` afterward (e.g. the Start
+    /// Menu auto-pin pinning against an empty list), whereas awaiting the in-flight
+    /// scan guarantees the caller sees its fresh results. The owning call clears
+    /// the handle when its scan finishes, so a later call starts a fresh scan.
+    ///
+    /// - Parameter scan: The rescan body; should publish into ``programs`` and
+    ///   manage ``programsLoading``. Only the owning call runs it — coalesced
+    ///   callers just await the shared result.
+    public func coalesceProgramScan(_ scan: @escaping @MainActor () async -> Void) async {
+        if let existing = programScanTask {
+            await existing.value
+            return
+        }
+        let task = Task { @MainActor in await scan() }
+        programScanTask = task
+        defer { programScanTask = nil }
+        await task.value
     }
 
     // MARK: - Equatable

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Bottle.swift
@@ -297,11 +297,16 @@ public final class Bottle: ObservableObject, Equatable, Hashable, Identifiable, 
     /// Runs a program rescan, coalescing concurrent callers onto one scan.
     ///
     /// If a scan is already in flight this awaits *that* scan instead of starting
-    /// a duplicate or returning early. The distinction matters: a caller that
-    /// returns early would read a stale ``programs`` afterward (e.g. the Start
-    /// Menu auto-pin pinning against an empty list), whereas awaiting the in-flight
-    /// scan guarantees the caller sees its fresh results. The owning call clears
-    /// the handle when its scan finishes, so a later call starts a fresh scan.
+    /// a duplicate or returning early. The distinction matters versus an
+    /// early-return guard: a caller that bailed out would then read whatever
+    /// ``programs`` happened to hold (e.g. the Start Menu auto-pin pinning against
+    /// an empty list), whereas awaiting means the caller observes the in-flight
+    /// scan's freshly published results before it proceeds. The owning call clears
+    /// the handle when its scan finishes, so the next call starts a fresh scan.
+    ///
+    /// The coalesced result reflects the in-flight scan, which began at the
+    /// *owning* call — so a caller that must observe a change it made after that
+    /// scan started should rescan once the current one completes.
     ///
     /// - Parameter scan: The rescan body; should publish into ``programs`` and
     ///   manage ``programsLoading``. Only the owning call runs it — coalesced

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleProgramScanTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleProgramScanTests.swift
@@ -1,0 +1,149 @@
+//
+//  BottleProgramScanTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WhiskyKit
+import XCTest
+
+/// Shared mutable state for the coalescing tests. `@MainActor` because every
+/// access happens from a main-actor test closure, which keeps the mutable
+/// captures legal under strict concurrency without a `var` capture dance.
+@MainActor
+private final class ScanProbe {
+    var runCount = 0
+    var published: String?
+    var resume: CheckedContinuation<Void, Never>?
+}
+
+/// Tests for ``Bottle/coalesceProgramScan(_:)`` — the wrapper that makes
+/// `updateInstalledPrograms()` coalesce concurrent rescans instead of dropping
+/// them. These pin the contract so a future "simplification" back to an
+/// early-return guard (which reintroduces the stale-`programs` bug behind the
+/// Start Menu auto-pin) fails loudly.
+final class BottleProgramScanTests: XCTestCase {
+    var tempDir: URL!
+    var bottleURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory.appending(path: "bottle_scan_test_\(UUID().uuidString)")
+        bottleURL = tempDir.appending(path: "TestBottle")
+        let driveCURL = bottleURL.appending(path: "drive_c")
+        try? FileManager.default.createDirectory(at: driveCURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    /// Spins (yielding the main actor) until `predicate` holds, with a bounded
+    /// ceiling so a broken implementation fails the test instead of hanging CI.
+    @MainActor
+    private func spinUntil(
+        _ predicate: () -> Bool,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        var spins = 0
+        while !predicate() {
+            await Task.yield()
+            spins += 1
+            if spins > 10_000 {
+                XCTFail(message, file: file, line: line)
+                return
+            }
+        }
+    }
+
+    /// Two callers overlapping in time share a single scan run.
+    @MainActor
+    func testConcurrentCallersCoalesceToSingleScan() async {
+        let bottle = Bottle(bottleUrl: bottleURL)
+        let probe = ScanProbe()
+
+        // Owner: runs the body, then parks so its scan is still in flight when
+        // the second caller arrives.
+        let owner = Task { @MainActor in
+            await bottle.coalesceProgramScan {
+                probe.runCount += 1
+                await withCheckedContinuation { probe.resume = $0 }
+            }
+        }
+        await spinUntil({ probe.resume != nil }, "Owning scan never started")
+        XCTAssertEqual(probe.runCount, 1)
+
+        // Second caller arrives mid-scan; it must coalesce, not start a new body.
+        let coalesced = Task { @MainActor in
+            await bottle.coalesceProgramScan {
+                probe.runCount += 1
+            }
+        }
+        await Task.yield()
+
+        // Release the owner; both tasks finish.
+        probe.resume?.resume()
+        await owner.value
+        await coalesced.value
+
+        XCTAssertEqual(probe.runCount, 1, "Concurrent callers must share one scan run")
+    }
+
+    /// A coalesced caller observes the in-flight scan's published result rather
+    /// than the value that predated it — the exact guarantee the Start Menu
+    /// auto-pin relies on.
+    @MainActor
+    func testCoalescedCallerObservesScanResult() async {
+        let bottle = Bottle(bottleUrl: bottleURL)
+        let probe = ScanProbe()
+
+        let owner = Task { @MainActor in
+            await bottle.coalesceProgramScan {
+                await withCheckedContinuation { probe.resume = $0 }
+                probe.published = "fresh" // published only as the scan completes
+            }
+        }
+        await spinUntil({ probe.resume != nil }, "Owning scan never started")
+
+        let coalesced = Task { @MainActor in
+            await bottle.coalesceProgramScan {}
+            return probe.published
+        }
+        await Task.yield()
+
+        probe.resume?.resume()
+        await owner.value
+        let observed = await coalesced.value
+
+        XCTAssertEqual(observed, "fresh", "Coalesced caller must see the scan's published result, not a stale value")
+    }
+
+    /// Once a scan completes the handle is cleared, so a later call runs a fresh
+    /// scan rather than being permanently suppressed.
+    @MainActor
+    func testSequentialCallsEachRunScan() async {
+        let bottle = Bottle(bottleUrl: bottleURL)
+        let probe = ScanProbe()
+
+        await bottle.coalesceProgramScan { probe.runCount += 1 }
+        await bottle.coalesceProgramScan { probe.runCount += 1 }
+
+        XCTAssertEqual(probe.runCount, 2, "Each sequential call runs its own scan once the handle clears")
+    }
+}


### PR DESCRIPTION
## Summary

A pre-release review of the four features queued for **3.5.0** (config descriptions, the opt-in menu-bar extra, async program loading, and gentle scheduled-update reminders) surfaced five issues. This PR fixes all of them before the release is cut. No new features — only hardening of code already on `main` but not yet shipped.

## Fixes

| Sev | Area | Problem → Fix |
|-----|------|---------------|
| **High** | Menu-bar extra | A bottle's submenu listed pins via `bottle.pinnedPrograms`, which only resolves against the lazily-populated `programs` list. A bottle never opened this session (e.g. right after launch) showed **"No pinned programs"** even when it had pins. → Read `settings.pins` directly (always loaded), filtered to files that still exist. |
| Med | Menu-bar extra | Pinned-program launches discarded the `LaunchResult`, so a failed launch was completely silent. → Capture the result and surface `.launchFailed` via an `NSAlert` (a view toast can't reach a window-less menu-bar app) + log it. |
| Med | Menu-bar extra | **"Open Whisky"** matched any `canBecomeMain` window, so it could bring the **Settings** window forward — or, when Settings was the only open window, never open the main window. → Match the main `WindowGroup` by its identifier prefix (`main-AppWindow-N`). |
| Med | Update reminders | The gentle-reminder delegate declared `…ShouldHandleShowingScheduledUpdate(_:andInState:)`, but Sparkle 2.8.1's real selector is `…andInImmediateFocus:`. The method never matched, so the deferral was **dead code** and Sparkle always showed its focus-stealing alert. → Correct the signature and `return immediateFocus`. |
| Low | Program scanning | `updateInstalledPrograms()` *dropped* a concurrent rescan (`guard !programsLoading`) instead of coalescing, so the Start-Menu auto-pin could read a stale/empty `programs`. → New `Bottle.coalesceProgramScan(_:)` awaits the in-flight scan so callers always see fresh results. (Also corrects a doc comment that falsely claimed coalescing.) |

## Verification

- `xcodebuild` Whisky scheme: **BUILD SUCCEEDED**, 0 errors
- `swift test --package-path WhiskyKit`: **1068 XCTest + 23 Swift Testing, 0 failures**
- `swiftformat --lint` clean · `swiftlint --strict` clean
- Sparkle selector checked against the real `SPUStandardUserDriverDelegate.h` header
- The `main-AppWindow-1` window identifier (basis for the "Open Whisky" fix) confirmed via the app's own saved `NSSplitView` autosave defaults key

## Localization

Adds one hand-placed key, `menubar.launchFailed` (`extractionState: manual`), for the launch-failure alert.