### PR TITLE
feat: add a text vdf parser

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Steam/VDFParser.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/VDFParser.swift
@@ -189,21 +189,25 @@ public enum VDFParser {
                 return result
 
             case let .string(key):
-                guard let valueToken = try scanner.nextToken() else {
-                    throw VDFParseError.unexpectedEnd
-                }
-                switch valueToken {
-                case let .string(value):
-                    result[key.lowercased()] = .string(value)
-                case .openBrace:
-                    result[key.lowercased()] = try .object(parseObjectBody(&scanner, isTopLevel: false))
-                case .closeBrace:
-                    throw VDFParseError.unexpectedToken(line: scanner.line)
-                }
+                result[key.lowercased()] = try parseValue(&scanner)
 
             case .openBrace:
                 throw VDFParseError.unexpectedToken(line: scanner.line)
             }
+        }
+    }
+
+    private static func parseValue(_ scanner: inout Scanner) throws -> VDFValue {
+        guard let token = try scanner.nextToken() else {
+            throw VDFParseError.unexpectedEnd
+        }
+        switch token {
+        case let .string(value):
+            return .string(value)
+        case .openBrace:
+            return try .object(parseObjectBody(&scanner, isTopLevel: false))
+        case .closeBrace:
+            throw VDFParseError.unexpectedToken(line: scanner.line)
         }
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Steam/VDFParser.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/VDFParser.swift
@@ -1,0 +1,209 @@
+//
+//  VDFParser.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// A value in a parsed Valve Data Format (VDF) document: either a string or a
+/// nested key-value object.
+public enum VDFValue: Equatable, Sendable {
+    case string(String)
+    indirect case object([String: VDFValue])
+
+    /// The string content, or `nil` for objects.
+    public var stringValue: String? {
+        if case let .string(value) = self { return value }
+        return nil
+    }
+
+    /// The nested object, or `nil` for strings.
+    public var objectValue: [String: VDFValue]? {
+        if case let .object(value) = self { return value }
+        return nil
+    }
+
+    /// The string content converted to `Int`, or `nil`.
+    public var intValue: Int? {
+        stringValue.flatMap(Int.init)
+    }
+}
+
+/// Errors thrown by ``VDFParser``.
+public enum VDFParseError: LocalizedError, Equatable {
+    /// A token appeared where the grammar doesn't allow it.
+    case unexpectedToken(line: Int)
+    /// A quoted string reached the end of its line or the document unclosed.
+    case unterminatedString(line: Int)
+    /// The document ended inside an unclosed object.
+    case unexpectedEnd
+
+    public var errorDescription: String? {
+        switch self {
+        case let .unexpectedToken(line):
+            "Unexpected token at line \(line)"
+        case let .unterminatedString(line):
+            "Unterminated string at line \(line)"
+        case .unexpectedEnd:
+            "Unexpected end of document inside an unclosed object"
+        }
+    }
+}
+
+/// Parses the text flavor of Valve's KeyValues format ("VDF"), the format of
+/// Steam's `appmanifest_*.acf`, `libraryfolders.vdf`, and `config.vdf`.
+///
+/// Supported grammar: quoted keys, quoted string values, `{}` nesting,
+/// `\\` and `\"` escapes, and `//` line comments. Keys are lowercased on
+/// parse because Valve's own files are case-inconsistent (`"AppState"`,
+/// `"appid"`, `"StateFlags"`). Duplicate keys keep the last occurrence.
+/// Binary VDF is not supported.
+public enum VDFParser {
+    /// Parses a VDF document into its top-level key-value pairs.
+    ///
+    /// - Parameter text: The document text.
+    /// - Returns: The top-level object, typically a single key like
+    ///   `"appstate"` or `"libraryfolders"` mapping to a nested object.
+    /// - Throws: ``VDFParseError`` if the document is malformed.
+    public static func parse(_ text: String) throws -> [String: VDFValue] {
+        var scanner = Scanner(text: text)
+        return try parseObjectBody(&scanner, isTopLevel: true)
+    }
+
+    // MARK: - Tokenizer
+
+    private enum Token: Equatable {
+        case string(String)
+        case openBrace
+        case closeBrace
+    }
+
+    private struct Scanner {
+        let characters: [Character]
+        var index = 0
+        var line = 1
+
+        init(text: String) {
+            self.characters = Array(text)
+        }
+
+        mutating func skipWhitespaceAndComments() {
+            while index < characters.count {
+                let character = characters[index]
+                if character == "\n" {
+                    line += 1
+                    index += 1
+                } else if character.isWhitespace {
+                    index += 1
+                } else if character == "/", index + 1 < characters.count, characters[index + 1] == "/" {
+                    while index < characters.count, characters[index] != "\n" {
+                        index += 1
+                    }
+                } else {
+                    break
+                }
+            }
+        }
+
+        /// Returns the next token, or `nil` at end of document.
+        mutating func nextToken() throws -> Token? {
+            skipWhitespaceAndComments()
+            guard index < characters.count else { return nil }
+
+            switch characters[index] {
+            case "{":
+                index += 1
+                return .openBrace
+            case "}":
+                index += 1
+                return .closeBrace
+            case "\"":
+                return try .string(scanQuotedString())
+            default:
+                throw VDFParseError.unexpectedToken(line: line)
+            }
+        }
+
+        private mutating func scanQuotedString() throws -> String {
+            let startLine = line
+            index += 1 // consume the opening quote
+            var value = ""
+
+            while index < characters.count {
+                let character = characters[index]
+                switch character {
+                case "\"":
+                    index += 1
+                    return value
+                case "\\":
+                    // Escape: append the next character literally. This maps
+                    // \\ to \ and \" to " — the two escapes Valve emits.
+                    guard index + 1 < characters.count else {
+                        throw VDFParseError.unterminatedString(line: startLine)
+                    }
+                    value.append(characters[index + 1])
+                    index += 2
+                case "\n":
+                    throw VDFParseError.unterminatedString(line: startLine)
+                default:
+                    value.append(character)
+                    index += 1
+                }
+            }
+            throw VDFParseError.unterminatedString(line: startLine)
+        }
+    }
+
+    // MARK: - Parser
+
+    private static func parseObjectBody(
+        _ scanner: inout Scanner,
+        isTopLevel: Bool
+    ) throws -> [String: VDFValue] {
+        var result: [String: VDFValue] = [:]
+
+        while true {
+            guard let token = try scanner.nextToken() else {
+                if isTopLevel { return result }
+                throw VDFParseError.unexpectedEnd
+            }
+
+            switch token {
+            case .closeBrace:
+                if isTopLevel {
+                    throw VDFParseError.unexpectedToken(line: scanner.line)
+                }
+                return result
+
+            case let .string(key):
+                guard let valueToken = try scanner.nextToken() else {
+                    throw VDFParseError.unexpectedEnd
+                }
+                switch valueToken {
+                case let .string(value):
+                    result[key.lowercased()] = .string(value)
+                case .openBrace:
+                    result[key.lowercased()] = try .object(parseObjectBody(&scanner, isTopLevel: false))
+                case .closeBrace:
+                    throw VDFParseError.unexpectedToken(line: scanner.line)
+                }
+
+            case .openBrace:
+                throw VDFParseError.unexpectedToken(line: scanner.line)
+            }
+        }
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/VDFParserTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/VDFParserTests.swift
@@ -142,6 +142,19 @@ struct VDFParserTests {
         #expect(try VDFParser.parse("// only a comment\n").isEmpty)
     }
 
+    // MARK: - Accessors
+
+    @Test("Accessors return nil for mismatched kinds")
+    func accessorsMismatch() {
+        let string = VDFValue.string("text")
+        let object = VDFValue.object([:])
+
+        #expect(string.objectValue == nil)
+        #expect(string.intValue == nil)
+        #expect(object.stringValue == nil)
+        #expect(object.intValue == nil)
+    }
+
     // MARK: - Malformed input
 
     @Test("Throws on unclosed object")
@@ -177,5 +190,33 @@ struct VDFParserTests {
         #expect(throws: VDFParseError.unexpectedEnd) {
             try VDFParser.parse("\"lonely\"")
         }
+    }
+
+    @Test("Throws on escape at end of document")
+    func throwsOnTrailingEscape() {
+        #expect(throws: VDFParseError.unterminatedString(line: 1)) {
+            try VDFParser.parse("\"key\" \"value\\")
+        }
+    }
+
+    @Test("Throws on object opening without a key")
+    func throwsOnBraceWithoutKey() {
+        #expect(throws: VDFParseError.unexpectedToken(line: 1)) {
+            try VDFParser.parse("{ \"a\" \"b\" }")
+        }
+    }
+
+    @Test("Errors carry descriptions")
+    func errorsCarryDescriptions() {
+        #expect(
+            VDFParseError.unexpectedToken(line: 3).errorDescription == "Unexpected token at line 3"
+        )
+        #expect(
+            VDFParseError.unterminatedString(line: 7).errorDescription == "Unterminated string at line 7"
+        )
+        #expect(
+            VDFParseError.unexpectedEnd.errorDescription
+                == "Unexpected end of document inside an unclosed object"
+        )
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/VDFParserTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/VDFParserTests.swift
@@ -1,0 +1,181 @@
+//
+//  VDFParserTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("VDFParser Tests")
+struct VDFParserTests {
+    // MARK: - Real-world shapes
+
+    @Test("Parses an app manifest")
+    func parsesAppManifest() throws {
+        let acf = """
+        "AppState"
+        {
+            "appid"        "4576510"
+            "name"        "Casualties: Unknown Demo"
+            "installdir"        "Casualties Unknown Demo"
+            "StateFlags"        "4"
+            "buildid"        "1785187029"
+            "SizeOnDisk"        "541968407"
+        }
+        """
+
+        let root = try VDFParser.parse(acf)
+        let appState = try #require(root["appstate"]?.objectValue)
+
+        #expect(appState["appid"]?.intValue == 4_576_510)
+        #expect(appState["name"]?.stringValue == "Casualties: Unknown Demo")
+        #expect(appState["installdir"]?.stringValue == "Casualties Unknown Demo")
+        #expect(appState["stateflags"]?.intValue == 4)
+        #expect(appState["sizeondisk"]?.intValue == 541_968_407)
+    }
+
+    @Test("Parses libraryfolders with multiple libraries")
+    func parsesLibraryFolders() throws {
+        let vdf = """
+        "libraryfolders"
+        {
+            "0"
+            {
+                "path"        "C:\\\\Program Files (x86)\\\\Steam"
+                "apps"
+                {
+                    "4576510"        "541968407"
+                }
+            }
+            "1"
+            {
+                "path"        "D:\\\\SteamLibrary"
+                "apps"
+                {
+                    "1245620"        "49061246523"
+                }
+            }
+        }
+        """
+
+        let root = try VDFParser.parse(vdf)
+        let folders = try #require(root["libraryfolders"]?.objectValue)
+
+        let first = try #require(folders["0"]?.objectValue)
+        #expect(first["path"]?.stringValue == "C:\\Program Files (x86)\\Steam")
+        #expect(first["apps"]?.objectValue?["4576510"]?.intValue == 541_968_407)
+
+        let second = try #require(folders["1"]?.objectValue)
+        #expect(second["path"]?.stringValue == "D:\\SteamLibrary")
+        #expect(second["apps"]?.objectValue?.count == 1)
+    }
+
+    // MARK: - Grammar details
+
+    @Test("Lowercases keys but preserves value case")
+    func lowercasesKeysOnly() throws {
+        let root = try VDFParser.parse("\"AppState\"  \"Mixed Case Value\"")
+
+        #expect(root["appstate"]?.stringValue == "Mixed Case Value")
+        #expect(root["AppState"] == nil)
+    }
+
+    @Test("Handles escaped quotes and backslashes")
+    func handlesEscapes() throws {
+        let root = try VDFParser.parse(#""name"  "a \"quoted\" path\\here""#)
+
+        #expect(root["name"]?.stringValue == #"a "quoted" path\here"#)
+    }
+
+    @Test("Skips line comments")
+    func skipsComments() throws {
+        let vdf = """
+        // header comment
+        "key"        "value" // trailing comment
+        "other"        "thing"
+        """
+
+        let root = try VDFParser.parse(vdf)
+
+        #expect(root["key"]?.stringValue == "value")
+        #expect(root["other"]?.stringValue == "thing")
+    }
+
+    @Test("Handles CRLF line endings")
+    func handlesCRLF() throws {
+        let root = try VDFParser.parse("\"a\"\r\n{\r\n\"b\"\t\"c\"\r\n}\r\n")
+
+        #expect(root["a"]?.objectValue?["b"]?.stringValue == "c")
+    }
+
+    @Test("Parses an empty object")
+    func parsesEmptyObject() throws {
+        let root = try VDFParser.parse("\"apps\" {}")
+
+        #expect(root["apps"]?.objectValue?.isEmpty == true)
+    }
+
+    @Test("Duplicate keys keep the last occurrence")
+    func duplicateKeysLastWins() throws {
+        let root = try VDFParser.parse("\"key\" \"first\"\n\"key\" \"second\"")
+
+        #expect(root["key"]?.stringValue == "second")
+    }
+
+    @Test("Parses an empty document")
+    func parsesEmptyDocument() throws {
+        #expect(try VDFParser.parse("").isEmpty)
+        #expect(try VDFParser.parse("// only a comment\n").isEmpty)
+    }
+
+    // MARK: - Malformed input
+
+    @Test("Throws on unclosed object")
+    func throwsOnUnclosedObject() {
+        #expect(throws: VDFParseError.unexpectedEnd) {
+            try VDFParser.parse("\"root\" { \"key\" \"value\"")
+        }
+    }
+
+    @Test("Throws on unterminated string with its line")
+    func throwsOnUnterminatedString() {
+        #expect(throws: VDFParseError.unterminatedString(line: 2)) {
+            try VDFParser.parse("\"a\" \"b\"\n\"unclosed")
+        }
+    }
+
+    @Test("Throws on bare token with its line")
+    func throwsOnBareToken() {
+        #expect(throws: VDFParseError.unexpectedToken(line: 1)) {
+            try VDFParser.parse("bare")
+        }
+    }
+
+    @Test("Throws on stray closing brace at top level")
+    func throwsOnStrayClosingBrace() {
+        #expect(throws: VDFParseError.self) {
+            try VDFParser.parse("\"a\" \"b\" }")
+        }
+    }
+
+    @Test("Throws on key without a value")
+    func throwsOnKeyWithoutValue() {
+        #expect(throws: VDFParseError.unexpectedEnd) {
+            try VDFParser.parse("\"lonely\"")
+        }
+    }
+}


### PR DESCRIPTION
groundwork for real steam library enumeration (reading appmanifest_*.acf and libraryfolders.vdf properly instead of scanning lines for one key). quoted keys/values, nesting, \\ and \" escapes, // comments, keys lowercased since valve's files are case-inconsistent. standalone module, nothing depends on it yet, follow-ups will grow SteamAppManifest on top.

14 swift-testing cases, suite green locally. swiftformat clean.