### PR TITLE
fix: surface D3DMetal unavailability instead of silently falling back

### DIFF
--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -22634,6 +22634,16 @@
         }
       }
     },
+    "config.graphics.backend.d3dMetal.missingWarning" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This bottle is set to D3DMetal, which the installed engine doesn't include. Games will fall back to WineD3D, which can't run DirectX 11 titles — switch to DXMT or DXVK."
+          }
+        }
+      }
+    },
     "config.graphics.backend.d3dMetal.summary" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -22641,6 +22651,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Apple's Direct3D-to-Metal translation, fastest on Apple Silicon for D3D9–12."
+          }
+        }
+      }
+    },
+    "config.graphics.backend.d3dMetal.unavailable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not included in the installed engine — needs a Game Porting Toolkit runtime"
           }
         }
       }

--- a/Whisky/Views/Bottle/BackendPickerView.swift
+++ b/Whisky/Views/Bottle/BackendPickerView.swift
@@ -122,7 +122,7 @@ private struct BackendCard: View {
                         .foregroundStyle(isSelected ? .white.opacity(0.8) : .secondary)
                         .lineLimit(2)
                 } else {
-                    Text("config.graphics.backend.dxmt.unavailable")
+                    Text(unavailableReasonKey)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
@@ -151,6 +151,16 @@ private struct BackendCard: View {
         .buttonStyle(.plain)
         .disabled(!isAvailable)
         .opacity(isAvailable ? 1 : 0.5)
+    }
+
+    // MARK: - Unavailability
+
+    /// Only payload-dependent backends (DXMT, D3DMetal) can be unavailable;
+    /// each explains what the installed engine is missing (issue #146).
+    private var unavailableReasonKey: LocalizedStringKey {
+        backend == .d3dMetal
+            ? "config.graphics.backend.d3dMetal.unavailable"
+            : "config.graphics.backend.dxmt.unavailable"
     }
 
     // MARK: - Icon

--- a/Whisky/Views/Bottle/GraphicsConfigSection.swift
+++ b/Whisky/Views/Bottle/GraphicsConfigSection.swift
@@ -51,6 +51,13 @@ struct GraphicsConfigSection: View {
                 }
             )
 
