### PR TITLE
fix: harden bottle registry and surface silent bottle-creation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- An unreadable bottle registry no longer silently wipes the bottle list. On
+  startup the corrupt file is moved aside (an alert says where) and, when the
+  file is in the older paths-only fallback format, the bottle paths are
+  recovered instead of being overwritten with an empty list (Refs #61).
+- Bottle creation now fails loudly when the new bottle can't be saved to the
+  registry: the save is verified on disk and the existing failure alert (with
+  copyable diagnostics) fires. Previously the error case existed but was never
+  raised, so the bottle silently vanished on the next launch (Refs #61).
+- Creating a bottle while the Wine runtime (WhiskyWine) isn't installed now
+  shows a clear "runtime missing" error with a Run Setup button instead of a
+  low-level file-not-found failure (Refs #61).
+- The Winetricks button now shows an error when the bundled winetricks
+  resources can't be found, instead of silently doing nothing (Refs #134).
+
 ## [3.5.1] - 2026-07-24 (App)
 
 ### Fixed

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -1021,6 +1021,16 @@
         }
       }
     },
+    "bottle.creation.error.runtimeMissing" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Wine runtime (WhiskyWine) isn't installed, so the bottle can't be initialized. Run Setup to download it, then try again."
+          }
+        }
+      }
+    },
     "bottle.creation.error.wineVersionChangeFailed" : {
       "localizations" : {
         "en" : {
@@ -1037,6 +1047,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Copy Diagnostics"
+          }
+        }
+      }
+    },
+    "bottle.creation.failed.runSetup" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Run Setup…"
           }
         }
       }
@@ -1077,6 +1097,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Some processes were started outside Whisky"
+          }
+        }
+      }
+    },
+    "bottle.registry.corrupt.message" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Whisky couldn't read its saved bottle list, so a fresh empty list was created. The unreadable file was moved to “%@”. Your bottle folders on disk were not deleted."
+          }
+        }
+      }
+    },
+    "bottle.registry.corrupt.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bottle List Couldn't Be Read"
           }
         }
       }
@@ -21883,6 +21923,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "The AppData directory is missing or incomplete. This will cause dependency installations to fail."
+          }
+        }
+      }
+    },
+    "winetricks.error.missingResources" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Winetricks Is Missing"
+          }
+        }
+      }
+    },
+    "winetricks.error.missingResourcesInfo" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The winetricks tool bundled with Whisky couldn't be found. Reinstall Whisky from a fresh download to restore it."
           }
         }
       }

