### PR TITLE
ci: harden workflow token permissions and tidy issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,5 @@
 name: 🐛 Bug Report
 description: App crash, broken feature, or unexpected behaviour.
-type: "Bug"
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,5 @@
 name: ✨ Feature Request
 description: Suggest a new feature or improvement.
-type: "Enhancement"
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/game-compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game-compatibility.yml
@@ -1,6 +1,5 @@
 name: 🎮 Game Compatibility Report
 description: A specific game won't run, crashes, or runs poorly.
-type: "Game compatibility"
 labels: ["game-compatibility"]
 body:
   - type: markdown
@@ -124,6 +123,8 @@ body:
       label: Pre-flight checks
       options:
         - label: I checked the in-app Game Configurations browser for an existing config.
+          required: true
+        - label: I'm running **this fork** (`frankea/Whisky`, confirmed via **Whisky → About**) — not the archived original that the default `brew install --cask whisky` installs.
           required: true
         - label: I searched existing issues for this game.
           required: true

--- a/.github/workflows/AutoAssign.yml
+++ b/.github/workflows/AutoAssign.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   assign:
     name: Assign

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,9 @@ on:
     paths-ignore: *docs-paths
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Shared environment variables for consistency across jobs
 env:
   XCODE_VERSION: 'latest-stable'

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
## Summary

- Add least-privilege `permissions:` blocks to the three workflows that had none: `AutoAssign` gets `issues: write` + `pull-requests: write`; `CI` and `Release` are pinned to `contents: read`. Artifact and Codecov uploads in CI don't need more than read.
- Remove the `type:` field from all three issue forms. Issue types are an organization-only feature, so on this user-owned repo the field is silently ignored — the `labels:` lines are what drive triage.
- Add the "I'm running this fork, not the archived original" pre-flight check to the game compatibility template, matching the bug template. That's the template confused `brew install --cask whisky` users are most likely to land on.

## Follow-up (repo settings, not in this PR)

Once this merges, Settings → Actions → General → Workflow permissions can be flipped to "Read repository contents" — every workflow that needs more now declares it explicitly. Flipping it **before** merging this would break AutoAssign.

## Testing

- All six files validated as parseable YAML.
- No behavioural change to CI/Release jobs; AutoAssign permissions verified against what `addAssignees` requires.