+            // A bottle explicitly set to D3DMetal without its payload silently
+            // degrades to WineD3D at launch — say so instead (issue #146).
+            if bottle.settings.graphicsBackend == .d3dMetal,
+               !WhiskyWineInstaller.isBackendAvailable(.d3dMetal) {
+                d3dMetalMissingWarning
+            }
+
             // Running process warning banner
             if hasRunningProcesses {
                 runningProcessWarning
@@ -129,6 +136,18 @@ struct GraphicsConfigSection: View {
         .animation(.default, value: advancedMode)
         .task {
             await checkRunningProcesses()
+        }
+    }
+
+    // MARK: - D3DMetal Missing Warning
+
+    private var d3dMetalMissingWarning: some View {
+        HStack {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(.orange)
+            Text("config.graphics.backend.d3dMetal.missingWarning")
+                .font(.caption)
+            Spacer()
         }
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -395,14 +395,39 @@ public class WhiskyWineInstaller {
 
     /// Whether `backend` can actually be selected against the currently
     /// installed runtime. Extends the pure
-    /// ``GraphicsBackend/isAvailable(runtimeInfo:)`` version gate with DXMT's
-    /// payload-variant capability check: only the *native* DXMT payload is
-    /// usable per-bottle, so an older builtin-variant payload (present but it
-    /// would silently redirect to wined3d) must not appear selectable.
+    /// ``GraphicsBackend/isAvailable(runtimeInfo:)`` version gate with the
+    /// payload checks version records can't express: DXMT needs the *native*
+    /// payload variant (an older builtin-variant payload would silently
+    /// redirect to wined3d), and D3DMetal needs the GPTK payload on disk —
+    /// without it a d3dMetal bottle silently degrades to wined3d at launch
+    /// (issue #146).
     public static func isBackendAvailable(_ backend: GraphicsBackend) -> Bool {
-        let versionAvailable = backend.isAvailable(runtimeInfo: whiskyWineInfo())
-        guard backend == .dxmt else { return versionAvailable }
-        return versionAvailable && Wine.isDXMTRuntimeNative()
+        backendAvailability(
+            backend,
+            runtimeInfo: whiskyWineInfo(),
+            d3dMetalInstalled: isD3DMetalInstalled(),
+            dxmtRuntimeNative: Wine.isDXMTRuntimeNative()
+        )
+    }
+
+    /// Pure availability logic behind ``isBackendAvailable(_:)``, with every
+    /// machine-dependent input injected so tests answer the same on every
+    /// machine.
+    static func backendAvailability(
+        _ backend: GraphicsBackend,
+        runtimeInfo: WhiskyWineVersion?,
+        d3dMetalInstalled: Bool,
+        dxmtRuntimeNative: Bool
+    ) -> Bool {
+        let versionAvailable = backend.isAvailable(runtimeInfo: runtimeInfo)
+        switch backend {
+        case .dxmt:
+            return versionAvailable && dxmtRuntimeNative
+        case .d3dMetal:
+            return versionAvailable && d3dMetalInstalled
+        case .recommended, .dxvk, .wined3d:
+            return versionAvailable
+        }
     }
 
     /// Reads the full version record from the installed WhiskyWine runtime.

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -22,6 +22,7 @@ import SemanticVersion
 @testable import WhiskyKit
 import XCTest
 
+// swiftlint:disable:next type_body_length
 final class WhiskyWineInstallerTests: XCTestCase {
     func testCleanupTarballRemovesExistingFile() throws {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -195,6 +196,43 @@ final class WhiskyWineInstallerTests: XCTestCase {
         )
 
         XCTAssertFalse(WhiskyWineInstaller.isD3DMetalPresent(inLibraryFolder: tempDir))
+    }
+
+    // MARK: - backendAvailability (issue #146)
+
+    func testD3DMetalUnavailableWithoutPayload() {
+        let runtime = WhiskyWineVersion(version: SemanticVersion(3, 1, 1), dxmtVersion: "0.80")
+
+        XCTAssertFalse(WhiskyWineInstaller.backendAvailability(
+            .d3dMetal, runtimeInfo: runtime, d3dMetalInstalled: false, dxmtRuntimeNative: true
+        ))
+    }
+
+    func testD3DMetalAvailableWithPayload() {
+        let runtime = WhiskyWineVersion(version: SemanticVersion(3, 1, 1), dxmtVersion: "0.80")
+
+        XCTAssertTrue(WhiskyWineInstaller.backendAvailability(
+            .d3dMetal, runtimeInfo: runtime, d3dMetalInstalled: true, dxmtRuntimeNative: true
+        ))
+    }
+
+    func testDXMTRequiresNativePayloadVariant() {
+        let runtime = WhiskyWineVersion(version: SemanticVersion(3, 1, 1), dxmtVersion: "0.80")
+
+        XCTAssertFalse(WhiskyWineInstaller.backendAvailability(
+            .dxmt, runtimeInfo: runtime, d3dMetalInstalled: true, dxmtRuntimeNative: false
+        ))
+        XCTAssertTrue(WhiskyWineInstaller.backendAvailability(
+            .dxmt, runtimeInfo: runtime, d3dMetalInstalled: false, dxmtRuntimeNative: true
+        ))
+    }
+
+    func testUniversalBackendsUnaffectedByMissingPayloads() {
+        for backend in [GraphicsBackend.recommended, .dxvk, .wined3d] {
+            XCTAssertTrue(WhiskyWineInstaller.backendAvailability(
+                backend, runtimeInfo: nil, d3dMetalInstalled: false, dxmtRuntimeNative: false
+            ))
+        }
     }
 
     func testRuntimeNotPresentWhenFolderEmpty() {


### PR DESCRIPTION
Closes #146. Completes the #141/#143 story: the resolver no longer picks a missing D3DMetal, but explicit selection could still hit the silent WineD3D fallback (#138 shows the symptom).

## Changes
- `WhiskyWineInstaller.isBackendAvailable` gates `.d3dMetal` on `isD3DMetalInstalled()` (the #143 payload check), via a pure `backendAvailability(_:runtimeInfo:d3dMetalInstalled:dxmtRuntimeNative:)` with all machine-dependent inputs injected — hermetic by construction, per today's lesson in #143.
- `BackendPickerView` greys the D3DMetal card with a backend-specific reason (the unavailable text was previously hardcoded to the DXMT explanation).
- `GraphicsConfigSection` shows a warning banner when a bottle is already configured for D3DMetal without the payload, recommending DXMT/DXVK. The program-level override picker inherits the gate through the existing `isBackendAvailable` route.
- 4 new hermetic `WhiskyWineInstallerTests` cases covering the availability matrix.

## Testing
- `swift test --filter WhiskyWineInstallerTests`: 22/22 green locally.
- Full app build green locally; `swiftformat --lint` and `swiftlint --strict` clean on changed files.