--- a/Whisky/Utils/Winetricks.swift
+++ b/Whisky/Utils/Winetricks.swift
@@ -78,7 +78,18 @@ class Winetricks {
 
         guard let resourcesURL = Bundle.main.url(forResource: "cabextract", withExtension: nil)?
             .deletingLastPathComponent()
-        else { return }
+        else {
+            // A missing bundled resource is unrecoverable in-app; tell the
+            // user instead of silently doing nothing (refs #134).
+            logger.error("Bundled winetricks resources are missing; cannot run '\(command)'")
+            let alert = NSAlert()
+            alert.messageText = String(localized: "winetricks.error.missingResources")
+            alert.informativeText = String(localized: "winetricks.error.missingResourcesInfo")
+            alert.alertStyle = .critical
+            alert.addButton(withTitle: String(localized: "button.ok"))
+            alert.runModal()
+            return
+        }
         // Winetricks ships in the app bundle Resources alongside cabextract. Invoke it via
         // `bash` (matching the headless install paths) so no executable bit is relied upon.
         let winetricksPath = resourcesURL.appending(path: "winetricks").path(percentEncoded: false)

--- a/Whisky/Utils/Winetricks.swift
+++ b/Whisky/Utils/Winetricks.swift
@@ -60,12 +60,7 @@ class Winetricks {
             // Don't offer repair again if this is already a retry after repair
             if isRetryAfterRepair {
                 logger.error("Validation still failing after repair attempt")
-                let alert = NSAlert()
-                alert.messageText = String(localized: "winetricks.error.repairFailed")
-                alert.informativeText = String(localized: "winetricks.error.repairFailedInfo")
-                alert.alertStyle = .critical
-                alert.addButton(withTitle: String(localized: "button.ok"))
-                alert.runModal()
+                showRepairFailedAlert(info: String(localized: "winetricks.error.repairFailedInfo"))
                 return
             }
             await showPrefixErrorAlert(
@@ -79,15 +74,7 @@ class Winetricks {
         guard let resourcesURL = Bundle.main.url(forResource: "cabextract", withExtension: nil)?
             .deletingLastPathComponent()
         else {
-            // A missing bundled resource is unrecoverable in-app; tell the
-            // user instead of silently doing nothing (refs #134).
-            logger.error("Bundled winetricks resources are missing; cannot run '\(command)'")
-            let alert = NSAlert()
-            alert.messageText = String(localized: "winetricks.error.missingResources")
-            alert.informativeText = String(localized: "winetricks.error.missingResourcesInfo")
-            alert.alertStyle = .critical
-            alert.addButton(withTitle: String(localized: "button.ok"))
-            alert.runModal()
+            showMissingResourcesAlert(command: command)
             return
         }
         // Winetricks ships in the app bundle Resources alongside cabextract. Invoke it via
@@ -123,6 +110,30 @@ class Winetricks {
                 }
             }
         }
+    }
+
+    /// Shown when the bundled winetricks resources can't be located. A missing
+    /// bundled resource is unrecoverable in-app, so tell the user instead of
+    /// silently doing nothing (refs #134).
+    @MainActor
+    private static func showMissingResourcesAlert(command: String) {
+        logger.error("Bundled winetricks resources are missing; cannot run '\(command)'")
+        let alert = NSAlert()
+        alert.messageText = String(localized: "winetricks.error.missingResources")
+        alert.informativeText = String(localized: "winetricks.error.missingResourcesInfo")
+        alert.alertStyle = .critical
+        alert.addButton(withTitle: String(localized: "button.ok"))
+        alert.runModal()
+    }
+
+    @MainActor
+    private static func showRepairFailedAlert(info: String) {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "winetricks.error.repairFailed")
+        alert.informativeText = info
+        alert.alertStyle = .critical
+        alert.addButton(withTitle: String(localized: "button.ok"))
+        alert.runModal()
     }
 
     @MainActor
@@ -183,12 +194,7 @@ class Winetricks {
             await runCommandInternal(command: command, bottle: bottle, isRetryAfterRepair: true)
         } catch {
             logger.error("Failed to repair prefix: \(error.localizedDescription)")
-            let alert = NSAlert()
-            alert.messageText = String(localized: "winetricks.error.repairFailed")
-            alert.informativeText = error.localizedDescription
-            alert.alertStyle = .critical
-            alert.addButton(withTitle: String(localized: "button.ok"))
-            alert.runModal()
+            showRepairFailedAlert(info: error.localizedDescription)
         }
     }
 

--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -23,11 +23,14 @@ import WhiskyKit
 
 // MARK: - Bottle Creation Errors
 
