### PR TITLE
fix: validate archives with -tzf and audit symlinks after extraction

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Tar.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Tar.swift
@@ -250,25 +250,25 @@ public class Tar {
         let fileManager = FileManager.default
 
         for name in try fileManager.contentsOfDirectory(atPath: source.path(percentEncoded: false)) {
-            let from = source.appending(path: name)
-            let to = destination.appending(path: name)
+            let staged = source.appending(path: name)
+            let target = destination.appending(path: name)
 
             // attributesOfItem does not follow symlinks, so a staged link to a
             // directory is moved as a link, never merged as a directory.
-            let fromType = try fileManager.attributesOfItem(
-                atPath: from.path(percentEncoded: false)
+            let stagedType = try fileManager.attributesOfItem(
+                atPath: staged.path(percentEncoded: false)
             )[.type] as? FileAttributeType
-            let toType = (try? fileManager.attributesOfItem(
-                atPath: to.path(percentEncoded: false)
+            let targetType = (try? fileManager.attributesOfItem(
+                atPath: target.path(percentEncoded: false)
             ))?[.type] as? FileAttributeType
 
-            if fromType == .typeDirectory, toType == .typeDirectory {
-                try mergeContents(of: from, into: to)
+            if stagedType == .typeDirectory, targetType == .typeDirectory {
+                try mergeContents(of: staged, into: target)
             } else {
-                if toType != nil {
-                    try fileManager.removeItem(at: to)
+                if targetType != nil {
+                    try fileManager.removeItem(at: target)
                 }
-                try fileManager.moveItem(at: from, to: to)
+                try fileManager.moveItem(at: staged, to: target)
             }
         }
     }

--- a/WhiskyKit/Sources/WhiskyKit/Tar.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Tar.swift
@@ -65,25 +65,37 @@ public class Tar {
 
     /// Extracts a tarball to the specified directory with path traversal protection.
     ///
-    /// This method validates all paths in the archive before extraction to prevent
-    /// "Zip Slip" attacks where malicious archives contain paths like `../../../etc/passwd`
-    /// that would escape the target directory.
+    /// Member paths are validated before extraction to prevent "Zip Slip" attacks
+    /// where malicious archives contain paths like `../../../etc/passwd` that would
+    /// escape the target directory. The archive is then extracted into a staging
+    /// directory next to the destination, every symlink in the staged tree is
+    /// audited (see ``auditSymlinks(underRoot:)``), and only after both checks pass
+    /// is the content moved into place. Nothing from a rejected archive ever
+    /// reaches the destination.
     ///
     /// - Parameters:
     ///   - tarBall: The URL to the tarball file to extract.
-    ///   - toURL: The destination directory for extraction.
+    ///   - toURL: The destination directory for extraction. Must already exist.
     /// - Throws: `TarError.pathTraversal` if the archive contains unsafe paths,
-    ///   or `TarError.commandFailed` if the tar command fails.
+    ///   `TarError.unsafeSymlink` if a symlink's target escapes the destination,
+    ///   `TarError.commandFailed` if the tar command fails, or a `FileManager`
+    ///   error if staging or the final move fails.
     public static func untar(tarBall: URL, toURL: URL) throws {
-        // First, validate archive contents for path traversal attacks
         try validateArchivePaths(tarBall: tarBall, targetDirectory: toURL)
 
-        // Safe to extract after validation
+        // Stage next to the destination so the final moves stay on one volume
+        // (rename, not copy) and a rejected archive leaves the destination
+        // untouched.
+        let stagingDir = toURL.deletingLastPathComponent()
+            .appending(path: ".untar-staging-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: stagingDir) }
+
         let process = Process()
         let pipe = Pipe()
 
         process.executableURL = tarBinary
-        process.arguments = ["-xzf", "\(tarBall.path)", "-C", "\(toURL.path)"]
+        process.arguments = ["-xzf", "\(tarBall.path)", "-C", "\(stagingDir.path)"]
         process.standardOutput = pipe
         process.standardError = pipe
 
@@ -97,31 +109,33 @@ public class Tar {
                 throw TarError.commandFailed(output: outputString)
             }
         }
+
+        try auditSymlinks(underRoot: stagingDir)
+
+        try mergeContents(of: stagingDir, into: toURL)
     }
 
     /// Validates that all paths in a tarball are safe and won't escape the target directory.
     ///
-    /// This method also validates symlinks to prevent symlink-based path traversal attacks
-    /// where a malicious archive creates a symlink pointing outside the target directory,
-    /// then writes files through that symlink.
+    /// Uses the non-verbose listing (`tar -tzf`): one path per line, with no
+    /// metadata columns and no locale-dependent formatting to parse. Symlink
+    /// safety — the reason the verbose listing was previously scraped — is
+    /// handled by the post-extraction audit in ``untar(tarBall:toURL:)``.
     ///
     /// - Parameters:
     ///   - tarBall: The URL to the tarball file to validate.
     ///   - targetDirectory: The intended extraction directory.
     /// - Throws: `TarError.pathTraversal` if any path would escape the target directory,
-    ///   or `TarError.unsafeSymlink` if a symlink target would escape the target directory.
+    ///   or `TarError.commandFailed` if the listing command fails.
     private static func validateArchivePaths(tarBall: URL, targetDirectory: URL) throws {
         let process = Process()
         let pipe = Pipe()
 
         process.executableURL = tarBinary
-        // Use verbose listing to see file types and symlink targets
-        // Format: "lrwxr-xr-x  0 user group    0 Jan 10 12:00 linkname -> target"
-        process.arguments = ["-tvzf", "\(tarBall.path)"]
-        // bsdtar's verbose listing is locale dependent: many locales print
-        // day-first dates ("13 Jun 09:54") that extractPathFromTarLine cannot
-        // parse, so every entry would be rejected as unsafe. Pin the C locale
-        // to get the month-first format the parser expects.
+        process.arguments = ["-tzf", "\(tarBall.path)"]
+        // Pin the C locale so bsdtar's escaping of non-printable filename bytes
+        // is stable across machines. Escaping can't hide a traversal: `.` and
+        // `/` are printable and never escaped, so `..` always appears literally.
         var environment = ProcessInfo.processInfo.environment
         environment["LC_ALL"] = "C"
         environment["LANG"] = "C"
@@ -131,7 +145,7 @@ public class Tar {
 
         try process.run()
 
-        // Drain the pipe BEFORE waitUntilExit. The verbose tar listing for a
+        // Drain the pipe BEFORE waitUntilExit. The listing for a
         // multi-hundred-MB archive easily exceeds the pipe buffer; if we wait
         // for tar to exit first, tar blocks writing while we wait for it to
         // finish and the install hangs forever.
@@ -149,14 +163,7 @@ public class Tar {
         let targetPath = targetDirectory.standardizedFileURL.path
         let lines = listing.components(separatedBy: .newlines).filter { !$0.isEmpty }
 
-        for line in lines {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-
-            // Parse the archive entry - extract file path and check for symlinks
-            let (archivePath, symlinkTarget) = parseVerboseTarLine(trimmed)
-
-            guard !archivePath.isEmpty else { continue }
-
+        for archivePath in lines {
             // Check for absolute paths
             if archivePath.hasPrefix("/") {
                 throw TarError.pathTraversal(path: archivePath)
@@ -181,140 +188,88 @@ public class Tar {
             if resolvedPath != targetPath, !resolvedPath.hasPrefix(normalizedTargetPrefix) {
                 throw TarError.pathTraversal(path: archivePath)
             }
-
-            // Validate symlink targets to prevent symlink-based path traversal
-            if let target = symlinkTarget {
-                try validateSymlinkTarget(
-                    symlinkPath: archivePath,
-                    target: target,
-                    targetDirectory: targetDirectory
-                )
-            }
         }
     }
 
-    /// Parses a verbose tar listing line to extract the file path and symlink target (if any).
-    ///
-    /// Verbose tar output format:
-    /// - Regular file: "-rw-r--r--  0 user group  1234 Jan 10 12:00 path/to/file"
-    /// - Directory:    "drwxr-xr-x  0 user group     0 Jan 10 12:00 path/to/dir/"
-    /// - Symlink:      "lrwxr-xr-x  0 user group     0 Jan 10 12:00 linkname -> target"
-    ///
-    /// - Note: If parsing fails (e.g., due to locale differences or unexpected formats),
-    ///   this method returns a synthetic path containing `../` that will trigger path traversal
-    ///   detection. This ensures archives with unparseable entries are rejected rather than
-    ///   having those entries silently skipped, which could allow malicious paths through.
-    ///
-    /// - Parameter line: A line from `tar -tvzf` output.
-    /// - Returns: A tuple of (archivePath, symlinkTarget) where symlinkTarget is nil for non-symlinks.
-    private static func parseVerboseTarLine(_ line: String) -> (path: String, symlinkTarget: String?) {
-        // Check if this is a symlink (line starts with 'l')
-        let isSymlink = line.hasPrefix("l")
-
-        if isSymlink, let arrowRange = line.range(of: " -> ") {
-            // Extract symlink path (before " -> ") and target (after " -> ")
-            let beforeArrow = String(line[..<arrowRange.lowerBound])
-            let target = String(line[arrowRange.upperBound...]).trimmingCharacters(in: .whitespaces)
-
-            // The path is the last whitespace-separated component before " -> "
-            // We need to find where the path starts after the metadata columns
-            if let path = extractPathFromTarLine(beforeArrow) {
-                return (path, target)
-            }
-            // If we cannot parse the path from this line, treat it as an unsafe entry.
-            // Returning a synthetic path that will be detected as a traversal attempt
-            // ensures the archive is rejected rather than silently skipping validation.
-            return ("../__TAR_PARSE_ERROR__", target)
-        } else {
-            // Regular file or directory - extract path from the line
-            if let path = extractPathFromTarLine(line) {
-                return (path, nil)
-            }
-            // If we cannot parse the path from this line, treat it as an unsafe entry.
-            // Returning a synthetic path that will be detected as a traversal attempt
-            // ensures the archive is rejected rather than silently skipping validation.
-            return ("../__TAR_PARSE_ERROR__", nil)
-        }
-    }
-
-    /// Extracts the file path from a tar verbose listing line.
-    ///
-    /// The format has variable-width columns, so we find the path by looking for
-    /// the timestamp pattern and taking everything after it.
-    ///
-    /// - Parameter line: A line or partial line from `tar -tvzf` output.
-    /// - Returns: The extracted file path, or nil if parsing fails.
-    private static func extractPathFromTarLine(_ line: String) -> String? {
-        // Tar verbose format: "perms links user group size month day time/year path"
-        // macOS BSD tar uses two timestamp formats:
-        // - Recent files (< ~6 months): "Jan 10 12:00" (month day time)
-        // - Older files (> ~6 months):  "Dec  4  2015" (month day year)
-        //
-        // Examples:
-        // "-rw-r--r--  0 user group  1234 Jan 10 12:00 path/to/file"
-        // "-rw-r--r--  0 user group  1234 Dec  4  2015 path/to/old/file"
-
-        // Pattern: month (3 chars) + space + day (1-2 digits) + space + (time OR year) + space + path
-        // Time format: HH:MM or HH:MM:SS (e.g., "12:00" or "12:00:00")
-        // Year format: YYYY (e.g., "2015")
-        let pattern = #"[A-Za-z]{3}\s+\d{1,2}\s+(?:\d{1,2}:\d{2}(?::\d{2})?|\d{4})\s+(.+)$"#
-
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: []),
-              let match = regex.firstMatch(
-                  in: line,
-                  options: [],
-                  range: NSRange(line.startIndex..., in: line)
-              ),
-              let pathRange = Range(match.range(at: 1), in: line)
-        else {
-            return nil
-        }
-
-        return String(line[pathRange]).trimmingCharacters(in: .whitespaces)
-    }
-
-    /// Validates that a symlink target is safe and won't allow escaping the target directory.
+    /// Walks an extracted tree and verifies every symlink's target stays inside it.
     ///
     /// This prevents symlink-based path traversal attacks where a malicious archive:
     /// 1. Creates a symlink pointing to a directory outside the target (e.g., `/etc`)
     /// 2. Extracts files "through" that symlink (e.g., `badlink/passwd` → `/etc/passwd`)
     ///
-    /// - Parameters:
-    ///   - symlinkPath: The path of the symlink within the archive.
-    ///   - target: The symlink's target path.
-    ///   - targetDirectory: The extraction target directory.
-    /// - Throws: `TarError.unsafeSymlink` if the symlink target would escape the target directory.
-    private static func validateSymlinkTarget(
-        symlinkPath: String,
-        target: String,
-        targetDirectory: URL
-    ) throws {
-        // Reject absolute symlink targets - these always escape
-        if target.hasPrefix("/") {
-            throw TarError.unsafeSymlink(path: symlinkPath, target: target)
+    /// Each link is checked lexically against the root on its own: absolute
+    /// targets are rejected outright, and relative targets are resolved from the
+    /// link's parent directory. Per-link lexical checks are chain-safe: a chain
+    /// of symlinks can only escape the root if some link in the chain has an
+    /// escaping target, and that link is rejected when the walk reaches it.
+    ///
+    /// - Parameter root: The root of the extracted tree to audit.
+    /// - Throws: `TarError.unsafeSymlink` if any symlink target escapes `root`.
+    static func auditSymlinks(underRoot root: URL) throws {
+        let fileManager = FileManager.default
+        let rootPath = root.standardizedFileURL.path
+        let rootPrefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+
+        guard let enumerator = fileManager.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isSymbolicLinkKey]
+        )
+        else { return }
+
+        for case let item as URL in enumerator {
+            let isSymlink = (try? item.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) ?? false
+            guard isSymlink else { continue }
+
+            let itemPath = item.standardizedFileURL.path
+            let relativePath = itemPath.hasPrefix(rootPrefix)
+                ? String(itemPath.dropFirst(rootPrefix.count))
+                : itemPath
+            let target = try fileManager.destinationOfSymbolicLink(
+                atPath: item.path(percentEncoded: false)
+            )
+
+            // Absolute targets always escape
+            if target.hasPrefix("/") {
+                throw TarError.unsafeSymlink(path: relativePath, target: target)
+            }
+
+            // Resolve the target lexically from the symlink's parent directory
+            let resolvedPath = item.deletingLastPathComponent()
+                .appendingPathComponent(target).standardizedFileURL.path
+
+            if resolvedPath != rootPath, !resolvedPath.hasPrefix(rootPrefix) {
+                throw TarError.unsafeSymlink(path: relativePath, target: target)
+            }
         }
+    }
 
-        // For relative symlink targets, resolve from the symlink's parent directory
-        // E.g., if symlink is "foo/bar/link" with target "../../../etc",
-        // resolve from "foo/bar/" to check if it escapes
+    /// Moves every entry of `source` into `destination`, merging directories and
+    /// replacing existing files — mirroring `tar -x` overwrite semantics so
+    /// staged extraction behaves like the direct extraction it replaced.
+    private static func mergeContents(of source: URL, into destination: URL) throws {
+        let fileManager = FileManager.default
 
-        let symlinkURL = targetDirectory.appendingPathComponent(symlinkPath)
-        let symlinkParent = symlinkURL.deletingLastPathComponent()
+        for name in try fileManager.contentsOfDirectory(atPath: source.path(percentEncoded: false)) {
+            let from = source.appending(path: name)
+            let to = destination.appending(path: name)
 
-        // Resolve the target relative to the symlink's location
-        let resolvedTarget = symlinkParent.appendingPathComponent(target).standardizedFileURL
-        let resolvedPath = resolvedTarget.path
-        let targetPath = targetDirectory.standardizedFileURL.path
+            // attributesOfItem does not follow symlinks, so a staged link to a
+            // directory is moved as a link, never merged as a directory.
+            let fromType = try fileManager.attributesOfItem(
+                atPath: from.path(percentEncoded: false)
+            )[.type] as? FileAttributeType
+            let toType = (try? fileManager.attributesOfItem(
+                atPath: to.path(percentEncoded: false)
+            ))?[.type] as? FileAttributeType
 
-        // Ensure that the target directory path ends with a separator so that we
-        // only treat true subpaths as inside the directory (and not siblings like
-        // "/foo/bar-malicious" when targetPath is "/foo/bar").
-        let normalizedTargetPrefix = targetPath.hasSuffix("/") ? targetPath : targetPath + "/"
-
-        // Check if the resolved symlink target stays within the target directory:
-        // it must either be exactly the directory itself or a proper subpath.
-        if resolvedPath != targetPath, !resolvedPath.hasPrefix(normalizedTargetPrefix) {
-            throw TarError.unsafeSymlink(path: symlinkPath, target: target)
+            if fromType == .typeDirectory, toType == .typeDirectory {
+                try mergeContents(of: from, into: to)
+            } else {
+                if toType != nil {
+                    try fileManager.removeItem(at: to)
+                }
+                try fileManager.moveItem(at: from, to: to)
+            }
         }
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/TarTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/TarTests.swift
@@ -16,6 +16,7 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
+// swiftlint:disable file_length
 import Foundation
 @testable import WhiskyKit
 import XCTest

--- a/WhiskyKit/Tests/WhiskyKitTests/TarTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/TarTests.swift
@@ -117,6 +117,95 @@ final class TarIntegrationTests: XCTestCase {
         XCTAssertNoThrow(try Tar.untar(tarBall: tarURL, toURL: extractDir))
     }
 
+    func testUntarPreservesInternalSymlink() throws {
+        try Data("Hello, World!".utf8).write(to: sourceDir.appending(path: "test.txt"))
+        try FileManager.default.createSymbolicLink(
+            atPath: sourceDir.appending(path: "link").path(percentEncoded: false),
+            withDestinationPath: "test.txt"
+        )
+
+        let tarURL = tempDir.appending(path: "symlink.tar.gz")
+        try Tar.tar(folder: sourceDir, toURL: tarURL)
+        try Tar.untar(tarBall: tarURL, toURL: extractDir)
+
+        // The extracted tree must still contain the (safe, internal) symlink.
+        let enumerator = FileManager.default.enumerator(
+            at: extractDir,
+            includingPropertiesForKeys: [.isSymbolicLinkKey]
+        )
+        let symlinks = (enumerator?.compactMap { item -> URL? in
+            guard let url = item as? URL else { return nil }
+            let isLink = (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) ?? false
+            return isLink ? url : nil
+        }) ?? []
+        XCTAssertEqual(symlinks.count, 1)
+    }
+
+    func testUntarRejectsAbsoluteSymlink() throws {
+        try Data("decoy".utf8).write(to: sourceDir.appending(path: "decoy.txt"))
+        try FileManager.default.createSymbolicLink(
+            atPath: sourceDir.appending(path: "evil").path(percentEncoded: false),
+            withDestinationPath: "/etc/passwd"
+        )
+
+        let tarURL = tempDir.appending(path: "abs-symlink.tar.gz")
+        try Tar.tar(folder: sourceDir, toURL: tarURL)
+
+        XCTAssertThrowsError(try Tar.untar(tarBall: tarURL, toURL: extractDir)) { error in
+            guard case .unsafeSymlink = error as? TarError else {
+                return XCTFail("Expected unsafeSymlink error, got \(error)")
+            }
+        }
+
+        // Extraction is staged: a rejected archive leaves the destination untouched.
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: extractDir, includingPropertiesForKeys: nil
+        )
+        XCTAssertTrue(contents.isEmpty)
+    }
+
+    func testUntarRejectsEscapingRelativeSymlink() throws {
+        // Deep enough to escape any staging root regardless of temp-path depth.
+        let escape = String(repeating: "../", count: 40) + "etc"
+        try FileManager.default.createSymbolicLink(
+            atPath: sourceDir.appending(path: "evil").path(percentEncoded: false),
+            withDestinationPath: escape
+        )
+
+        let tarURL = tempDir.appending(path: "rel-symlink.tar.gz")
+        try Tar.tar(folder: sourceDir, toURL: tarURL)
+
+        XCTAssertThrowsError(try Tar.untar(tarBall: tarURL, toURL: extractDir)) { error in
+            guard case .unsafeSymlink = error as? TarError else {
+                return XCTFail("Expected unsafeSymlink error, got \(error)")
+            }
+        }
+    }
+
+    func testUntarRejectsCraftedTraversalPath() throws {
+        // Build an archive whose member path literally contains `../` using
+        // tar -P, which stores the path verbatim instead of sanitizing it.
+        try Data("outside".utf8).write(to: tempDir.appending(path: "escape.txt"))
+
+        let tarURL = tempDir.appending(path: "traversal.tar.gz")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        process.arguments = [
+            "-czPf", tarURL.path(percentEncoded: false),
+            "-C", sourceDir.path(percentEncoded: false),
+            "../escape.txt"
+        ]
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+
+        XCTAssertThrowsError(try Tar.untar(tarBall: tarURL, toURL: extractDir)) { error in
+            guard case .pathTraversal = error as? TarError else {
+                return XCTFail("Expected pathTraversal error, got \(error)")
+            }
+        }
+    }
+
     func testTarWithMultipleFiles() throws {
         try Data("File 1 content".utf8).write(to: sourceDir.appending(path: "file1.txt"))
         try Data("File 2 content".utf8).write(to: sourceDir.appending(path: "file2.txt"))


### PR DESCRIPTION
Closes #147, the follow-up shape agreed in #139/#142.

## Changes

### Path validation moves to the non-verbose listing
`validateArchivePaths` now parses `tar -tzf`: one path per line, no metadata columns, nothing locale-sensitive. The regex scraper (`parseVerboseTarLine` / `extractPathFromTarLine`) and its `../__TAR_PARSE_ERROR__` sentinel are gone. The `LC_ALL=C` pin stays, with a new purpose: it stabilizes bsdtar's escaping of non-printable filename bytes, which can't hide a traversal (`.` and `/` are printable and never escaped, so `..` always appears literally). The resolved-path prefix check remains the authoritative boundary, unchanged.

### Symlink safety becomes a post-extraction audit of a staged tree
Extraction goes into a staging directory next to the destination (same volume, so the final moves are renames). `auditSymlinks(underRoot:)` walks the staged tree: absolute targets are rejected outright, relative targets resolve lexically from the link's parent and must stay inside the root. Per-link checks are chain-safe: a chain of links can only escape if some link in the chain has an escaping target, and that link is rejected on its own line. Only after the audit does `mergeContents` move the tree into place with `tar -x`-style overwrite semantics.

Side effect worth having: a rejected archive now leaves the destination completely untouched, where the old flow validated-then-extracted-in-place.

## Testing
- Four new tests: internal symlink survives a round trip; absolute-target symlink rejected (and destination verifiably untouched); deeply-escaping relative symlink rejected; crafted archive with a literal `../` member (built with `tar -P`) rejected by path validation.
- Verified end to end with an SPM harness under `LC_ALL=en_GB.UTF-8` (the locale from #139): all seven checks pass, including staged extraction of the real 317 MB v3.1.1 `Libraries.tar.gz` with `wine64` landing in place, and each malicious case rejected with the expected `TarError`.
- `swiftformat --lint` (0.58.7) clean on both files.
- The XCTest suite couldn't run locally (Command Line Tools only, no XCTest module), relying on CI for the full suite.
