### PR TITLE
test: cover the Troubleshooting flow engine, session, and fix machinery

### DIFF
--- a/WhiskyKit/Tests/WhiskyKitTests/FixApplicatorTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/FixApplicatorTests.swift
@@ -1,0 +1,171 @@
+//
+//  FixApplicatorTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+/// Covers the settings-mutating fixes end to end: preview describes the
+/// change, apply performs and records it, undo restores the prior value.
+/// The process-touching fix (restart-wineserver) is deliberately not
+/// exercised — it spawns wineserver and is not hermetic.
+@MainActor
+final class FixApplicatorTests: XCTestCase {
+    private var tempDir: URL!
+    private var bottle: Bottle!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        bottle = Bottle(bottleUrl: tempDir, inFlight: false, isAvailable: true)
+    }
+
+    override func tearDownWithError() throws {
+        bottle = nil
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+    }
+
+    // MARK: - Preview
+
+    func testPreviewSwitchBackendDescribesCurrentAndTarget() throws {
+        bottle.settings.graphicsBackend = .wined3d
+
+        let preview = try XCTUnwrap(FixApplicator.preview(
+            fixId: "switch-backend", params: ["backend": "dxvk"], bottle: bottle, program: nil
+        ))
+
+        XCTAssertEqual(preview.settingName, "Graphics Backend")
+        XCTAssertEqual(preview.currentValue, "WineD3D")
+        XCTAssertEqual(preview.newValue, "DXVK")
+        XCTAssertTrue(preview.isReversible)
+    }
+
+    func testPreviewNonReversibleInstallFix() throws {
+        let preview = try XCTUnwrap(FixApplicator.preview(
+            fixId: "install-winetricks-verb", params: ["verb": "vcrun2019"], bottle: bottle, program: nil
+        ))
+
+        XCTAssertEqual(preview.newValue, "vcrun2019")
+        XCTAssertFalse(preview.isReversible)
+    }
+
+    func testPreviewUnknownFixIdReturnsNil() {
+        XCTAssertNil(FixApplicator.preview(fixId: "no.such_fix", params: [:], bottle: bottle, program: nil))
+    }
+
+    // MARK: - Apply
+
+    func testApplySwitchBackendMutatesSettingsAndRecordsValues() {
+        bottle.settings.graphicsBackend = .wined3d
+
+        let attempt = FixApplicator.apply(
+            fixId: "switch-backend", params: ["backend": "dxmt"], bottle: bottle, program: nil
+        )
+
+        XCTAssertEqual(bottle.settings.graphicsBackend, .dxmt)
+        XCTAssertEqual(attempt.beforeValue, "wined3d")
+        XCTAssertEqual(attempt.afterValue, "dxmt")
+        XCTAssertEqual(attempt.result, .applied)
+    }
+
+    func testApplySwitchBackendWithBadParamFallsBackToRecommended() {
+        let attempt = FixApplicator.apply(
+            fixId: "switch-backend", params: ["backend": "not-a-backend"], bottle: bottle, program: nil
+        )
+
+        XCTAssertEqual(bottle.settings.graphicsBackend, .recommended)
+        XCTAssertEqual(attempt.afterValue, "recommended")
+    }
+
+    func testApplyEnableDXVKAsync() {
+        bottle.settings.dxvkAsync = false
+
+        let attempt = FixApplicator.apply(fixId: "enable-dxvk-async", params: [:], bottle: bottle, program: nil)
+
+        XCTAssertTrue(bottle.settings.dxvkAsync)
+        XCTAssertEqual(attempt.beforeValue, "false")
+        XCTAssertEqual(attempt.result, .applied)
+    }
+
+    func testApplyEnableEsync() {
+        bottle.settings.enhancedSync = .none
+
+        let attempt = FixApplicator.apply(fixId: "enable-esync", params: [:], bottle: bottle, program: nil)
+
+        XCTAssertEqual(bottle.settings.enhancedSync, .esync)
+        XCTAssertEqual(attempt.result, .applied)
+    }
+
+    func testApplyRegistryBackedFixesStayPendingForVerification() {
+        let attempt = FixApplicator.apply(
+            fixId: "set-buffer-size", params: ["preset": "stable"], bottle: bottle, program: nil
+        )
+
+        XCTAssertEqual(attempt.result, .pending)
+    }
+
+    func testApplyUnknownFixIdFails() {
+        let attempt = FixApplicator.apply(fixId: "no.such_fix", params: [:], bottle: bottle, program: nil)
+
+        XCTAssertEqual(attempt.result, .failed)
+        XCTAssertNil(attempt.beforeValue)
+    }
+
+    // MARK: - Undo
+
+    func testApplyThenUndoRestoresOriginalBackend() {
+        bottle.settings.graphicsBackend = .dxvk
+        let attempt = FixApplicator.apply(
+            fixId: "switch-backend", params: ["backend": "dxmt"], bottle: bottle, program: nil
+        )
+        XCTAssertEqual(bottle.settings.graphicsBackend, .dxmt)
+
+        let undone = FixApplicator.undo(attempt: attempt, bottle: bottle, program: nil)
+
+        XCTAssertTrue(undone)
+        XCTAssertEqual(bottle.settings.graphicsBackend, .dxvk)
+    }
+
+    func testUndoEsyncRestoresPriorMode() {
+        bottle.settings.enhancedSync = .msync
+        let attempt = FixApplicator.apply(fixId: "enable-esync", params: [:], bottle: bottle, program: nil)
+
+        XCTAssertTrue(FixApplicator.undo(attempt: attempt, bottle: bottle, program: nil))
+        XCTAssertEqual(bottle.settings.enhancedSync, .msync)
+    }
+
+    func testUndoWithMissingBeforeValueFails() {
+        let attempt = FixAttempt(fixId: "switch-backend", beforeValue: nil, afterValue: "dxvk", result: .applied)
+
+        XCTAssertFalse(FixApplicator.undo(attempt: attempt, bottle: bottle, program: nil))
+    }
+
+    func testUndoNonReversibleFixFails() {
+        let attempt = FixAttempt(fixId: "install-dependency", afterValue: "dotnet48", result: .applied)
+
+        XCTAssertFalse(FixApplicator.undo(attempt: attempt, bottle: bottle, program: nil))
+    }
+
+    func testUndoUnknownFixIdFails() {
+        let attempt = FixAttempt(fixId: "no.such_fix", result: .applied)
+
+        XCTAssertFalse(FixApplicator.undo(attempt: attempt, bottle: bottle, program: nil))
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/FlowDefinitionTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/FlowDefinitionTests.swift
@@ -1,0 +1,148 @@
+//
+//  FlowDefinitionTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+final class FlowDefinitionTests: XCTestCase {
+    // MARK: - Decoding
+
+    func testDecodesMinimalFlow() throws {
+        let json = """
+        {
+            "version": 1,
+            "categoryId": "graphics",
+            "entryNodeId": "start",
+            "nodes": {
+                "start": {
+                    "id": "start",
+                    "type": "check",
+                    "phase": "checks",
+                    "checkId": "graphics.backend_is",
+                    "params": {"expected": "dxvk"},
+                    "on": {"pass": "done", "fail": "fix-backend"}
+                }
+            }
+        }
+        """
+        let flow = try JSONDecoder().decode(FlowDefinition.self, from: Data(json.utf8))
+
+        XCTAssertEqual(flow.version, 1)
+        XCTAssertEqual(flow.categoryId, "graphics")
+        XCTAssertEqual(flow.entryNodeId, "start")
+        let node = try XCTUnwrap(flow.nodes["start"])
+        XCTAssertEqual(node.type, .check)
+        XCTAssertEqual(node.phase, .checks)
+        XCTAssertEqual(node.checkId, "graphics.backend_is")
+        XCTAssertEqual(node.params?["expected"], "dxvk")
+        XCTAssertEqual(node.on?["pass"], "done")
+        // Absent optionals decode to nil rather than failing the parent decode
+        XCTAssertNil(node.title)
+        XCTAssertNil(node.fixId)
+        XCTAssertNil(node.fixPreview)
+        XCTAssertNil(node.fragmentRef)
+    }
+
+    func testDecodesFixNodeWithPreview() throws {
+        let json = """
+        {
+            "id": "fix-backend",
+            "type": "fix",
+            "phase": "fix",
+            "title": "Switch to DXVK",
+            "fixId": "graphics.set_backend_dxvk",
+            "isReversible": true,
+            "requiresConfirmation": false,
+            "fixPreview": {
+                "settingName": "Graphics Backend",
+                "currentValueKey": "current",
+                "newValue": "dxvk",
+                "scope": "bottle"
+            }
+        }
+        """
+        let node = try JSONDecoder().decode(FlowStepNode.self, from: Data(json.utf8))
+
+        XCTAssertEqual(node.type, .fix)
+        XCTAssertEqual(node.fixId, "graphics.set_backend_dxvk")
+        XCTAssertEqual(node.isReversible, true)
+        XCTAssertEqual(node.requiresConfirmation, false)
+        let preview = try XCTUnwrap(node.fixPreview)
+        XCTAssertEqual(preview.settingName, "Graphics Backend")
+        XCTAssertEqual(preview.currentValueKey, "current")
+        XCTAssertEqual(preview.newValue, "dxvk")
+        XCTAssertEqual(preview.scope, "bottle")
+    }
+
+    func testUnknownNodeTypeFailsDecode() {
+        let json = """
+        {"id": "x", "type": "teleport", "phase": "checks"}
+        """
+        XCTAssertThrowsError(try JSONDecoder().decode(FlowStepNode.self, from: Data(json.utf8)))
+    }
+
+    // MARK: - CheckResult round trip
+
+    func testCheckResultCodableRoundTrip() throws {
+        let result = CheckResult(
+            outcome: .alreadyConfigured,
+            evidence: ["current": "dxvk"],
+            summary: "Already set",
+            confidence: .high
+        )
+        let data = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(CheckResult.self, from: data)
+
+        XCTAssertEqual(decoded.outcome, .alreadyConfigured)
+        XCTAssertEqual(decoded.evidence, ["current": "dxvk"])
+        XCTAssertEqual(decoded.summary, "Already set")
+        XCTAssertEqual(decoded.confidence, .high)
+    }
+
+    func testCheckOutcomeRawValuesMatchFlowJSONKeys() {
+        // Branching maps in flow JSON key on these exact strings; changing a
+        // raw value silently breaks every "on" table that uses it.
+        XCTAssertEqual(CheckOutcome.pass.rawValue, "pass")
+        XCTAssertEqual(CheckOutcome.fail.rawValue, "fail")
+        XCTAssertEqual(CheckOutcome.alreadyConfigured.rawValue, "already_configured")
+        XCTAssertEqual(CheckOutcome.unknown.rawValue, "unknown")
+        XCTAssertEqual(CheckOutcome.error.rawValue, "error")
+    }
+
+    // MARK: - Phase mapping
+
+    func testSessionPhaseFromFlowPhaseCoversAllCases() {
+        XCTAssertEqual(TroubleshootingSession.SessionPhase(flowPhase: .symptom), .symptom)
+        XCTAssertEqual(TroubleshootingSession.SessionPhase(flowPhase: .checks), .checks)
+        XCTAssertEqual(TroubleshootingSession.SessionPhase(flowPhase: .fix), .fix)
+        XCTAssertEqual(TroubleshootingSession.SessionPhase(flowPhase: .verify), .verify)
+        XCTAssertEqual(TroubleshootingSession.SessionPhase(flowPhase: .export), .export)
+    }
+
+    // MARK: - SymptomCategory
+
+    func testEveryCategoryHasAJSONFlowFileName() {
+        for category in SymptomCategory.allCases {
+            XCTAssertTrue(
+                category.flowFileName.hasSuffix(".json"),
+                "\(category) flow file name should end in .json"
+            )
+            XCTAssertFalse(category.displayTitle.isEmpty)
+        }
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/FlowLoaderValidatorTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/FlowLoaderValidatorTests.swift
@@ -1,0 +1,174 @@
+//
+//  FlowLoaderValidatorTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+/// Integration tests over the flow JSON actually shipped in the package
+/// resources: every flow must load, validate, and reference only checks
+/// that exist. These are the tests that catch a broken flow file at CI
+/// time instead of at the user's first troubleshooting attempt.
+final class FlowLoaderValidatorTests: XCTestCase {
+    // MARK: - Bundled resources
+
+    func testIndexLoadsAndCoversEveryCategory() throws {
+        let index = try XCTUnwrap(FlowLoader.loadIndex())
+        XCTAssertFalse(index.categories.isEmpty)
+
+        // Every SymptomCategory's flow file must be present in the index so
+        // selecting any symptom in the UI reaches a real flow — except .other,
+        // which by design has no flow: selecting it escalates directly to the
+        // export fragment (the engine's no-flow path).
+        let indexedFiles = Set(index.categories.map(\.flowFile))
+        for category in SymptomCategory.allCases where category != .other {
+            XCTAssertTrue(
+                indexedFiles.contains(category.flowFileName),
+                "index.json is missing \(category.flowFileName) for category \(category)"
+            )
+        }
+        XCTAssertFalse(
+            indexedFiles.contains(SymptomCategory.other.flowFileName),
+            ".other gained a flow file — update the engine's no-flow escalation expectations"
+        )
+    }
+
+    func testAllIndexedFlowsLoad() throws {
+        let index = try XCTUnwrap(FlowLoader.loadIndex())
+        let flows = FlowLoader.loadAllFlows()
+
+        XCTAssertEqual(
+            flows.count, index.categories.count,
+            "every category in index.json must load; a silently skipped flow means a dead symptom path"
+        )
+    }
+
+    func testFragmentsLoad() {
+        let fragments = FlowLoader.loadFragments()
+
+        // The engine's escalation path depends on export-escalation existing.
+        XCTAssertNotNil(fragments["export-escalation"])
+        XCTAssertNotNil(fragments["dependency-install"])
+    }
+
+    func testBundledFlowsPassValidationWithoutErrors() {
+        let flows = FlowLoader.loadAllFlows()
+        let fragments = FlowLoader.loadFragments()
+        XCTAssertFalse(flows.isEmpty)
+
+        let issues = FlowValidator.validate(flows: flows, fragments: fragments)
+        let errors = issues.filter { $0.severity == .error }
+
+        XCTAssertTrue(
+            errors.isEmpty,
+            "bundled flows have validation errors: \(errors.map { "\($0.flowId)/\($0.nodeId ?? "-"): \($0.message)" })"
+        )
+    }
+
+    func testEveryReferencedCheckIdHasAnImplementation() {
+        // Collect the checkIds the shipped flows actually reference…
+        let flows = FlowLoader.loadAllFlows()
+        let fragments = FlowLoader.loadFragments()
+        var referenced: Set<String> = []
+        for flow in flows.values.map(\.nodes) + fragments.values.map(\.nodes) {
+            for node in flow.values {
+                if let checkId = node.checkId {
+                    referenced.insert(checkId)
+                }
+            }
+        }
+        XCTAssertFalse(referenced.isEmpty)
+
+        // …and compare against the concrete implementations the registry
+        // registers, without running any of them (several probe hardware).
+        let implemented: Set<String> = Set(
+            ([
+                CrashLogCheck(), GraphicsBackendCheck(), DXVKSettingsCheck(),
+                AudioDriverCheck(), AudioDeviceCheck(), AudioTestCheck(),
+                DependencyCheck(), WinetricksVerbCheck(),
+                LauncherTypeCheck(), ProcessRunningCheck(),
+                EnvironmentCheck(), RegistryValueCheck(),
+                GameConfigAvailableCheck(), SettingValueCheck(), DiagnosticsEnhanceCheck()
+            ] as [any TroubleshootingCheck]).map(\.checkId)
+        )
+
+        let missing = referenced.subtracting(implemented)
+        XCTAssertTrue(
+            missing.isEmpty,
+            "flow JSON references check IDs with no implementation: \(missing.sorted())"
+        )
+    }
+
+    // MARK: - Validator failure detection
+
+    private func makeNode(
+        id: String,
+        type: NodeType = .check,
+        checkId: String? = "graphics.backend_is",
+        on: [String: String]? = nil // swiftlint:disable:this identifier_name
+    ) -> FlowStepNode {
+        FlowStepNode(id: id, type: type, phase: .checks, checkId: checkId, on: on)
+    }
+
+    func testValidatorFlagsDanglingNodeReference() {
+        let flow = FlowDefinition(
+            version: 1,
+            categoryId: "test",
+            nodes: ["start": makeNode(id: "start", on: ["pass": "does-not-exist"])],
+            entryNodeId: "start"
+        )
+
+        let issues = FlowValidator.validate(flows: ["test": flow], fragments: [:])
+
+        XCTAssertTrue(
+            issues.contains { $0.severity == .error },
+            "a branch target that resolves nowhere must be a validation error, got: \(issues)"
+        )
+    }
+
+    func testValidatorFlagsMissingEntryNode() {
+        let flow = FlowDefinition(
+            version: 1,
+            categoryId: "test",
+            nodes: ["start": makeNode(id: "start")],
+            entryNodeId: "nope"
+        )
+
+        let issues = FlowValidator.validate(flows: ["test": flow], fragments: [:])
+
+        XCTAssertTrue(issues.contains { $0.severity == .error })
+    }
+
+    func testValidatorAcceptsWellFormedFlow() {
+        let flow = FlowDefinition(
+            version: 1,
+            categoryId: "test",
+            nodes: [
+                "start": makeNode(id: "start", on: ["pass": "done", "fail": "done"]),
+                "done": makeNode(id: "done", type: .info, checkId: nil)
+            ],
+            entryNodeId: "start"
+        )
+
+        let issues = FlowValidator.validate(flows: ["test": flow], fragments: [:])
+
+        XCTAssertTrue(
+            issues.filter { $0.severity == .error }.isEmpty,
+            "well-formed flow should have no errors, got: \(issues)"
+        )
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/TroubleshootingChecksTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/TroubleshootingChecksTests.swift
@@ -1,0 +1,198 @@
+//
+//  TroubleshootingChecksTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+/// A check stub whose outcome is driven entirely by its params, so registry
+/// and engine tests never touch a real diagnostic.
+struct StubCheck: TroubleshootingCheck {
+    let checkId: String
+
+    func run(params: [String: String], context _: CheckContext) async -> CheckResult {
+        CheckResult(
+            outcome: CheckOutcome(rawValue: params["outcome"] ?? "pass") ?? .pass,
+            evidence: ["stub": "true"],
+            summary: "stub result"
+        )
+    }
+}
+
+/// Builds a hermetic check context: all inputs injected, nothing read from
+/// the machine running the tests.
+func makeCheckContext(
+    graphicsBackend: String = "dxmt",
+    launcherType: String? = nil,
+    programName: String? = nil
+) -> CheckContext {
+    let bottleURL = URL(filePath: "/tmp/test-bottle-\(UUID().uuidString)")
+    let preflight = PreflightData(
+        bottleURL: bottleURL,
+        bottleName: "Test Bottle",
+        programName: programName,
+        launcherType: launcherType,
+        isWineserverRunning: false,
+        processCount: 0,
+        graphicsBackend: graphicsBackend
+    )
+    return CheckContext(
+        bottleURL: bottleURL,
+        bottleName: "Test Bottle",
+        programName: programName,
+        preflight: preflight,
+        session: TroubleshootingSession(bottleURL: bottleURL)
+    )
+}
+
+final class TroubleshootingChecksTests: XCTestCase {
+    // MARK: - CheckRegistry
+
+    func testUnknownCheckIdReturnsErrorResultInsteadOfCrashing() async {
+        let registry = CheckRegistry()
+
+        let result = await registry.run(checkId: "no.such_check", params: [:], context: makeCheckContext())
+
+        XCTAssertEqual(result.outcome, .error)
+        XCTAssertTrue(result.summary.contains("no.such_check"))
+    }
+
+    func testRegisteredCheckRuns() async {
+        let registry = CheckRegistry()
+        registry.register(StubCheck(checkId: "stub.custom"))
+
+        let result = await registry.run(
+            checkId: "stub.custom",
+            params: ["outcome": "fail"],
+            context: makeCheckContext()
+        )
+
+        XCTAssertEqual(result.outcome, .fail)
+        XCTAssertEqual(result.evidence["stub"], "true")
+    }
+
+    func testReRegisteringSameIdReplacesSilently() async {
+        struct FixedCheck: TroubleshootingCheck {
+            let checkId = "stub.replace"
+            let outcome: CheckOutcome
+            func run(params _: [String: String], context _: CheckContext) async -> CheckResult {
+                CheckResult(outcome: outcome, summary: "fixed")
+            }
+        }
+        let registry = CheckRegistry()
+        registry.register(FixedCheck(outcome: .pass))
+        registry.register(FixedCheck(outcome: .unknown))
+
+        let result = await registry.run(checkId: "stub.replace", params: [:], context: makeCheckContext())
+
+        XCTAssertEqual(result.outcome, .unknown)
+    }
+
+    // MARK: - GraphicsBackendCheck
+
+    func testGraphicsBackendCheckMissingParamIsError() async {
+        let result = await GraphicsBackendCheck().run(params: [:], context: makeCheckContext())
+
+        XCTAssertEqual(result.outcome, .error)
+    }
+
+    func testGraphicsBackendCheckMatchIsAlreadyConfigured() async {
+        let result = await GraphicsBackendCheck().run(
+            params: ["expected": "dxmt"],
+            context: makeCheckContext(graphicsBackend: "dxmt")
+        )
+
+        XCTAssertEqual(result.outcome, .alreadyConfigured)
+        XCTAssertEqual(result.evidence["current"], "dxmt")
+        XCTAssertEqual(result.confidence, .high)
+    }
+
+    func testGraphicsBackendCheckMismatchIsFail() async {
+        let result = await GraphicsBackendCheck().run(
+            params: ["expected": "dxvk"],
+            context: makeCheckContext(graphicsBackend: "wined3d")
+        )
+
+        XCTAssertEqual(result.outcome, .fail)
+        XCTAssertEqual(result.evidence["current"], "wined3d")
+        XCTAssertEqual(result.evidence["expected"], "dxvk")
+    }
+
+    // MARK: - LauncherTypeCheck
+
+    func testLauncherTypeCheckNoLauncherIsUnknown() async {
+        let result = await LauncherTypeCheck().run(params: [:], context: makeCheckContext(launcherType: nil))
+
+        XCTAssertEqual(result.outcome, .unknown)
+        XCTAssertEqual(result.confidence, .low)
+    }
+
+    func testLauncherTypeCheckDetectedWithoutExpectationIsPass() async {
+        let result = await LauncherTypeCheck().run(params: [:], context: makeCheckContext(launcherType: "steam"))
+
+        XCTAssertEqual(result.outcome, .pass)
+        XCTAssertEqual(result.evidence["detectedLauncher"], "steam")
+    }
+
+    func testLauncherTypeCheckExpectationMatchesCaseInsensitively() async {
+        let result = await LauncherTypeCheck().run(
+            params: ["expected": "Steam"],
+            context: makeCheckContext(launcherType: "steam")
+        )
+
+        XCTAssertEqual(result.outcome, .pass)
+    }
+
+    func testLauncherTypeCheckExpectationMismatchIsFail() async {
+        let result = await LauncherTypeCheck().run(
+            params: ["expected": "epic"],
+            context: makeCheckContext(launcherType: "steam")
+        )
+
+        XCTAssertEqual(result.outcome, .fail)
+        XCTAssertEqual(result.evidence["expected"], "epic")
+    }
+
+    // MARK: - ProcessRunningCheck
+
+    func testProcessRunningCheckNoProcessesIsFail() async {
+        // The context's bottle URL is unique per test, so the shared process
+        // registry has no entries for it.
+        let result = await ProcessRunningCheck().run(params: [:], context: makeCheckContext())
+
+        XCTAssertEqual(result.outcome, .fail)
+        XCTAssertEqual(result.evidence["count"], "0")
+    }
+
+    // MARK: - GameConfigAvailableCheck
+
+    func testGameConfigCheckWithoutProgramIsUnknown() async {
+        let result = await GameConfigAvailableCheck().run(params: [:], context: makeCheckContext())
+
+        XCTAssertEqual(result.outcome, .unknown)
+    }
+
+    func testGameConfigCheckUnknownProgramIsFail() async {
+        let result = await GameConfigAvailableCheck().run(
+            params: [:],
+            context: makeCheckContext(programName: "definitely-not-a-real-game-zzz.exe")
+        )
+
+        XCTAssertEqual(result.outcome, .fail)
+        XCTAssertEqual(result.evidence["programName"], "definitely-not-a-real-game-zzz.exe")
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/TroubleshootingFlowEngineTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/TroubleshootingFlowEngineTests.swift
@@ -1,0 +1,333 @@
+//
+//  TroubleshootingFlowEngineTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+/// In-memory session store so engine tests observe auto-save and completion
+/// behavior without touching the filesystem.
+final class SpySessionStore: TroubleshootingSessionStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var savedSessions: [TroubleshootingSession] = []
+    private var completedSessions: [TroubleshootingSession] = []
+
+    var saveCount: Int {
+        lock.withLock { savedSessions.count }
+    }
+
+    var completed: [TroubleshootingSession] {
+        lock.withLock { completedSessions }
+    }
+
+    func save(_ session: TroubleshootingSession) {
+        lock.withLock { savedSessions.append(session) }
+    }
+
+    func completeSession(_ session: TroubleshootingSession) {
+        lock.withLock { completedSessions.append(session) }
+    }
+}
+
+@MainActor
+final class TroubleshootingFlowEngineTests: XCTestCase {
+    // MARK: - Fixtures
+
+    private func checkNode(
+        _ id: String,
+        outcome: String = "pass",
+        on: [String: String] // swiftlint:disable:this identifier_name
+    ) -> FlowStepNode {
+        FlowStepNode(
+            id: id, type: .check, phase: .checks,
+            checkId: "stub.outcome", params: ["outcome": outcome], on: on
+        )
+    }
+
+    private func infoNode(_ id: String, on: [String: String]? = nil) -> FlowStepNode {
+        // swiftlint:disable:previous identifier_name
+        FlowStepNode(id: id, type: .info, phase: .checks, title: "Info \(id)", on: on)
+    }
+
+    /// The "graphics" key matches SymptomCategory.graphics.flowFileName minus
+    /// its .json suffix, which is how the engine derives flow lookup keys.
+    private func makeEngine(
+        nodes: [String: FlowStepNode],
+        entry: String = "start",
+        fragments: [String: FlowDefinition] = [:],
+        session: TroubleshootingSession? = nil
+    ) -> (TroubleshootingFlowEngine, SpySessionStore) {
+        let flow = FlowDefinition(version: 1, categoryId: "graphics", nodes: nodes, entryNodeId: entry)
+        let registry = CheckRegistry()
+        registry.register(StubCheck(checkId: "stub.outcome"))
+        let store = SpySessionStore()
+        // Node resolution goes through the session's active flow category, so
+        // direct navigateToNode calls need it preset the way selectCategory
+        // would have set it.
+        var defaultSession = TroubleshootingSession(bottleURL: URL(filePath: "/tmp/engine-test-bottle"))
+        defaultSession.currentFlowCategoryId = "graphics"
+        let engine = TroubleshootingFlowEngine(
+            flowDefinitions: ["graphics": flow],
+            fragments: fragments,
+            checkRegistry: registry,
+            sessionStore: store,
+            session: session ?? defaultSession
+        )
+        return (engine, store)
+    }
+
+    /// Waits until `condition` holds, yielding to let the engine's check
+    /// tasks run; fails the test after ~2 seconds.
+    private func waitUntil(
+        _ message: String,
+        condition: () -> Bool
+    ) async {
+        for _ in 0 ..< 200 where !condition() {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(condition(), "timed out waiting for: \(message)")
+    }
+
+    // MARK: - Category selection
+
+    func testSelectCategoryNavigatesToEntryAndBranchesOnPass() async {
+        let (engine, store) = makeEngine(nodes: [
+            "start": checkNode("start", outcome: "pass", on: ["pass": "done-pass", "fail": "done-fail"]),
+            "done-pass": infoNode("done-pass"),
+            "done-fail": infoNode("done-fail")
+        ])
+
+        engine.selectCategory(.graphics)
+
+        await waitUntil("branch to done-pass") { engine.currentNode?.id == "done-pass" }
+        XCTAssertEqual(engine.session.phase, .checks)
+        XCTAssertEqual(engine.session.checkResults["start"]?.outcome, .pass)
+        XCTAssertEqual(engine.session.branchDecisions.last?.toNodeId, "done-pass")
+        XCTAssertEqual(engine.session.stepHistory.map(\.nodeId), ["start", "done-pass"])
+        XCTAssertGreaterThan(store.saveCount, 0)
+    }
+
+    func testUnmappedOutcomeFallsBackToDefaultBranch() async {
+        let (engine, _) = makeEngine(nodes: [
+            "start": checkNode("start", outcome: "unknown", on: ["pass": "done-pass", "default": "done-default"]),
+            "done-pass": infoNode("done-pass"),
+            "done-default": infoNode("done-default")
+        ])
+
+        engine.selectCategory(.graphics)
+
+        await waitUntil("default branch") { engine.currentNode?.id == "done-default" }
+        XCTAssertEqual(engine.session.checkResults["start"]?.outcome, .unknown)
+    }
+
+    func testOutcomeWithNoTargetStaysOnNodeButRecordsResult() async {
+        let (engine, _) = makeEngine(nodes: [
+            "start": checkNode("start", outcome: "fail", on: ["pass": "done"]),
+            "done": infoNode("done")
+        ])
+
+        engine.selectCategory(.graphics)
+
+        await waitUntil("check result recorded") { engine.session.checkResults["start"] != nil }
+        XCTAssertEqual(engine.currentNode?.id, "start")
+        XCTAssertFalse(engine.isRunningCheck)
+    }
+
+    func testUnknownCategoryEscalates() {
+        let registry = CheckRegistry()
+        let store = SpySessionStore()
+        let engine = TroubleshootingFlowEngine(
+            flowDefinitions: [:],
+            fragments: [:],
+            checkRegistry: registry,
+            sessionStore: store
+        )
+
+        engine.selectCategory(.audio)
+
+        XCTAssertEqual(engine.session.phase, .escalation)
+    }
+
+    func testEscalationNavigatesToFragmentEntryWhenAvailable() {
+        let fragment = FlowDefinition(
+            version: 1,
+            categoryId: "export-escalation",
+            nodes: ["export-start": infoNode("export-start")],
+            entryNodeId: "export-start"
+        )
+        let (engine, _) = makeEngine(
+            nodes: ["start": infoNode("start")],
+            fragments: ["export-escalation": fragment]
+        )
+
+        engine.escalate()
+
+        XCTAssertEqual(engine.session.phase, .escalation)
+        XCTAssertEqual(engine.currentNode?.id, "export-start")
+        XCTAssertEqual(engine.session.stepHistory.last?.nodeId, "export-start")
+    }
+
+    // MARK: - Cycle protection
+
+    func testSelfLoopingCheckEscalatesInsteadOfSpinningForever() async {
+        let (engine, _) = makeEngine(nodes: [
+            "start": checkNode("start", outcome: "pass", on: ["pass": "start"])
+        ])
+
+        engine.selectCategory(.graphics)
+
+        await waitUntil("cycle protection escalation") { engine.session.phase == .escalation }
+    }
+
+    // MARK: - Navigation helpers
+
+    func testSkipStepFollowsSkippedTarget() {
+        let (engine, _) = makeEngine(nodes: [
+            "start": infoNode("start", on: ["skipped": "after-skip"]),
+            "after-skip": infoNode("after-skip")
+        ])
+        engine.navigateToNode("start")
+
+        engine.skipStep()
+
+        XCTAssertEqual(engine.currentNode?.id, "after-skip")
+    }
+
+    func testGoBackRestoresPreviousNode() {
+        let (engine, _) = makeEngine(nodes: [
+            "start": infoNode("start"),
+            "second": infoNode("second")
+        ])
+        engine.navigateToNode("start")
+        engine.navigateToNode("second")
+
+        engine.goBack()
+
+        XCTAssertEqual(engine.currentNode?.id, "start")
+        XCTAssertEqual(engine.session.currentNodeId, "start")
+        XCTAssertEqual(engine.session.stepHistory.count, 1)
+    }
+
+    func testGoBackAtHistoryRootIsNoOp() {
+        let (engine, _) = makeEngine(nodes: ["start": infoNode("start")])
+        engine.navigateToNode("start")
+
+        engine.goBack()
+
+        XCTAssertEqual(engine.currentNode?.id, "start")
+    }
+
+    func testNavigateToMissingNodeEscalates() {
+        let (engine, _) = makeEngine(nodes: ["start": infoNode("start")])
+
+        engine.navigateToNode("no-such-node")
+
+        XCTAssertEqual(engine.session.phase, .escalation)
+    }
+
+    func testInitRestoresCurrentNodeFromResumedSession() {
+        var session = TroubleshootingSession(bottleURL: URL(filePath: "/tmp/engine-test-bottle"))
+        session.currentFlowCategoryId = "graphics"
+        session.currentNodeId = "second"
+
+        let (engine, _) = makeEngine(
+            nodes: ["start": infoNode("start"), "second": infoNode("second")],
+            session: session
+        )
+
+        XCTAssertEqual(engine.currentNode?.id, "second")
+    }
+
+    // MARK: - Fix lifecycle
+
+    func testFixLifecycleThroughUserReportsFixed() {
+        let (engine, store) = makeEngine(nodes: ["start": infoNode("start")])
+
+        engine.applyFix(fixId: "graphics.set_backend_dxvk", beforeValue: "wined3d", afterValue: "dxvk")
+        XCTAssertEqual(engine.session.phase, .verify)
+        XCTAssertEqual(engine.session.fixAttempts.last?.result, .pending)
+
+        engine.confirmFixApplied(fixId: "graphics.set_backend_dxvk")
+        XCTAssertEqual(engine.session.fixAttempts.last?.result, .applied)
+
+        engine.userReportsFixed()
+        XCTAssertEqual(engine.session.outcome, .resolved)
+        XCTAssertEqual(engine.session.phase, .export)
+        XCTAssertEqual(engine.session.fixAttempts.last?.result, .verified)
+        XCTAssertEqual(store.completed.count, 1)
+    }
+
+    func testUndoLastFixMarksApplied() {
+        let (engine, _) = makeEngine(nodes: ["start": infoNode("start")])
+        engine.applyFix(fixId: "fix.a", beforeValue: nil, afterValue: nil)
+        engine.confirmFixApplied(fixId: "fix.a")
+
+        engine.undoLastFix()
+
+        XCTAssertEqual(engine.session.fixAttempts.last?.result, .undone)
+    }
+
+    func testThreeFailedFixesEscalate() {
+        let (engine, _) = makeEngine(nodes: ["start": infoNode("start")])
+
+        for attempt in 0 ..< 3 {
+            engine.applyFix(fixId: "fix.\(attempt)", beforeValue: nil, afterValue: nil)
+            engine.confirmFixApplied(fixId: "fix.\(attempt)")
+            engine.userReportsNotFixed()
+        }
+
+        XCTAssertEqual(engine.session.failedFixCount, 3)
+        XCTAssertEqual(engine.session.phase, .escalation)
+    }
+
+    func testNotFixedFollowsNoTargetWhenAvailable() {
+        let (engine, _) = makeEngine(nodes: [
+            "verify": infoNode("verify", on: ["no": "second-fix"]),
+            "second-fix": infoNode("second-fix")
+        ])
+        engine.navigateToNode("verify")
+        engine.applyFix(fixId: "fix.a", beforeValue: nil, afterValue: nil)
+        engine.confirmFixApplied(fixId: "fix.a")
+
+        engine.userReportsNotFixed()
+
+        XCTAssertEqual(engine.session.fixAttempts.last?.result, .failed)
+        XCTAssertEqual(engine.currentNode?.id, "second-fix")
+    }
+
+    // MARK: - Start over
+
+    func testStartOverPreservesIdentityButClearsProgress() {
+        let bottleURL = URL(filePath: "/tmp/engine-test-bottle")
+        let (engine, _) = makeEngine(nodes: [
+            "start": infoNode("start"),
+            "second": infoNode("second")
+        ])
+        let originalSessionId = engine.session.id
+        engine.navigateToNode("start")
+        engine.applyFix(fixId: "fix.a", beforeValue: nil, afterValue: nil)
+
+        engine.startOver()
+
+        XCTAssertNotEqual(engine.session.id, originalSessionId)
+        XCTAssertEqual(engine.session.bottleURL, bottleURL)
+        XCTAssertTrue(engine.session.stepHistory.isEmpty)
+        XCTAssertTrue(engine.session.fixAttempts.isEmpty)
+        XCTAssertNil(engine.currentNode)
+        XCTAssertEqual(engine.session.phase, .symptom)
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/TroubleshootingSessionTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/TroubleshootingSessionTests.swift
@@ -1,0 +1,161 @@
+//
+//  TroubleshootingSessionTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+final class TroubleshootingSessionTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+    }
+
+    private func makeNode(id: String, phase: FlowPhase = .checks) -> FlowStepNode {
+        FlowStepNode(id: id, type: .check, phase: phase, title: "Node \(id)")
+    }
+
+    // MARK: - Session mutations
+
+    func testPushStepAppendsHistoryAndTracksCurrentNode() {
+        var session = TroubleshootingSession()
+
+        session.pushStep(makeNode(id: "a"))
+        session.pushStep(makeNode(id: "b", phase: .fix))
+
+        XCTAssertEqual(session.stepHistory.map(\.nodeId), ["a", "b"])
+        XCTAssertEqual(session.currentNodeId, "b")
+        XCTAssertEqual(session.stepHistory.last?.phase, .fix)
+    }
+
+    func testRecordCheckResultAttachesToMatchingStep() {
+        var session = TroubleshootingSession()
+        session.pushStep(makeNode(id: "a"))
+        session.pushStep(makeNode(id: "b"))
+
+        let result = CheckResult(outcome: .fail, summary: "nope")
+        session.recordCheckResult(nodeId: "a", result: result)
+
+        XCTAssertEqual(session.checkResults["a"]?.outcome, .fail)
+        XCTAssertEqual(session.stepHistory[0].checkResult?.outcome, .fail)
+        XCTAssertNil(session.stepHistory[1].checkResult)
+    }
+
+    func testFailedFixCountCountsOnlyFailures() {
+        var session = TroubleshootingSession()
+        for (index, result) in [FixResult.failed, .applied, .failed, .verified].enumerated() {
+            session.recordFixAttempt(FixAttempt(
+                fixId: "fix.\(index)", timestamp: Date(), beforeValue: nil, afterValue: nil, result: result
+            ))
+        }
+
+        XCTAssertEqual(session.failedFixCount, 2)
+    }
+
+    func testRecordBranchKeepsDecisionOrder() {
+        var session = TroubleshootingSession()
+
+        session.recordBranch(from: "a", targetNodeId: "b", reason: "pass")
+        session.recordBranch(from: "b", targetNodeId: "c")
+
+        XCTAssertEqual(session.branchDecisions.map(\.fromNodeId), ["a", "b"])
+        XCTAssertEqual(session.branchDecisions.first?.reason, "pass")
+    }
+
+    func testSessionCodableRoundTrip() throws {
+        var session = TroubleshootingSession(bottleURL: tempDir)
+        session.pushStep(makeNode(id: "a"))
+        session.recordCheckResult(nodeId: "a", result: CheckResult(outcome: .pass, summary: "ok"))
+        session.symptomCategory = .graphics
+        session.outcome = .resolved
+
+        let data = try PropertyListEncoder().encode(session)
+        let decoded = try PropertyListDecoder().decode(TroubleshootingSession.self, from: data)
+
+        XCTAssertEqual(decoded.id, session.id)
+        XCTAssertEqual(decoded.stepHistory.map(\.nodeId), ["a"])
+        XCTAssertEqual(decoded.checkResults["a"]?.outcome, .pass)
+        XCTAssertEqual(decoded.symptomCategory, .graphics)
+        XCTAssertEqual(decoded.outcome, .resolved)
+    }
+
+    // MARK: - Session store
+
+    func testSaveWritesActiveSessionIntoBottleDir() throws {
+        let store = TroubleshootingSessionStore()
+        let session = TroubleshootingSession(bottleURL: tempDir)
+
+        store.save(session)
+
+        let file = tempDir.appendingPathComponent(TroubleshootingSessionStore.activeSessionFileName)
+        let data = try Data(contentsOf: file)
+        let decoded = try PropertyListDecoder().decode(TroubleshootingSession.self, from: data)
+        XCTAssertEqual(decoded.id, session.id)
+    }
+
+    func testSaveWithoutBottleURLIsSafeNoOp() {
+        let store = TroubleshootingSessionStore()
+
+        store.save(TroubleshootingSession())
+        // Nothing to assert on disk; the point is no crash and no stray file
+        // in the current directory.
+    }
+
+    func testCompleteSessionWritesHistoryAndRemovesActiveFile() {
+        let store = TroubleshootingSessionStore()
+        var session = TroubleshootingSession(bottleURL: tempDir)
+        session.symptomCategory = .audio
+        session.outcome = .resolved
+        session.recordCheckResult(nodeId: "a", result: CheckResult(outcome: .fail, summary: "finding"))
+        store.save(session)
+
+        store.completeSession(session)
+
+        let history = TroubleshootingHistory.load(from: tempDir)
+        XCTAssertEqual(history.entries.count, 1)
+        XCTAssertEqual(history.entries.first?.symptomCategory, .audio)
+        XCTAssertEqual(history.entries.first?.outcome, .resolved)
+        XCTAssertEqual(history.entries.first?.primaryFindings, ["finding"])
+
+        let activeFile = tempDir.appendingPathComponent(TroubleshootingSessionStore.activeSessionFileName)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: activeFile.path(percentEncoded: false)))
+    }
+
+    func testCompleteSessionAppendsToExistingHistory() {
+        let store = TroubleshootingSessionStore()
+        var first = TroubleshootingSession(bottleURL: tempDir)
+        first.outcome = .resolved
+        var second = TroubleshootingSession(bottleURL: tempDir)
+        second.outcome = .unresolved
+
+        store.completeSession(first)
+        store.completeSession(second)
+
+        let history = TroubleshootingHistory.load(from: tempDir)
+        XCTAssertEqual(history.entries.count, 2)
+        XCTAssertEqual(history.entries.map(\.outcome), [.resolved, .unresolved])
+    }
+}


### PR DESCRIPTION
The Troubleshooting module was WhiskyKit's largest untested surface: 0% of ~2,400 coverage-relevant lines. This adds 67 hermetic tests across six files, measured locally at **49% module coverage**, lifting WhiskyKit overall from ~52.5% to ~61%.

## What's covered
- **TroubleshootingFlowEngine** — category selection, outcome branching (mapped/default/unmapped), cycle protection (self-looping flow escalates instead of spinning), skip/back/restart, fragment escalation, session resume, full fix lifecycle (pending → applied → verified / 3×failed → escalation). Uses a params-driven `StubCheck` and an in-memory spy store; no filesystem, no real diagnostics.
- **Bundled flow JSON** (the shipped resources) — every indexed flow loads and validates with zero errors; every referenced `checkId` has a registered implementation; every `SymptomCategory` except the by-design flow-less `.other` is indexed (with a tripwire if `.other` ever gains a flow).
- **FixApplicator** — preview/apply/undo for the settings-mutating fixes against temp bottles, bad-param fallback to `.recommended`, registry-backed fixes staying `.pending`, non-reversible/unknown-fix refusals.
- **Session/Store** — mutation bookkeeping, Codable round trips, save/complete into the bottle directory, history accumulation, no-bottle-URL no-op.
- **Checks** — registry unknown-ID error path, replace-on-reregister, and the preflight-driven checks (GraphicsBackend, LauncherType, ProcessRunning, GameConfigAvailable).

## Deliberately not covered
`PreflightCollector`, `restart-wineserver`, and the audio probes spawn processes or query CoreAudio hardware; they need injection seams before hermetic tests are possible. Noted here rather than papered over with tests that would be machine-dependent — the #143 lesson.

## Testing
- Full WhiskyKit suite: 1,167 tests, 0 failures locally.
- `swiftlint --strict` and `swiftformat --lint` clean on the new files.