### PR TITLE
fix: resolve recommended graphics backend to an installed one

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -787,16 +787,23 @@ public struct BottleSettings: Codable, Equatable {
     /// This method replaces the direct dict mutation in the deprecated ``environmentVariables(wineEnv:)``.
     /// DLL override entries are returned separately for composition by ``DLLOverrideResolver``.
     ///
-    /// - Parameter builder: The environment builder to populate.
+    /// - Parameters:
+    ///   - builder: The environment builder to populate.
+    ///   - resolvedBackend: The concrete backend to use when the bottle is set to
+    ///     `.recommended`. Defaults to `nil`, which resolves via
+    ///     ``GraphicsBackendResolver`` and therefore depends on the machine's
+    ///     installed runtime — tests pin an explicit value so the suite answers
+    ///     the same everywhere.
     /// - Returns: Managed DLL override entries with their sources for the DLLOverrideResolver.
     public func populateBottleManagedLayer(
-        builder: inout EnvironmentBuilder
+        builder: inout EnvironmentBuilder,
+        resolvedBackend: GraphicsBackend? = nil
     ) -> [(entry: DLLOverrideEntry, source: DLLOverrideSource)] {
         var managedDLLOverrides: [(entry: DLLOverrideEntry, source: DLLOverrideSource)] = []
 
         // Resolve the graphics backend (`.recommended` -> concrete backend)
         let resolvedBackend = if graphicsBackend == .recommended {
-            GraphicsBackendResolver.resolve()
+            resolvedBackend ?? GraphicsBackendResolver.resolve()
         } else {
             graphicsBackend
         }

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -130,6 +130,29 @@ public class WhiskyWineInstaller {
         return FileManager.default.fileExists(atPath: wineBinary.path(percentEncoded: false))
     }
 
+    /// Checks whether the installed runtime bundles Apple's D3DMetal layer.
+    ///
+    /// GPTK-based Wine builds carry D3DMetal under `Wine/lib/external/` as
+    /// `D3DMetal.framework` with `libd3dshared.dylib` alongside. Runtimes built
+    /// without GPTK ship neither, and a bottle configured for D3DMetal silently
+    /// falls back to wined3d at launch.
+    ///
+    /// - Returns: `true` only if the D3DMetal payload is present on disk.
+    public static func isD3DMetalInstalled() -> Bool {
+        isD3DMetalPresent(inLibraryFolder: libraryFolder)
+    }
+
+    /// Whether the D3DMetal payload exists under `folder`. Factored out of
+    /// ``isD3DMetalInstalled()`` so it can be tested against a temp directory.
+    static func isD3DMetalPresent(inLibraryFolder folder: URL) -> Bool {
+        let external = folder.appending(path: "Wine").appending(path: "lib").appending(path: "external")
+        let candidates = [
+            external.appending(path: "D3DMetal.framework"),
+            external.appending(path: "libd3dshared.dylib")
+        ]
+        return candidates.contains { FileManager.default.fileExists(atPath: $0.path(percentEncoded: false)) }
+    }
+
     /// Installs WhiskyWine from a downloaded tarball.
     ///
     /// This method extracts the WhiskyWine tarball to the application support

--- a/WhiskyKit/Sources/WhiskyKit/Wine/GraphicsBackendResolver.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/GraphicsBackendResolver.swift
@@ -27,16 +27,32 @@ import os.log
 public enum GraphicsBackendResolver {
     /// Resolves the recommended graphics backend for the current system.
     ///
-    /// D3DMetal is the default and best-supported path on macOS 15+ Apple Silicon.
-    /// Future versions may adjust based on GPU family or macOS version.
+    /// D3DMetal is the best-supported path on macOS 15+ Apple Silicon, but only
+    /// GPTK-based runtimes bundle its payload. Recommending it on a runtime
+    /// without the payload makes launches silently fall back to wined3d, which
+    /// cannot bring up D3D11 on current macOS — so the resolver only recommends
+    /// backends that are actually installed: DXMT (native D3D11-to-Metal) when
+    /// the runtime bundles it, otherwise DXVK, which ships with every runtime.
     ///
-    /// - Parameter macOSVersion: The macOS version to consider. Defaults to the running system.
+    /// - Parameters:
+    ///   - macOSVersion: The macOS version to consider. Defaults to the running system.
+    ///   - runtimeInfo: The runtime record to consider. Defaults to the installed
+    ///     runtime's version plist.
+    ///   - d3dMetalInstalled: Whether the D3DMetal payload exists on disk. Defaults
+    ///     to checking the installed runtime.
     /// - Returns: A concrete ``GraphicsBackend`` (never `.recommended`).
-    public static func resolve(macOSVersion: MacOSVersion = .current) -> GraphicsBackend {
-        // D3DMetal is Wine's native Metal translation layer and the best-supported
-        // path on Apple Silicon. The architecture supports future heuristic
-        // sophistication without changing the data model.
-        .d3dMetal
+    public static func resolve(
+        macOSVersion: MacOSVersion = .current,
+        runtimeInfo: WhiskyWineVersion? = WhiskyWineInstaller.whiskyWineInfo(),
+        d3dMetalInstalled: Bool = WhiskyWineInstaller.isD3DMetalInstalled()
+    ) -> GraphicsBackend {
+        if d3dMetalInstalled {
+            return .d3dMetal
+        }
+        if GraphicsBackend.dxmt.isAvailable(runtimeInfo: runtimeInfo) {
+            return .dxmt
+        }
+        return .dxvk
     }
 
     /// Returns a localized explanation for the recommended backend choice.

--- a/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
@@ -312,13 +312,39 @@ final class EnvironmentVariablesTests: XCTestCase {
     }
 
     func testPopulateBottleManagedLayerNoDXVKOverridesWhenDisabled() {
+        // `dxvk = false` maps the backend to `.recommended`, whose ambient
+        // resolution depends on the machine's installed runtime. Pin a
+        // builtin-backed backend: this test is about the DXVK toggle being
+        // off, not about resolution.
         var settings = BottleSettings()
         settings.dxvk = false
 
         var builder = EnvironmentBuilder()
-        let managedOverrides = settings.populateBottleManagedLayer(builder: &builder)
+        let managedOverrides = settings.populateBottleManagedLayer(
+            builder: &builder, resolvedBackend: .d3dMetal
+        )
 
         XCTAssertTrue(managedOverrides.isEmpty)
+    }
+
+    func testPopulateBottleManagedLayerRecommendedWithoutRuntimeAppliesDXVKPreset() {
+        // On a machine with no installed runtime `.recommended` resolves to
+        // DXVK, and the managed layer applies the DXVK preset even though the
+        // legacy `dxvk` toggle is off — backend selection supersedes the
+        // toggle, matching explicit `.dxvk` behavior.
+        var settings = BottleSettings()
+        settings.dxvk = false
+
+        let resolved = GraphicsBackendResolver.resolve(runtimeInfo: nil, d3dMetalInstalled: false)
+        XCTAssertEqual(resolved, .dxvk)
+
+        var builder = EnvironmentBuilder()
+        let managedOverrides = settings.populateBottleManagedLayer(
+            builder: &builder, resolvedBackend: resolved
+        )
+
+        XCTAssertEqual(managedOverrides.count, 4) // dxgi, d3d9, d3d10core, d3d11
+        XCTAssertTrue(managedOverrides.allSatisfy { $0.source == .dxvk })
     }
 
     func testPopulateLauncherManagedLayerReturnsEmptyWhenDisabled() {

--- a/WhiskyKit/Tests/WhiskyKitTests/GraphicsBackendResolverTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GraphicsBackendResolverTests.swift
@@ -1,0 +1,67 @@
+//
+//  GraphicsBackendResolverTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import SemanticVersion
+@testable import WhiskyKit
+import XCTest
+
+final class GraphicsBackendResolverTests: XCTestCase {
+    func testResolvesD3DMetalWhenPayloadInstalled() {
+        let runtime = WhiskyWineVersion(version: SemanticVersion(3, 1, 1), dxmtVersion: "0.80")
+
+        XCTAssertEqual(
+            GraphicsBackendResolver.resolve(runtimeInfo: runtime, d3dMetalInstalled: true),
+            .d3dMetal
+        )
+    }
+
+    func testResolvesDXMTWhenNoD3DMetalButRuntimeBundlesIt() {
+        let runtime = WhiskyWineVersion(version: SemanticVersion(3, 1, 1), dxmtVersion: "0.80")
+
+        XCTAssertEqual(
+            GraphicsBackendResolver.resolve(runtimeInfo: runtime, d3dMetalInstalled: false),
+            .dxmt
+        )
+    }
+
+    func testResolvesDXVKWhenNoD3DMetalAndNoDXMT() {
+        // Pre-3.1.0 runtimes bundle DXVK but not DXMT.
+        let runtime = WhiskyWineVersion(version: SemanticVersion(3, 0, 0))
+
+        XCTAssertEqual(
+            GraphicsBackendResolver.resolve(runtimeInfo: runtime, d3dMetalInstalled: false),
+            .dxvk
+        )
+    }
+
+    func testResolvesDXVKWhenRuntimeRecordMissing() {
+        XCTAssertEqual(
+            GraphicsBackendResolver.resolve(runtimeInfo: nil, d3dMetalInstalled: false),
+            .dxvk
+        )
+    }
+
+    func testNeverResolvesToRecommended() {
+        for installed in [true, false] {
+            XCTAssertNotEqual(
+                GraphicsBackendResolver.resolve(runtimeInfo: nil, d3dMetalInstalled: installed),
+                .recommended
+            )
+        }
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/LauncherDiagnosticsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/LauncherDiagnosticsTests.swift
@@ -405,6 +405,12 @@ final class LauncherDiagnosticsTests: XCTestCase {
         bottle.settings.detectedLauncher = .steam // Steam doesn't require DXVK
         bottle.settings.autoEnableDXVK = true
         bottle.settings.dxvk = false
+        // Pin a builtin-backed backend: `.recommended` resolves via ambient
+        // machine state and would add the DXVK preset through the bottle layer
+        // on machines without a runtime. Auto-enable applies through the
+        // launcher layer regardless of backend, so the assertion below still
+        // catches Steam wrongly auto-enabling.
+        bottle.settings.graphicsBackend = .d3dMetal
 
         var env: [String: String] = [:]
         bottle.settings.environmentVariables(wineEnv: &env)

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -169,6 +169,34 @@ final class WhiskyWineInstallerTests: XCTestCase {
         XCTAssertFalse(WhiskyWineInstaller.isRuntimePresent(inLibraryFolder: tempDir))
     }
 
+    // MARK: - isD3DMetalPresent (GPTK payload)
+
+    func testD3DMetalPresentWhenFrameworkExists() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let external = tempDir.appending(path: "Wine").appending(path: "lib").appending(path: "external")
+        try FileManager.default.createDirectory(
+            at: external.appending(path: "D3DMetal.framework"),
+            withIntermediateDirectories: true
+        )
+
+        XCTAssertTrue(WhiskyWineInstaller.isD3DMetalPresent(inLibraryFolder: tempDir))
+    }
+
+    func testD3DMetalNotPresentInRuntimeWithoutGPTKPayload() throws {
+        // The layout the current Libraries bundle actually ships: Wine, DXVK
+        // and DXMT, but no D3DMetal payload under Wine/lib/external.
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try makeRuntime(in: tempDir, plist: true, wine64: true)
+        try FileManager.default.createDirectory(
+            at: tempDir.appending(path: "DXVK").appending(path: "x64"),
+            withIntermediateDirectories: true
+        )
+
+        XCTAssertFalse(WhiskyWineInstaller.isD3DMetalPresent(inLibraryFolder: tempDir))
+    }
+
     func testRuntimeNotPresentWhenFolderEmpty() {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         XCTAssertFalse(WhiskyWineInstaller.isRuntimePresent(inLibraryFolder: tempDir))


### PR DESCRIPTION
Fixes #141.

A fresh bottle on default settings ("Recommended" backend) cannot run DX11 games: Unity titles die with `InitializeEngineGraphics failed` because the resolved backend does not exist in the shipped runtime.

## Changes

### Resolve `.recommended` to a backend the runtime actually ships
`GraphicsBackendResolver.resolve()` unconditionally returned `.d3dMetal`, but the Libraries runtime bundles no D3DMetal payload (only DXVK, DXMT and MoltenVK), so every launch on default settings silently fell back to wined3d, which cannot bring up D3D11 on current macOS. `resolve()` now takes the runtime record and a D3DMetal-presence check (both defaulted, all existing call sites unchanged) and prefers: D3DMetal when its payload is on disk, then DXMT when the runtime bundles it (same `dxmtVersion` gate `GraphicsBackend.isAvailable` already uses), then DXVK, which ships with every runtime. Preferring DXMT over DXVK for D3D11 seemed consistent with the runtime's investment in it (nvapi spoofing etc.), flipping that order is a one-liner if you'd rather default to DXVK.

### `WhiskyWineInstaller.isD3DMetalInstalled()`
New check mirroring `isWhiskyWineInstalled()`, looking for the GPTK payload (`Wine/lib/external/D3DMetal.framework` or `libd3dshared.dylib`), with a testable `inLibraryFolder:` variant like `isRuntimePresent`.

### Tests
`GraphicsBackendResolverTests` covers all four resolution paths via injected records; `WhiskyWineInstallerTests` gains payload-presence cases including the layout the current Libraries bundle actually ships.

## Testing
- Reproduced on macOS 27.0 beta (arm64), whisky 3.5.1, runtime 3.1.1: default bottle + Unity 2022.3 DX11 game (Casualties: Unknown demo via Windows Steam) fails to initialize graphics; manually wiring DXVK into the same bottle fixes it instantly, details in #141.
- Verified the new resolution logic with a small SPM harness against WhiskyKit: all four paths (payload installed → d3dMetal; absent + DXMT runtime → dxmt; absent + pre-3.1 runtime → dxvk; absent + no record → dxvk) behave as described.
- `swiftformat --lint` (0.58.7) clean on the changed files.
- The XCTest suite couldn't run locally (Command Line Tools only, no XCTest module), relying on CI for the full suite.

## Update after review

- `populateBottleManagedLayer` now takes an injectable `resolvedBackend` (nil default falls back to the resolver), the toggle-off test pins `.d3dMetal`, and a new case covers `.recommended` + no runtime → DXVK preset applied. The suite answers the same on every machine again.
- On the deliberate call: agreed. With `.recommended` resolving to `.dxvk`, the DXVK preset applies even when the legacy `dxvk` toggle is off, backend selection supersedes the toggle, which is exactly how an explicit `.dxvk` backend already behaves. The new test encodes this behavior.