-enum BottleCreationError: LocalizedError {
+enum BottleCreationError: LocalizedError, Equatable {
     case directoryCreationFailed
     case metadataCreationFailed
     case wineVersionChangeFailed
     case persistenceSaveFailed
+    /// The Wine runtime (WhiskyWine) is not installed, so the prefix can't be
+    /// initialized. Surfaced with a "Run Setup" action in the failure alert.
+    case runtimeMissing
     /// The chosen location failed pre-flight validation. Carries the already
     /// localized, user-facing message (built at the throw site) since the alert
     /// displays `errorDescription` verbatim.
@@ -43,6 +46,8 @@ enum BottleCreationError: LocalizedError {
             String(localized: "bottle.creation.error.wineVersionChangeFailed")
         case .persistenceSaveFailed:
             String(localized: "bottle.creation.error.persistenceSaveFailed")
+        case .runtimeMissing:
+            String(localized: "bottle.creation.error.runtimeMissing")
         case let .locationUnsuitable(message):
             message
         }
@@ -66,6 +71,9 @@ final class BottleVM: ObservableObject {
         let id = UUID()
         let message: String
         let diagnostics: String
+        /// When true the alert offers a "Run Setup" action so the user can
+        /// install the missing Wine runtime directly.
+        let isRuntimeMissing: Bool
     }
 
     func loadBottles() {
@@ -101,6 +109,13 @@ final class BottleVM: ObservableObject {
     private func createBottleTask(request: BottleCreationRequest) async {
         var bottle: Bottle?
         do {
+            // The Wine runtime is required to initialize the prefix; fail fast
+            // with an actionable error instead of a low-level file-not-found
+            // failure from the wine invocation (issue #61).
+            guard WhiskyWineInstaller.isWhiskyWineInstalled() else {
+                throw BottleCreationError.runtimeMissing
+            }
+
             // Pre-flight the chosen location before creating anything, so an
             // unwritable or near-full destination surfaces a clear error up
             // front instead of a cryptic late wineboot failure (issue #61).
@@ -143,7 +158,7 @@ final class BottleVM: ObservableObject {
             // Save settings
             createdBottle.saveBottleSettings()
 
-            persistBottleCreation(request: request)
+            try persistBottleCreation(request: request)
             loadBottles()
             Telemetry.capture(.firstBottleCreated)
         } catch {
@@ -163,9 +178,12 @@ final class BottleVM: ObservableObject {
         }
     }
 
-    private func persistBottleCreation(request: BottleCreationRequest) {
-        if !bottlesList.paths.contains(request.newBottleDir) {
-            bottlesList.paths.append(request.newBottleDir)
+    private func persistBottleCreation(request: BottleCreationRequest) throws {
+        // registerBottlePath verifies the entries file on disk actually
+        // contains the new path; a silent save failure here used to make the
+        // bottle vanish on the next launch with no explanation (issue #61).
+        guard bottlesList.registerBottlePath(request.newBottleDir) else {
+            throw BottleCreationError.persistenceSaveFailed
         }
     }
 
@@ -186,7 +204,8 @@ final class BottleVM: ObservableObject {
         bottleVMLogger.error("\(diagnostics, privacy: .public)")
         bottleCreationAlert = BottleCreationAlert(
             message: message,
-            diagnostics: diagnostics
+            diagnostics: diagnostics,
+            isRuntimeMissing: (error as? BottleCreationError) == .runtimeMissing
         )
 
         // Clean up on failure

--- a/Whisky/Views/ContentView.swift
+++ b/Whisky/Views/ContentView.swift
@@ -38,6 +38,7 @@ struct ContentView: View {
 
     @State private var bottleFilter = ""
     @State private var toast: ToastData?
+    @State private var corruptRegistryBackupURL: URL?
 
     var body: some View {
         NavigationSplitView {
@@ -67,6 +68,11 @@ struct ContentView: View {
             ),
             presenting: bottleVM.bottleCreationAlert
         ) { alert in
+            if alert.isRuntimeMissing {
+                Button("bottle.creation.failed.runSetup") {
+                    showSetup = true
+                }
+            }
             Button("bottle.creation.failed.copyDiagnostics") {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(alert.diagnostics, forType: .string)
@@ -77,6 +83,21 @@ struct ContentView: View {
             Button("button.ok", role: .cancel) {}
         } message: { alert in
             Text(alert.message)
+        }
+        .alert(
+            "bottle.registry.corrupt.title",
+            isPresented: Binding(
+                get: { corruptRegistryBackupURL != nil },
+                set: { if !$0 { corruptRegistryBackupURL = nil } }
+            ),
+            presenting: corruptRegistryBackupURL
+        ) { _ in
+            Button("button.ok", role: .cancel) {}
+        } message: { url in
+            Text(String(
+                format: String(localized: "bottle.registry.corrupt.message"),
+                url.prettyPath()
+            ))
         }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -149,6 +170,10 @@ struct ContentView: View {
         .task {
             bottleVM.loadBottles()
             bottlesLoaded = true
+
+            // Surface a registry that couldn't be read and was moved aside at
+            // startup, so the reset bottle list doesn't pass silently (#61).
+            corruptRegistryBackupURL = bottleVM.bottlesList.corruptRegistryBackupURL
 
             if !bottleVM.bottles.isEmpty || bottleVM.countActive() != 0 {
                 if let bottle = bottleVM.bottles.first(where: { $0.url == selectedBottleURL && $0.isAvailable }) {

--- a/Whisky/Views/ContentView.swift
+++ b/Whisky/Views/ContentView.swift
@@ -218,6 +218,11 @@ struct ContentView: View {
         }
     }
 
+}
+
+// MARK: - Sidebar & Detail
+
+extension ContentView {
     var sidebar: some View {
         ScrollViewReader { proxy in
             List(selection: $selected) {

--- a/Whisky/Views/ContentView.swift
+++ b/Whisky/Views/ContentView.swift
@@ -217,7 +217,6 @@ struct ContentView: View {
             }
         }
     }
-
 }
 
 // MARK: - Sidebar & Detail

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleData.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleData.swift
@@ -28,6 +28,11 @@ private struct BottleDataMinimal: Codable {
 // MARK: - BottleData
 
 public struct BottleData: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case fileVersion
+        case paths
+    }
+
     public static let containerDir = FileManager.default.homeDirectoryForCurrentUser
         .appending(path: "Library")
         .appending(path: "Containers")
@@ -43,6 +48,12 @@ public struct BottleData: Codable {
     static let currentVersion = SemanticVersion(1, 0, 0)
 
     private var fileVersion: SemanticVersion
+
+    /// Non-nil when ``init()`` found an existing registry file it couldn't
+    /// read and moved it aside instead of overwriting it, so the UI can tell
+    /// the user where their old bottle list went. Never persisted.
+    public private(set) var corruptRegistryBackupURL: URL?
+
     public var paths: [URL] = [] {
         didSet {
             encode()
@@ -55,6 +66,12 @@ public struct BottleData: Codable {
         if !decode() {
             encode()
         }
+    }
+
+    private init(fileVersion: SemanticVersion, paths: [URL], corruptRegistryBackupURL: URL?) {
+        self.fileVersion = fileVersion
+        self.paths = paths
+        self.corruptRegistryBackupURL = corruptRegistryBackupURL
     }
 
     @MainActor
@@ -77,22 +94,104 @@ public struct BottleData: Codable {
         return bottles
     }
 
+    /// Appends a bottle path to the registry and verifies the entries file on
+    /// disk actually contains it afterwards, so a failed save can't silently
+    /// drop the bottle on the next launch (issue #61).
+    ///
+    /// - Returns: `true` when the path is durably persisted.
+    public mutating func registerBottlePath(_ url: URL) -> Bool {
+        if !paths.contains(url) {
+            paths.append(url) // didSet persists via encode()
+        }
+        return Self.persistedPaths()?.contains(url) ?? false
+    }
+
+    /// Reads the bottle paths back from the entries file, accepting both the
+    /// full and the minimal (fallback) encodings.
+    private static func persistedPaths() -> [URL]? {
+        guard let data = try? Data(contentsOf: bottleEntriesDir) else { return nil }
+        let decoder = PropertyListDecoder()
+        if let full = try? decoder.decode(BottleData.self, from: data) {
+            return full.paths
+        }
+        if let minimal = try? decoder.decode(BottleDataMinimal.self, from: data) {
+            return minimal.paths
+        }
+        return nil
+    }
+
     @discardableResult
     private mutating func decode() -> Bool {
         let decoder = PropertyListDecoder()
+        let data: Data
         do {
-            let data = try Data(contentsOf: Self.bottleEntriesDir)
-            self = try decoder.decode(BottleData.self, from: data)
-            let loadedVersion = self.fileVersion
-            let currentVersion = Self.currentVersion
-            if loadedVersion != currentVersion {
-                Logger.wineKit.warning("Invalid file version \(loadedVersion), expected \(currentVersion)")
+            data = try Data(contentsOf: Self.bottleEntriesDir)
+        } catch {
+            // Missing entries file: first run, start with an empty registry.
+            Logger.wineKit.error("Failed to read BottleData: \(error)")
+            return false
+        }
+        do {
+            let decoded = try decoder.decode(BottleData.self, from: data)
+            if decoded.fileVersion != Self.currentVersion {
+                Logger.wineKit.warning(
+                    "Invalid file version \(decoded.fileVersion), expected \(Self.currentVersion)"
+                )
+                // Keep the registered paths; init() re-encodes them in the
+                // current format instead of discarding them.
+                self = BottleData(
+                    fileVersion: Self.currentVersion,
+                    paths: decoded.paths,
+                    corruptRegistryBackupURL: nil
+                )
                 return false
             }
+            self = decoded
             return true
         } catch {
             Logger.wineKit.error("Failed to decode BottleData: \(error)")
+        }
+        // The full decode failed on an existing file. Salvage the paths-only
+        // shape written by encodeFallback() before treating it as corrupt.
+        if let minimal = try? decoder.decode(BottleDataMinimal.self, from: data) {
+            Logger.wineKit.warning("Recovered \(minimal.paths.count) bottle path(s) from minimal registry")
+            self = BottleData(
+                fileVersion: Self.currentVersion,
+                paths: minimal.paths,
+                corruptRegistryBackupURL: nil
+            )
             return false
+        }
+        // Truly unreadable: move the file aside so the fresh registry written
+        // by init() doesn't destroy the user's bottle list (issue #61).
+        self = BottleData(
+            fileVersion: Self.currentVersion,
+            paths: [],
+            corruptRegistryBackupURL: Self.backUpCorruptRegistry()
+        )
+        return false
+    }
+
+    /// Moves an unreadable registry file aside, returning the backup location.
+    private static func backUpCorruptRegistry() -> URL? {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: bottleEntriesDir.path(percentEncoded: false)) else {
+            return nil
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        let name = bottleEntriesDir.deletingPathExtension().lastPathComponent
+        let backupURL = bottleEntriesDir
+            .deletingLastPathComponent()
+            .appending(path: "\(name).corrupt-\(formatter.string(from: Date())).plist")
+        do {
+            try fileManager.moveItem(at: bottleEntriesDir, to: backupURL)
+            Logger.wineKit.warning("Moved unreadable bottle registry to \(backupURL.path)")
+            return backupURL
+        } catch {
+            Logger.wineKit.error("Failed to back up unreadable bottle registry: \(error)")
+            return nil
         }
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleData.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleData.swift
@@ -49,6 +49,11 @@ public struct BottleData: Codable {
 
     private var fileVersion: SemanticVersion
 
+    /// The registry file this instance reads and writes. Defaults to
+    /// ``bottleEntriesDir``; injectable so tests can run against a temp
+    /// directory instead of the user's real registry. Never persisted.
+    var entriesFile: URL = BottleData.bottleEntriesDir
+
     /// Non-nil when ``init()`` found an existing registry file it couldn't
     /// read and moved it aside instead of overwriting it, so the UI can tell
     /// the user where their old bottle list went. Never persisted.
@@ -61,6 +66,13 @@ public struct BottleData: Codable {
     }
 
     public init() {
+        self.init(entriesFile: Self.bottleEntriesDir)
+    }
+
+    /// Reads or creates the registry at `entriesFile`. Factored out of
+    /// ``init()`` so it can be tested against a temp directory.
+    init(entriesFile: URL) {
+        self.entriesFile = entriesFile
         fileVersion = Self.currentVersion
 
         if !decode() {
@@ -68,10 +80,16 @@ public struct BottleData: Codable {
         }
     }
 
-    private init(fileVersion: SemanticVersion, paths: [URL], corruptRegistryBackupURL: URL?) {
+    private init(
+        fileVersion: SemanticVersion,
+        paths: [URL],
+        corruptRegistryBackupURL: URL?,
+        entriesFile: URL
+    ) {
         self.fileVersion = fileVersion
         self.paths = paths
         self.corruptRegistryBackupURL = corruptRegistryBackupURL
+        self.entriesFile = entriesFile
     }
 
     @MainActor
@@ -103,13 +121,13 @@ public struct BottleData: Codable {
         if !paths.contains(url) {
             paths.append(url) // didSet persists via encode()
         }
-        return Self.persistedPaths()?.contains(url) ?? false
+        return persistedPaths()?.contains(url) ?? false
     }
 
     /// Reads the bottle paths back from the entries file, accepting both the
     /// full and the minimal (fallback) encodings.
-    private static func persistedPaths() -> [URL]? {
-        guard let data = try? Data(contentsOf: bottleEntriesDir) else { return nil }
+    private func persistedPaths() -> [URL]? {
+        guard let data = try? Data(contentsOf: entriesFile) else { return nil }
         let decoder = PropertyListDecoder()
         if let full = try? decoder.decode(BottleData.self, from: data) {
             return full.paths
@@ -120,12 +138,24 @@ public struct BottleData: Codable {
         return nil
     }
 
+    /// Rebuilds self at the current version, carrying entriesFile over
+    /// explicitly: it's excluded from Codable, so a decoded value always
+    /// holds the production default and must never supply it.
+    private func replacement(paths: [URL], corruptRegistryBackupURL: URL? = nil) -> BottleData {
+        BottleData(
+            fileVersion: Self.currentVersion,
+            paths: paths,
+            corruptRegistryBackupURL: corruptRegistryBackupURL,
+            entriesFile: entriesFile
+        )
+    }
+
     @discardableResult
     private mutating func decode() -> Bool {
         let decoder = PropertyListDecoder()
         let data: Data
         do {
-            data = try Data(contentsOf: Self.bottleEntriesDir)
+            data = try Data(contentsOf: entriesFile)
         } catch {
             // Missing entries file: first run, start with an empty registry.
             Logger.wineKit.error("Failed to read BottleData: \(error)")
@@ -139,14 +169,10 @@ public struct BottleData: Codable {
                 )
                 // Keep the registered paths; init() re-encodes them in the
                 // current format instead of discarding them.
-                self = BottleData(
-                    fileVersion: Self.currentVersion,
-                    paths: decoded.paths,
-                    corruptRegistryBackupURL: nil
-                )
+                self = replacement(paths: decoded.paths)
                 return false
             }
-            self = decoded
+            self = replacement(paths: decoded.paths)
             return true
         } catch {
             Logger.wineKit.error("Failed to decode BottleData: \(error)")
@@ -155,38 +181,33 @@ public struct BottleData: Codable {
         // shape written by encodeFallback() before treating it as corrupt.
         if let minimal = try? decoder.decode(BottleDataMinimal.self, from: data) {
             Logger.wineKit.warning("Recovered \(minimal.paths.count) bottle path(s) from minimal registry")
-            self = BottleData(
-                fileVersion: Self.currentVersion,
-                paths: minimal.paths,
-                corruptRegistryBackupURL: nil
-            )
+            self = replacement(paths: minimal.paths)
             return false
         }
         // Truly unreadable: move the file aside so the fresh registry written
         // by init() doesn't destroy the user's bottle list (issue #61).
-        self = BottleData(
-            fileVersion: Self.currentVersion,
+        self = replacement(
             paths: [],
-            corruptRegistryBackupURL: Self.backUpCorruptRegistry()
+            corruptRegistryBackupURL: Self.backUpCorruptRegistry(at: entriesFile)
         )
         return false
     }
 
     /// Moves an unreadable registry file aside, returning the backup location.
-    private static func backUpCorruptRegistry() -> URL? {
+    private static func backUpCorruptRegistry(at file: URL) -> URL? {
         let fileManager = FileManager.default
-        guard fileManager.fileExists(atPath: bottleEntriesDir.path(percentEncoded: false)) else {
+        guard fileManager.fileExists(atPath: file.path(percentEncoded: false)) else {
             return nil
         }
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyyMMdd-HHmmss"
-        let name = bottleEntriesDir.deletingPathExtension().lastPathComponent
-        let backupURL = bottleEntriesDir
+        let name = file.deletingPathExtension().lastPathComponent
+        let backupURL = file
             .deletingLastPathComponent()
             .appending(path: "\(name).corrupt-\(formatter.string(from: Date())).plist")
         do {
-            try fileManager.moveItem(at: bottleEntriesDir, to: backupURL)
+            try fileManager.moveItem(at: file, to: backupURL)
             Logger.wineKit.warning("Moved unreadable bottle registry to \(backupURL.path)")
             return backupURL
         } catch {
@@ -201,9 +222,12 @@ public struct BottleData: Codable {
         encoder.outputFormat = .xml
 
         do {
-            try FileManager.default.createDirectory(at: Self.containerDir, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(
+                at: entriesFile.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
             let data = try encoder.encode(self)
-            try data.write(to: Self.bottleEntriesDir, options: .atomic)
+            try data.write(to: entriesFile, options: .atomic)
             return true
         } catch {
             Logger.wineKit.error("Failed to encode BottleData: \(error)")
@@ -218,11 +242,14 @@ public struct BottleData: Codable {
         encoder.outputFormat = .xml
 
         do {
-            try FileManager.default.createDirectory(at: Self.containerDir, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(
+                at: entriesFile.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
             // Create a minimal BottleData with just the paths
             let fallbackData = BottleDataMinimal(paths: self.paths)
             let data = try encoder.encode(fallbackData)
-            try data.write(to: Self.bottleEntriesDir, options: .atomic)
+            try data.write(to: entriesFile, options: .atomic)
             return true
         } catch {
             Logger.wineKit.error("Failed to encode fallback BottleData: \(error)")

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleDataTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleDataTests.swift
@@ -1,0 +1,123 @@
+//
+//  BottleDataTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+final class BottleDataTests: XCTestCase {
+    private var tempDir: URL!
+    private var entriesFile: URL!
+
+    /// Mirror of the paths-only fallback shape `encodeFallback()` writes,
+    /// which the full decoder cannot read back on its own.
+    private struct MinimalShape: Codable {
+        var paths: [URL]
+    }
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        entriesFile = tempDir.appendingPathComponent("BottleVM.plist")
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+        entriesFile = nil
+    }
+
+    // MARK: - First run
+
+    func testFirstRunCreatesEmptyRegistryFile() {
+        let data = BottleData(entriesFile: entriesFile)
+
+        XCTAssertTrue(data.paths.isEmpty)
+        XCTAssertNil(data.corruptRegistryBackupURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: entriesFile.path(percentEncoded: false)))
+    }
+
+    // MARK: - Round trip
+
+    func testRegisterBottlePathPersistsAndRoundTrips() {
+        var data = BottleData(entriesFile: entriesFile)
+        let bottle = tempDir.appendingPathComponent("Bottles").appendingPathComponent(UUID().uuidString)
+
+        XCTAssertTrue(data.registerBottlePath(bottle))
+
+        let reloaded = BottleData(entriesFile: entriesFile)
+        XCTAssertEqual(reloaded.paths, [bottle])
+        XCTAssertNil(reloaded.corruptRegistryBackupURL)
+    }
+
+    func testRegisterBottlePathIsIdempotent() {
+        var data = BottleData(entriesFile: entriesFile)
+        let bottle = tempDir.appendingPathComponent("Bottle")
+
+        XCTAssertTrue(data.registerBottlePath(bottle))
+        XCTAssertTrue(data.registerBottlePath(bottle))
+
+        XCTAssertEqual(data.paths, [bottle])
+        XCTAssertEqual(BottleData(entriesFile: entriesFile).paths, [bottle])
+    }
+
+    // MARK: - Corrupt registry (issue #61)
+
+    func testCorruptRegistryIsBackedUpNotOverwritten() throws {
+        let garbage = Data("definitely not a plist".utf8)
+        try garbage.write(to: entriesFile)
+
+        let data = BottleData(entriesFile: entriesFile)
+
+        // The unreadable registry must be preserved, byte for byte, in a
+        // sibling backup file — not silently clobbered by the fresh registry.
+        XCTAssertTrue(data.paths.isEmpty)
+        let backupURL = try XCTUnwrap(data.corruptRegistryBackupURL)
+        XCTAssertTrue(backupURL.lastPathComponent.hasPrefix("BottleVM.corrupt-"))
+        XCTAssertEqual(backupURL.deletingLastPathComponent(), entriesFile.deletingLastPathComponent())
+        XCTAssertEqual(try Data(contentsOf: backupURL), garbage)
+
+        // A fresh, readable registry takes the corrupt file's place.
+        let reloaded = BottleData(entriesFile: entriesFile)
+        XCTAssertTrue(reloaded.paths.isEmpty)
+        XCTAssertNil(reloaded.corruptRegistryBackupURL)
+    }
+
+    // MARK: - Fallback-format salvage
+
+    func testMinimalFallbackFormatIsSalvagedWithoutBackup() throws {
+        // Simulate a registry left behind by encodeFallback(): paths only,
+        // no fileVersion, unreadable by the primary decoder.
+        let bottle = tempDir.appendingPathComponent("SalvagedBottle")
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        try encoder.encode(MinimalShape(paths: [bottle])).write(to: entriesFile)
+
+        let data = BottleData(entriesFile: entriesFile)
+
+        // The registered path survives, nothing is treated as corrupt, and
+        // the file is upgraded in place to the full format.
+        XCTAssertEqual(data.paths, [bottle])
+        XCTAssertNil(data.corruptRegistryBackupURL)
+
+        let reloaded = BottleData(entriesFile: entriesFile)
+        XCTAssertEqual(reloaded.paths, [bottle])
+        XCTAssertNil(reloaded.corruptRegistryBackupURL)
+    }
+}


### PR DESCRIPTION
Follow-up to the new reports on #61 and #134 (both from the same user on 2026-07-25). Reviewing the remaining failure paths turned up four gaps that can still make bottles disappear silently or leave the user with no feedback; this PR closes all four.

## Changes

### 1. An unreadable bottle registry is no longer wiped (Refs #61)
`BottleData.init` used to respond to a failed decode of `BottleVM.plist` by immediately re-encoding an **empty** registry over it — every registered bottle vanished from the sidebar with no error and no way back. Now:
- The paths-only fallback shape (written by `encodeFallback()`, which the primary decoder could never read back) is salvaged before the file is treated as corrupt.
- A genuinely unreadable file is **moved aside** to `BottleVM.corrupt-<timestamp>.plist` instead of being overwritten, and an alert on launch tells the user where it went and that their bottle folders were not deleted.
- A version-mismatch decode now keeps the registered paths and upgrades the file format instead of re-writing the stale version on every launch.

### 2. Registry save failures now surface (Refs #61)
`BottleCreationError.persistenceSaveFailed` existed but was never thrown — `BottleData.encode()`'s failure result was silently discarded, so a bottle that couldn't be saved looked created and then vanished on the next launch. Bottle creation now goes through `registerBottlePath(_:)`, which verifies the entries file on disk actually contains the new path and throws into the existing failure alert (with copyable diagnostics) when it doesn't.

### 3. Missing Wine runtime fails fast with a way out (Refs #61)
Creating a bottle without WhiskyWine installed (failed/skipped first-run download) previously died mid-creation with a low-level file-not-found error. The preflight now checks `isWhiskyWineInstalled()` and throws a dedicated `runtimeMissing` error, and the failure alert gains a **Run Setup…** button that opens the setup sheet directly.

### 4. Winetricks no longer silently does nothing (Refs #134)
`Winetricks.runCommand` returned without any feedback when the bundled resources couldn't be located. It now shows a critical alert with reinstall guidance, matching the headless install path's behavior.

Also adds the six new localized strings (English source; Crowdin sync picks them up) and a `[Unreleased]` changelog entry.

## Testing
- `Localizable.xcstrings` validated as JSON; new keys inserted in Xcode's sorted format.
- Line lengths and file headers checked against `.swiftlint.yml`.
- Existing UI tests are unaffected (the create-bottle test cancels without creating, so the new runtime preflight never triggers).
- Not compiled locally (no macOS toolchain in this environment) — relying on CI for build + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NkZVxUeRT7ejcP7mppS2D

---
_Generated by [Claude Code](https://claude.ai/code/session_014NkZVxUeRT7ejcP7mppS2D)_