### PR TITLE
fix: pin C locale when listing tar archives for validation

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Tar.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Tar.swift
@@ -118,6 +118,14 @@ public class Tar {
         // Use verbose listing to see file types and symlink targets
         // Format: "lrwxr-xr-x  0 user group    0 Jan 10 12:00 linkname -> target"
         process.arguments = ["-tvzf", "\(tarBall.path)"]
+        // bsdtar's verbose listing is locale dependent: many locales print
+        // day-first dates ("13 Jun 09:54") that extractPathFromTarLine cannot
+        // parse, so every entry would be rejected as unsafe. Pin the C locale
+        // to get the month-first format the parser expects.
+        var environment = ProcessInfo.processInfo.environment
+        environment["LC_ALL"] = "C"
+        environment["LANG"] = "C"
+        process.environment = environment
         process.standardOutput = pipe
         process.standardError = pipe
 

--- a/WhiskyKit/Tests/WhiskyKitTests/TarTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/TarTests.swift
@@ -94,6 +94,29 @@ final class TarIntegrationTests: XCTestCase {
         XCTAssertFalse(extractedItems.isEmpty)
     }
 
+    func testUntarRoundTripWithDayFirstDateLocale() throws {
+        // bsdtar formats verbose listing dates per locale; en_GB prints
+        // "13 Jun 09:54" instead of "Jun 13 09:54". Archive validation must
+        // not depend on the host locale (see #139).
+        let previous = getenv("LC_ALL").map { String(cString: $0) }
+        setenv("LC_ALL", "en_GB.UTF-8", 1)
+        defer {
+            if let previous {
+                setenv("LC_ALL", previous, 1)
+            } else {
+                unsetenv("LC_ALL")
+            }
+        }
+
+        let testFile = sourceDir.appending(path: "test.txt")
+        try Data("Hello, World!".utf8).write(to: testFile)
+
+        let tarURL = tempDir.appending(path: "locale.tar.gz")
+        try Tar.tar(folder: sourceDir, toURL: tarURL)
+
+        XCTAssertNoThrow(try Tar.untar(tarBall: tarURL, toURL: extractDir))
+    }
+
     func testTarWithMultipleFiles() throws {
         try Data("File 1 content".utf8).write(to: sourceDir.appending(path: "file1.txt"))
         try Data("File 2 content".utf8).write(to: sourceDir.appending(path: "file2.txt"))


### PR DESCRIPTION
Fixes #139.

WhiskyWine setup fails at the install stage with `Archive contains unsafe path that escapes target directory: ../__TAR_PARSE_ERROR__` on any system whose locale prints day-first dates.

## Changes

### Pin the C locale for the tar listing used by archive validation
`validateArchivePaths` parses `tar -tvzf` output, and `extractPathFromTarLine`'s regex expects bsdtar's month-first timestamp format ("Jun 13 09:54"). bsdtar localizes that column: with e.g. `LANG=en_GB.UTF-8` it prints "13 Jun 09:54", the regex matches nothing, every entry degrades to the `../__TAR_PARSE_ERROR__` sentinel, and the whole archive is rejected as a traversal attempt. The tar process now runs with `LC_ALL=C` / `LANG=C` so the listing format is stable regardless of host locale.

### Regression test
`testUntarRoundTripWithDayFirstDateLocale` forces `LC_ALL=en_GB.UTF-8` around a tar/untar round trip so this can't quietly come back.

## Testing
- Reproduced on macOS 27.0 beta (arm64) with `LANG=en_GB.UTF-8`: 5348/5348 entries of the v3.1.1 `Libraries.tar.gz` fail the path regex, matching the setup diagnostics in #139.
- Verified with a small SPM harness calling `Tar.tar`/`Tar.untar` under `LC_ALL=en_GB.UTF-8`: fails with `pathTraversal("../__TAR_PARSE_ERROR__")` before this change, passes after, including validating and extracting the real 317 MB `Libraries.tar.gz`.
- `swiftformat --lint` (0.58.7) clean on the changed files.
- The XCTest suite couldn't run locally (Command Line Tools only, no XCTest module), relying on CI for the full suite.
