### PR TITLE
build: add nix dev shell with pinned swiftformat and swiftlint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,15 @@ unzip swiftformat.zip
 sudo mv swiftformat /usr/local/bin/
 ```
 
+**Option 3: Nix**
+
+If you use Nix, the repository flake provides a dev shell with SwiftFormat
+pinned to exactly the version above (plus SwiftLint):
+```bash
+nix develop
+swiftformat --version  # 0.58.7
+```
+
 #### Usage
 
 To format all Swift files in the project:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785301185,
+        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "Whisky development tools (pinned swiftformat and swiftlint)";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+      # CONTRIBUTING.md requires this exact version; CI lints with it too.
+      swiftformatVersion = "0.58.7";
+      swiftlintVersion = "0.65.0";
+
+      swiftformat =
+        pkgs:
+        pkgs.stdenvNoCC.mkDerivation {
+          pname = "swiftformat-bin";
+          version = swiftformatVersion;
+          src = pkgs.fetchurl {
+            url = "https://github.com/nicklockwood/SwiftFormat/releases/download/${swiftformatVersion}/swiftformat.zip";
+            hash = "sha256-fkP44U4gie64PWlYzhYv+pDJMw8/MJygVGk2FLKxskE=";
+          };
+          nativeBuildInputs = [ pkgs.unzip ];
+          unpackPhase = "unzip $src";
+          installPhase = "install -Dm755 swiftformat $out/bin/swiftformat";
+        };
+
+      swiftlint =
+        pkgs:
+        pkgs.stdenvNoCC.mkDerivation {
+          pname = "swiftlint-bin";
+          version = swiftlintVersion;
+          src = pkgs.fetchurl {
+            url = "https://github.com/realm/SwiftLint/releases/download/${swiftlintVersion}/portable_swiftlint.zip";
+            hash = "sha256-1ssKp6L18e8wb8nje8tU3Jom+syPd4SsDD3T7M9ca6Y=";
+          };
+          nativeBuildInputs = [ pkgs.unzip ];
+          unpackPhase = "unzip $src";
+          installPhase = "install -Dm755 swiftlint $out/bin/swiftlint";
+        };
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            (swiftformat pkgs)
+            (swiftlint pkgs)
+          ];
+        };
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,9 @@
 
       # CONTRIBUTING.md requires this exact version; CI lints with it too.
       swiftformatVersion = "0.58.7";
+      # Current SwiftLint release. CI's action bundles its own build, so lint
+      # results are close but not guaranteed identical; the SwiftFormat pin is
+      # the load-bearing one.
       swiftlintVersion = "0.65.0";
 
       swiftformat =


### PR DESCRIPTION
CONTRIBUTING.md requires SwiftFormat 0.58.7 exactly and currently has contributors download and install it by hand. This adds a Nix flake dev shell that pins the toolchain to what CI runs.

## Changes

### `flake.nix` + `flake.lock`
A dev shell for `aarch64-darwin`/`x86_64-darwin` exposing:
- SwiftFormat **0.58.7** (the exact version CONTRIBUTING and CI require), packaged from the same official release binary the docs point at, hash-pinned
- SwiftLint **0.65.0** from the official portable release binary, hash-pinned

`nix develop` and you have the toolchain, nothing installed globally, no version drift. Xcode itself stays a system dependency as before, the shell only covers the lint/format tools.

### CONTRIBUTING.md
Adds the dev shell as "Option 3: Nix" in the SwiftFormat installation section.

## Testing
- `nix develop -c swiftformat --version` → 0.58.7
- `nix develop -c swiftlint version` → 0.65.0
- `swiftformat --lint` from the shell produces the same results as the pinned binary CI installs
- flake.nix formatted with nixfmt
