### PR TITLE
ci: skip untranslated strings in Crowdin export

### DIFF
--- a/.github/workflows/Crowdin.yml
+++ b/.github/workflows/Crowdin.yml
@@ -62,6 +62,12 @@ jobs:
         with:
           upload_sources: true
           download_translations: true
+          # Untranslated strings must be omitted from the export — otherwise
+          # every language gets English source-copies for all 700+ keys and
+          # Xcode loses its untranslated-fallback signal. The action passes
+          # this to the CLI explicitly, which overrides the project-level
+          # skipUntranslatedStrings setting, so it has to be set here.
+          skip_untranslated_strings: true
           localization_branch_name: l10n/crowdin
           create_pull_request: true
           pull_request_title: 'New translations from Crowdin'


### PR DESCRIPTION
First dispatch of the Crowdin sync pushed an `l10n/crowdin` branch where every language was filled to 722/722 entries — untranslated keys came back as English source-copies with `state: new`, destroying Xcode's untranslated-fallback signal and adding ~16k junk entries.

Root cause: the crowdin/github-action passes `skip_untranslated_strings` (default `false`) to the CLI, which overrides the `skipUntranslatedStrings` export option already enabled on the Crowdin project. Setting it explicitly in the workflow fixes the export and keeps the intent version-controlled.

Verified against the bad export: all 3,236 existing translations were byte-identical (nothing lost) — the only defect was the source-copy fill. The stale `l10n/crowdin` branch has been deleted; the next dispatch will regenerate it with this fix.