### PR TITLE
feat: offer re-import of bottle folders missing from the registry

### DIFF
--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -1101,6 +1101,36 @@
         }
       }
     },
+    "bottle.orphaned.message" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "These bottles exist on disk but aren't in your library: %@. Re-importing adds them back to the sidebar; nothing on disk is changed."
+          }
+        }
+      }
+    },
+    "bottle.orphaned.reimport" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Re-Import"
+          }
+        }
+      }
+    },
+    "bottle.orphaned.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bottles Found on Disk"
+          }
+        }
+      }
+    },
     "bottle.registry.corrupt.message" : {
       "localizations" : {
         "en" : {

--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -80,6 +80,28 @@ final class BottleVM: ObservableObject {
         bottles = bottlesList.loadBottles()
     }
 
+    /// Bottles found on disk with no registry entry, awaiting a re-import
+    /// decision from the user (issue #145). Non-empty drives the recovery
+    /// alert in ContentView.
+    @Published var orphanedBottles: [BottleData.OrphanedBottle] = []
+
+    /// Scans the default bottles directory for bottle folders the registry
+    /// doesn't know about — pre-#136 creations, a reset registry, or a
+    /// restored Bottles/ backup.
+    func scanForOrphanedBottles() {
+        orphanedBottles = bottlesList.orphanedBottles()
+    }
+
+    func reimportOrphanedBottles() {
+        for orphan in orphanedBottles where !bottlesList.registerBottlePath(orphan.url) {
+            bottleVMLogger.error(
+                "Failed to re-register orphaned bottle at \(orphan.url.path(percentEncoded: false), privacy: .public)"
+            )
+        }
+        orphanedBottles = []
+        loadBottles()
+    }
+
     func countActive() -> Int {
         bottles.filter { $0.isAvailable == true }.count
     }

--- a/Whisky/Views/ContentView.swift
+++ b/Whisky/Views/ContentView.swift
@@ -99,6 +99,23 @@ struct ContentView: View {
                 url.prettyPath()
             ))
         }
+        .alert(
+            "bottle.orphaned.title",
+            isPresented: Binding(
+                get: { !bottleVM.orphanedBottles.isEmpty },
+                set: { if !$0 { bottleVM.orphanedBottles = [] } }
+            )
+        ) {
+            Button("bottle.orphaned.reimport") {
+                bottleVM.reimportOrphanedBottles()
+            }
+            Button("button.cancel", role: .cancel) {}
+        } message: {
+            Text(String(
+                format: String(localized: "bottle.orphaned.message"),
+                bottleVM.orphanedBottles.map(\.name).joined(separator: ", ")
+            ))
+        }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {
@@ -174,6 +191,11 @@ struct ContentView: View {
             // Surface a registry that couldn't be read and was moved aside at
             // startup, so the reset bottle list doesn't pass silently (#61).
             corruptRegistryBackupURL = bottleVM.bottlesList.corruptRegistryBackupURL
+
+            // Offer re-import for bottle folders the registry doesn't know
+            // about — pairs with the corrupt-registry backup above: after a
+            // registry reset the scan offers everything back (issue #145).
+            bottleVM.scanForOrphanedBottles()
 
             if !bottleVM.bottles.isEmpty || bottleVM.countActive() != 0 {
                 if let bottle = bottleVM.bottles.first(where: { $0.url == selectedBottleURL && $0.isAvailable }) {

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleData.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleData.swift
@@ -112,6 +112,63 @@ public struct BottleData: Codable {
         return bottles
     }
 
+    // MARK: - Orphaned Bottle Recovery
+
+    /// A bottle directory found on disk with no corresponding registry entry.
+    public struct OrphanedBottle: Equatable {
+        /// The bottle's root directory.
+        public let url: URL
+        /// The bottle name from its `Metadata.plist`.
+        public let name: String
+    }
+
+    /// Finds bottle directories on disk that aren't in the registry.
+    ///
+    /// Scans the immediate subdirectories of `directory` for a decodable
+    /// `Metadata.plist` with no matching registry entry, so bottles that fell
+    /// out of the registry (pre-#136 creations, a reset registry, a restored
+    /// `Bottles/` backup) can be offered for one-click re-import instead of
+    /// requiring hand edits to the entries plist (issue #145).
+    ///
+    /// The read is deliberately side-effect free: unlike
+    /// ``BottleSettings/decode(from:)`` it never creates, migrates, or
+    /// quarantines files in directories it merely probes. Only the default
+    /// bottles directory is scanned — custom-location bottles stay manual.
+    ///
+    /// - Parameter directory: The directory to scan. Defaults to
+    ///   ``defaultBottleDir``.
+    /// - Returns: Orphaned bottles sorted by name.
+    public func orphanedBottles(in directory: URL = BottleData.defaultBottleDir) -> [OrphanedBottle] {
+        let fileManager = FileManager.default
+        let registered = Set(paths.map(Self.comparablePath))
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        else { return [] }
+
+        return entries
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+            .filter { !registered.contains(Self.comparablePath($0)) }
+            .compactMap { url in
+                let metadataURL = url.appending(path: "Metadata").appendingPathExtension("plist")
+                guard let data = try? Data(contentsOf: metadataURL),
+                      let settings = try? PropertyListDecoder().decode(BottleSettings.self, from: data)
+                else { return nil }
+                return OrphanedBottle(url: url, name: settings.name)
+            }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// Canonical path form for registry-membership comparison: trailing
+    /// slashes stripped and symlinks resolved, so directory-listing URLs
+    /// (trailing slash, `/private/var`) match registered paths (`/var`, no
+    /// slash) for the same directory.
+    private static func comparablePath(_ url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path(percentEncoded: false)
+    }
+
     /// Appends a bottle path to the registry and verifies the entries file on
     /// disk actually contains it afterwards, so a failed save can't silently
     /// drop the bottle on the next launch (issue #61).

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleDataTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleDataTests.swift
@@ -99,6 +99,100 @@ final class BottleDataTests: XCTestCase {
         XCTAssertNil(reloaded.corruptRegistryBackupURL)
     }
 
+    // MARK: - Orphaned bottle scan (issue #145)
+
+    /// Creates a bottle directory with a decodable Metadata.plist, mirroring
+    /// what a real creation leaves on disk.
+    @discardableResult
+    private func makeBottleDir(named name: String, in dir: URL) throws -> URL {
+        let bottleDir = dir.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: bottleDir, withIntermediateDirectories: true)
+        var settings = BottleSettings()
+        settings.name = name
+        try settings.encode(to: bottleDir.appendingPathComponent("Metadata.plist"))
+        return bottleDir
+    }
+
+    func testOrphanScanFindsUnregisteredBottle() throws {
+        let scanDir = tempDir.appendingPathComponent("Bottles")
+        let bottleDir = try makeBottleDir(named: "Steam Stuff", in: scanDir)
+
+        let data = BottleData(entriesFile: entriesFile)
+        let orphans = data.orphanedBottles(in: scanDir)
+
+        XCTAssertEqual(orphans.map(\.name), ["Steam Stuff"])
+        // Compare resolved paths: the listing yields /private/var-style URLs
+        // where the test constructed /var-style ones.
+        XCTAssertEqual(
+            orphans.map { $0.url.resolvingSymlinksInPath().path },
+            [bottleDir.resolvingSymlinksInPath().path]
+        )
+    }
+
+    func testOrphanScanSkipsRegisteredBottles() throws {
+        let scanDir = tempDir.appendingPathComponent("Bottles")
+        let bottleDir = try makeBottleDir(named: "Registered", in: scanDir)
+
+        var data = BottleData(entriesFile: entriesFile)
+        XCTAssertTrue(data.registerBottlePath(bottleDir))
+
+        XCTAssertTrue(data.orphanedBottles(in: scanDir).isEmpty)
+    }
+
+    func testOrphanScanMatchesRegistrationDespiteTrailingSlash() throws {
+        // contentsOfDirectory yields directory URLs with a trailing slash;
+        // registered paths are stored without one. The comparison must not
+        // report a registered bottle as orphaned over that difference.
+        let scanDir = tempDir.appendingPathComponent("Bottles")
+        let bottleDir = try makeBottleDir(named: "Slashed", in: scanDir)
+
+        var data = BottleData(entriesFile: entriesFile)
+        XCTAssertTrue(data.registerBottlePath(URL(fileURLWithPath: bottleDir.path + "/", isDirectory: true)))
+
+        XCTAssertTrue(data.orphanedBottles(in: scanDir).isEmpty)
+    }
+
+    func testOrphanScanSkipsDirsWithoutMetadataAndPlainFiles() throws {
+        let scanDir = tempDir.appendingPathComponent("Bottles")
+        try FileManager.default.createDirectory(
+            at: scanDir.appendingPathComponent("no-metadata"),
+            withIntermediateDirectories: true
+        )
+        try Data("not a bottle".utf8).write(to: scanDir.appendingPathComponent("stray-file"))
+
+        let data = BottleData(entriesFile: entriesFile)
+        XCTAssertTrue(data.orphanedBottles(in: scanDir).isEmpty)
+    }
+
+    func testOrphanScanSkipsCorruptMetadata() throws {
+        let scanDir = tempDir.appendingPathComponent("Bottles")
+        let bottleDir = scanDir.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: bottleDir, withIntermediateDirectories: true)
+        let metadataURL = bottleDir.appendingPathComponent("Metadata.plist")
+        let garbage = Data("garbage".utf8)
+        try garbage.write(to: metadataURL)
+
+        let data = BottleData(entriesFile: entriesFile)
+
+        XCTAssertTrue(data.orphanedBottles(in: scanDir).isEmpty)
+        // The probe must be side-effect free: no quarantine, no default rewrite.
+        XCTAssertEqual(try Data(contentsOf: metadataURL), garbage)
+    }
+
+    func testOrphanScanSortsByName() throws {
+        let scanDir = tempDir.appendingPathComponent("Bottles")
+        try makeBottleDir(named: "zeta", in: scanDir)
+        try makeBottleDir(named: "Alpha", in: scanDir)
+
+        let data = BottleData(entriesFile: entriesFile)
+        XCTAssertEqual(data.orphanedBottles(in: scanDir).map(\.name), ["Alpha", "zeta"])
+    }
+
+    func testOrphanScanMissingDirectoryReturnsEmpty() {
+        let data = BottleData(entriesFile: entriesFile)
+        XCTAssertTrue(data.orphanedBottles(in: tempDir.appendingPathComponent("nope")).isEmpty)
+    }
+
     // MARK: - Fallback-format salvage
 
     func testMinimalFallbackFormatIsSalvagedWithoutBackup() throws {


### PR DESCRIPTION
Closes #145.

At startup, scan `BottleData.defaultBottleDir` for subdirectories with a decodable `Metadata.plist` that have no registry entry, and surface a one-click re-import alert.

## Changes
- `BottleData.orphanedBottles(in:)` — side-effect-free scan (never creates/migrates/quarantines files in probed directories, unlike `BottleSettings.decode(from:)`); symlink- and trailing-slash-insensitive registry comparison; results sorted by bottle name.
- `BottleVM.scanForOrphanedBottles()` / `reimportOrphanedBottles()` — re-import routes through the verified `registerBottlePath` from #136.
- ContentView alert listing the found bottle names, wired into the startup task after the corrupt-registry surfacing (after a registry reset the scan offers everything back).
- 7 new `BottleDataTests` cases: detection, registered-path exclusion, slash/symlink normalization, non-bottle dirs and files, corrupt metadata (including probe side-effect-freedom), name sorting, missing scan dir.

## Testing
- `swift test --filter BottleDataTests`: 12/12 green locally.
- Full app build green locally; `swiftlint --strict` clean on changed files.