### PR TITLE
ci: add Crowdin translation sync workflow

### DIFF
--- a/.github/workflows/Crowdin.yml
+++ b/.github/workflows/Crowdin.yml
@@ -1,0 +1,75 @@
+name: Crowdin
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Whisky/Localizable.xcstrings'
+      - 'crowdin.yml'
+      - '.github/workflows/Crowdin.yml'
+  schedule:
+    # Mondays at 06:00 UTC — pull any new translations into a PR
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: crowdin
+  cancel-in-progress: false
+
+jobs:
+  synchronize:
+    name: Sync with Crowdin
+    runs-on: ubuntu-latest
+    steps:
+      # Stays dormant until the maintainer adds the Crowdin secrets, so the
+      # workflow can live in the repo without failing on every push.
+      - name: Check Crowdin credentials
+        id: check
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+        run: |
+          if [ -n "$CROWDIN_PROJECT_ID" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CROWDIN_PROJECT_ID secret is not set — skipping sync. See CONTRIBUTING.md for setup."
+          fi
+
+      - name: Checkout
+        if: steps.check.outputs.configured == 'true'
+        uses: actions/checkout@v6
+
+      # Push to main → push new English source strings up to Crowdin.
+      - name: Upload sources
+        if: steps.check.outputs.configured == 'true' && github.event_name == 'push'
+        uses: crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f # v2.16.3
+        with:
+          upload_sources: true
+          download_translations: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      # Schedule / manual → refresh sources, pull translations, open a PR.
+      - name: Download translations
+        if: steps.check.outputs.configured == 'true' && github.event_name != 'push'
+        uses: crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f # v2.16.3
+        with:
+          upload_sources: true
+          download_translations: true
+          localization_branch_name: l10n/crowdin
+          create_pull_request: true
+          pull_request_title: 'New translations from Crowdin'
+          pull_request_body: >-
+            Automated translation sync. Crowdin is the source of truth for
+            translations — do not hand-edit non-English strings here.
+          pull_request_base_branch_name: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,20 @@ cp .github/hooks/pre-commit .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
 
-## General Guidelines
+## Localization
 
-All added strings must be properly localised and added to the EN strings file. Do not add keys for other languages or translate within your PR.
+All user-facing strings must be localized. Add every new string to the
+English (source) entries in `Whisky/Localizable.xcstrings`. **Do not add
+other-language translations, and do not edit another language's entries, in a
+PR** — hand-editing the string catalog tends to re-serialize the whole file
+(producing huge, unreviewable diffs) and can silently drop existing
+translations.
 
-> **Note:** Translations are managed via Crowdin for the upstream project. This fork inherits existing translations but does not currently manage Crowdin directly. New strings will be in English only until a translation workflow is established.
+Translations are managed through Crowdin and synced automatically: the
+[`Crowdin`](.github/workflows/Crowdin.yml) workflow uploads new English strings
+to the project's Crowdin, and opens a `New translations from Crowdin` pull
+request when translators add or update strings. To help translate, contribute
+through the Crowdin project rather than opening a PR here.
 
 ## Changelog
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,5 @@
+preserve_hierarchy: true
+
 files:
   - source: /Whisky/Localizable.xcstrings
     translation: /Whisky/Localizable.xcstrings

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -57,7 +57,7 @@ upstream patch; the rest are features or docs, tracked individually.
 | [#765](https://github.com/whisky-app/whisky/pull/765) | Custom SwiftUI update UI | **Adopted (lighter-touch)** — gentle scheduled-update reminders via an `SPUStandardUserDriverDelegate` (Dock badge + "Install Update…" instead of a focus-stealing dialog); kept Sparkle's proven install flow |
 | [#571](https://github.com/whisky-app/whisky/pull/571) | Menu-bar extra (survive window close) | **Adopted** — opt-in menu-bar extra (Settings → General) that launches pinned programs and keeps the app alive after the window closes |
 | [#1207](https://github.com/whisky-app/whisky/pull/1207) / [#1206](https://github.com/whisky-app/whisky/issues/1206) | Document a complete uninstall | **Done** — see *Uninstalling* in the [README](../README.md) |
-| [#1375](https://github.com/whisky-app/whisky/pull/1375) | Crowdin translation sync | **N/A** — this fork manages translations through its own Crowdin project, not via PRs |
+| [#1375](https://github.com/whisky-app/whisky/pull/1375) | Crowdin translation sync | **N/A (own tooling)** — this fork syncs translations via its own Crowdin project and the [`Crowdin`](../.github/workflows/Crowdin.yml) workflow, not the upstream PR |
 
 ## Running the tool
 


### PR DESCRIPTION
## Summary

- Adds a `Crowdin` workflow: pushes to `main` touching `Whisky/Localizable.xcstrings` upload new English sources to Crowdin; a Monday cron (plus `workflow_dispatch`) pulls translations and opens an `l10n/crowdin` PR.
- The workflow stays dormant (with a notice) until the Crowdin secrets exist, so it can merge independently of Crowdin setup.
- `crowdin.yml` gains `preserve_hierarchy: true` — without it the CLI flattens the file to `/Localizable.xcstrings` on upload and the download step can't map the export back to `Whisky/Localizable.xcstrings`.
- Rewrites the CONTRIBUTING localization section: English-only strings in PRs, translations via Crowdin; updates the AUDIT.md entry for upstream #1375.

## Setup already completed (out-of-repo)

- Crowdin project `frankea-whisky` (ID 913423) created: public, English source, 22 target languages matching the catalog.
- `CROWDIN_PROJECT_ID` / `CROWDIN_PERSONAL_TOKEN` repo secrets configured.
- Existing catalog translations seeded into Crowdin (per-language import, `--import-eq-suggestions`), and `skipUntranslatedStrings` enabled on the project so exports omit untranslated entries instead of filling them with English source-copies.
- Round-trip verified lossless: a test download reproduces every translated string in the repo catalog with correct Apple-style language keys (`es`, `zh-Hans`, `pt-BR`, …).

## Testing

- `crowdin upload sources` / `upload translations` / `download translations` all exercised against the live project with this exact config.
- First real run: trigger the workflow manually after merge and eyeball the resulting `l10n/crowdin` PR for mass deletions before merging it.