### PR TITLE
fix: keep in-flight bottles alive across registry reloads

### DIFF
--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -80,11 +80,8 @@ final class BottleVM: ObservableObject {
         // Keep the live instance for any bottle that is mid-operation:
         // rebuilding it would reset inFlight and drop the guard that blocks
         // conflicting actions during move/export/duplicate.
-        let inFlightBottles = Dictionary(
-            bottles.filter(\.inFlight).map { ($0.url, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        bottles = bottlesList.loadBottles().map { inFlightBottles[$0.url] ?? $0 }
+        let inFlight = Dictionary(bottles.filter(\.inFlight).map { ($0.url, $0) }) { first, _ in first }
+        bottles = bottlesList.loadBottles().map { inFlight[$0.url] ?? $0 }
     }
 
     /// Bottles found on disk with no registry entry, awaiting a re-import

--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -77,7 +77,14 @@ final class BottleVM: ObservableObject {
     }
 
     func loadBottles() {
-        bottles = bottlesList.loadBottles()
+        // Keep the live instance for any bottle that is mid-operation:
+        // rebuilding it would reset inFlight and drop the guard that blocks
+        // conflicting actions during move/export/duplicate.
+        let inFlightBottles = Dictionary(
+            bottles.filter(\.inFlight).map { ($0.url, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        bottles = bottlesList.loadBottles().map { inFlightBottles[$0.url] ?? $0 }
     }
 
     /// Bottles found on disk with no registry entry, awaiting a re-import


### PR DESCRIPTION
`loadBottles()` builds fresh `Bottle` instances on every call, so any bottle mid export/duplicate/move lost its `inFlight` guard the moment something reloaded the registry (bottle creation, orphan re-import, another bottle's move all trigger it). the ui then re-enables actions on a bottle whose files are actively being copied or moved.

fix: carry the live instance over for bottles that are in flight, take the fresh instance for everything else, so reloads still pick up metadata/availability changes.

app-target change, not compilable locally (CLT only), relying on CI. swiftformat clean.
