### PR TITLE
feat: per-launch gamedb profiles via a gameProfile env layer

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Steam/LaunchResolver.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/LaunchResolver.swift
@@ -1,0 +1,106 @@
+//
+//  LaunchResolver.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// The resolved configuration for launching one game once.
+///
+/// Nothing in a plan is persisted: GameDB recommendations are applied
+/// per launch, so two games in the same bottle never fight over
+/// bottle-wide settings.
+public struct LaunchPlan {
+    /// Per-launch program overrides: the user's persisted overrides with
+    /// GameDB variant settings filling any field the user left unset.
+    public let overrides: ProgramOverrides
+    /// Extra environment for the ``EnvironmentLayer/gameProfile`` layer.
+    public let gameProfileEnvironment: [String: String]
+    /// Human-readable notes on where the configuration came from, for
+    /// logging and provenance UI.
+    public let provenance: [String]
+}
+
+/// Turns a Steam App ID into a ``LaunchPlan`` by matching the GameDB and
+/// merging its recommended variant under the user's own overrides.
+public enum LaunchResolver {
+    /// Builds the launch plan for a game.
+    ///
+    /// - Parameters:
+    ///   - steamAppId: The game's Steam App ID (a hard identifier for
+    ///     ``GameMatcher``, so no fuzzy-match risk).
+    ///   - exeName: Optional executable name hint for matching.
+    ///   - userOverrides: The user's persisted per-program overrides. Every
+    ///     non-nil field wins over the GameDB recommendation.
+    ///   - entries: The GameDB entries to match against. Defaults to the
+    ///     bundled database.
+    /// - Returns: A plan; without a GameDB match it simply carries the user
+    ///   overrides and empty profile environment.
+    public static func plan(
+        steamAppId: Int,
+        exeName: String? = nil,
+        userOverrides: ProgramOverrides? = nil,
+        entries: [GameDBEntry]? = nil
+    ) -> LaunchPlan {
+        let database = entries ?? GameDBLoader.loadDefaults()
+        let metadata = ProgramMetadata(exeName: exeName ?? "", steamAppId: steamAppId)
+
+        guard let match = GameMatcher.bestMatch(metadata: metadata, against: database),
+              let variant = match.recommendedVariant
+        else {
+            return LaunchPlan(
+                overrides: userOverrides ?? ProgramOverrides(),
+                gameProfileEnvironment: [:],
+                provenance: []
+            )
+        }
+
+        let overrides = merge(variant: variant.settings, dllOverrides: variant.dllOverrides, under: userOverrides)
+
+        return LaunchPlan(
+            overrides: overrides,
+            gameProfileEnvironment: variant.environmentVariables ?? [:],
+            provenance: [
+                "gamedb: \(match.entry.title) — \(variant.label) (\(match.explanation))",
+            ]
+        )
+    }
+
+    /// Fills GameDB variant settings into every field the user left unset.
+    ///
+    /// Bottle-level variant settings (`avxEnabled`, `sequoiaCompatMode`) and
+    /// `winetricksVerbs` are not mapped: the first two have no per-program
+    /// equivalent and verbs are an install-time action, not launch config.
+    static func merge(
+        variant: GameConfigVariantSettings,
+        dllOverrides: [DLLOverrideEntry]?,
+        under userOverrides: ProgramOverrides?
+    ) -> ProgramOverrides {
+        var merged = userOverrides ?? ProgramOverrides()
+
+        merged.graphicsBackend = merged.graphicsBackend ?? variant.graphicsBackend
+        merged.dxvk = merged.dxvk ?? variant.dxvk
+        merged.dxvkAsync = merged.dxvkAsync ?? variant.dxvkAsync
+        merged.enhancedSync = merged.enhancedSync ?? variant.enhancedSync
+        merged.forceD3D11 = merged.forceD3D11 ?? variant.forceD3D11
+        merged.shaderCacheEnabled = merged.shaderCacheEnabled ?? variant.shaderCacheEnabled
+        merged.performancePreset = merged.performancePreset
+            ?? variant.performancePreset.flatMap(PerformancePreset.init(rawValue:))
+        merged.dllOverrides = merged.dllOverrides ?? dllOverrides
+
+        return merged
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Steam/LaunchResolver.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/LaunchResolver.swift
@@ -74,7 +74,7 @@ public enum LaunchResolver {
             overrides: overrides,
             gameProfileEnvironment: variant.environmentVariables ?? [:],
             provenance: [
-                "gamedb: \(match.entry.title) — \(variant.label) (\(match.explanation))",
+                "gamedb: \(match.entry.title) — \(variant.label) (\(match.explanation))"
             ]
         )
     }

--- a/WhiskyKit/Sources/WhiskyKit/Wine/EnvironmentBuilder.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/EnvironmentBuilder.swift
@@ -30,15 +30,17 @@ import Foundation
 /// 2. ``platform`` -- macOS compatibility fixes
 /// 3. ``bottleManaged`` -- Toggles/presets Whisky owns (DXVK, Metal, sync, performance)
 /// 4. ``launcherManaged`` -- Launcher compatibility mode and detected overrides
-/// 5. ``bottleUser`` -- User-defined bottle-level environment variables
-/// 6. ``programUser`` -- Program settings environment variables and locale
-/// 7. ``featureRuntime`` -- Launch-time feature injectors (ClickOnce, one-off modes)
-/// 8. ``callsiteOverride`` -- Explicit overrides passed to `Wine.runProgram(environment:)`
+/// 5. ``gameProfile`` -- GameDB variant environment applied for a single launch
+/// 6. ``bottleUser`` -- User-defined bottle-level environment variables
+/// 7. ``programUser`` -- Program settings environment variables and locale
+/// 8. ``featureRuntime`` -- Launch-time feature injectors (ClickOnce, one-off modes)
+/// 9. ``callsiteOverride`` -- Explicit overrides passed to `Wine.runProgram(environment:)`
 public enum EnvironmentLayer: Int, CaseIterable, Comparable, Sendable, Hashable {
     case base = 0
     case platform
     case bottleManaged
     case launcherManaged
+    case gameProfile
     case bottleUser
     case programUser
     case featureRuntime

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -238,7 +238,8 @@ public class Wine {
     @MainActor
     public static func runProgram(
         at url: URL, args: [String] = [], bottle: Bottle, environment: [String: String] = [:],
-        programOverrides: ProgramOverrides? = nil, programSettings: ProgramSettings? = nil
+        programOverrides: ProgramOverrides? = nil, programSettings: ProgramSettings? = nil,
+        gameProfileEnvironment: [String: String] = [:]
     ) async throws -> ProgramRunResult {
         // Note: Launcher detection is handled at the app level (FileOpenView/BottleView)
         // before calling this method. The detection logic uses LauncherDetection utility
@@ -296,7 +297,7 @@ public class Wine {
 
         let wineEnvironment = constructWineEnvironment(
             for: bottle, environment: environment, programOverrides: programOverrides,
-            programSettings: programSettings
+            programSettings: programSettings, gameProfileEnvironment: gameProfileEnvironment
         )
 
         // Create a run log entry to track this session

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
@@ -45,7 +45,8 @@ extension Wine {
         for bottle: Bottle,
         environment: [String: String] = [:],
         programOverrides: ProgramOverrides? = nil,
-        programSettings: ProgramSettings? = nil
+        programSettings: ProgramSettings? = nil,
+        gameProfileEnvironment: [String: String] = [:]
     ) -> [String: String] {
         var builder = EnvironmentBuilder()
         var dllResolver = DLLOverrideResolver(managed: [], bottleCustom: [], programCustom: [])
@@ -90,9 +91,19 @@ extension Wine {
         // Input compatibility (bottleManaged layer -- input settings are bottle-managed toggles)
         bottle.settings.populateInputCompatibilityLayer(builder: &builder)
 
-        // Layer 5: Bottle user (empty for now -- no bottle-level custom env vars UI yet)
+        // Layer 5: Game profile -- GameDB variant environment for this launch.
+        // Beats bottle/launcher defaults, loses to anything the user set.
+        for (key, value) in gameProfileEnvironment {
+            if isValidEnvKey(key) {
+                builder.set(key, value, layer: .gameProfile, reason: "GameDB profile")
+            } else {
+                envLogger.debug("Skipping invalid game profile key '\(key)' in constructWineEnvironment")
+            }
+        }
 
-        // Layer 6: Program user (caller-provided environment dict, typically from Program.generateEnvironment())
+        // Layer 6: Bottle user (empty for now -- no bottle-level custom env vars UI yet)
+
+        // Layer 7: Program user (caller-provided environment dict, typically from Program.generateEnvironment())
         if !environment.isEmpty {
             for (key, value) in environment {
                 if isValidEnvKey(key) {
@@ -108,12 +119,12 @@ extension Wine {
             applyProgramOverrides(overrides, builder: &builder, dllResolver: &dllResolver)
         }
 
-        // Layer 7: featureRuntime -- diagnostic WINEDEBUG preset override
+        // Layer 8: featureRuntime -- diagnostic WINEDEBUG preset override
         if let preset = programSettings?.activeWineDebugPreset, preset != .normal {
             builder.set("WINEDEBUG", preset.winedebugValue, layer: .featureRuntime)
         }
 
-        // Layer 8: callsiteOverride is left empty (populated by direct callers)
+        // Layer 9: callsiteOverride is left empty (populated by direct callers)
 
         // Collect bottle custom DLL overrides for the resolver
         dllResolver.bottleCustom = bottle.settings.dllOverrides
@@ -322,6 +333,7 @@ extension Wine {
             case .platform: "platform"
             case .bottleManaged: "bottleManaged"
             case .launcherManaged: "launcherManaged"
+            case .gameProfile: "gameProfile"
             case .bottleUser: "bottleUser"
             case .programUser: "programUser"
             case .featureRuntime: "featureRuntime"

--- a/WhiskyKit/Tests/WhiskyKitTests/LaunchResolverTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/LaunchResolverTests.swift
@@ -1,0 +1,159 @@
+//
+//  LaunchResolverTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("GameProfile Layer Tests")
+struct GameProfileLayerTests {
+    @Test("Game profile beats launcher defaults, loses to user layers")
+    func layerOrdering() {
+        var builder = EnvironmentBuilder()
+
+        builder.set("SHARED", "launcher", layer: .launcherManaged)
+        builder.set("SHARED", "gamedb", layer: .gameProfile)
+        builder.set("USER_WINS", "gamedb", layer: .gameProfile)
+        builder.set("USER_WINS", "bottle-user", layer: .bottleUser)
+        builder.set("PROGRAM_WINS", "gamedb", layer: .gameProfile)
+        builder.set("PROGRAM_WINS", "program", layer: .programUser)
+
+        let (resolved, _) = builder.resolve()
+
+        #expect(resolved["SHARED"] == "gamedb")
+        #expect(resolved["USER_WINS"] == "bottle-user")
+        #expect(resolved["PROGRAM_WINS"] == "program")
+    }
+
+    @Test("constructWineEnvironment carries the game profile environment")
+    @MainActor func constructCarriesProfile() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let bottle = Bottle(bottleUrl: tempDir, inFlight: false, isAvailable: true)
+
+        let env = Wine.constructWineEnvironment(
+            for: bottle,
+            environment: ["CONTESTED": "program-user"],
+            gameProfileEnvironment: [
+                "GAME_PROFILE_ONLY": "1",
+                "CONTESTED": "gamedb",
+                "not a valid key!": "dropped",
+            ]
+        )
+
+        #expect(env["GAME_PROFILE_ONLY"] == "1")
+        #expect(env["CONTESTED"] == "program-user")
+        #expect(env["not a valid key!"] == nil)
+    }
+}
+
+@Suite("LaunchResolver Tests")
+struct LaunchResolverTests {
+    private func fixtureEntries() throws -> [GameDBEntry] {
+        let json = """
+        {
+            "version": 1,
+            "entries": [
+                {
+                    "id": "casualties-unknown-demo",
+                    "title": "Casualties: Unknown Demo",
+                    "rating": "unverified",
+                    "steamAppId": 4576510,
+                    "variants": [
+                        {
+                            "id": "recommended",
+                            "label": "Recommended",
+                            "isDefault": true,
+                            "settings": {
+                                "graphicsBackend": "dxvk",
+                                "dxvkAsync": true,
+                                "forceD3D11": false,
+                                "performancePreset": "unity"
+                            },
+                            "environmentVariables": {
+                                "DXVK_FRAME_RATE": "120"
+                            },
+                            "dllOverrides": []
+                        }
+                    ]
+                }
+            ]
+        }
+        """
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let url = tempDir.appending(path: "gamedb.json")
+        try Data(json.utf8).write(to: url)
+        return try GameDBLoader.loadEntries(from: url)
+    }
+
+    @Test("Plans from a GameDB match by App ID")
+    func plansFromMatch() throws {
+        let plan = try LaunchResolver.plan(steamAppId: 4_576_510, entries: fixtureEntries())
+
+        #expect(plan.overrides.graphicsBackend == .dxvk)
+        #expect(plan.overrides.dxvkAsync == true)
+        #expect(plan.overrides.forceD3D11 == false)
+        #expect(plan.overrides.performancePreset == .unity)
+        #expect(plan.gameProfileEnvironment["DXVK_FRAME_RATE"] == "120")
+        #expect(plan.provenance.count == 1)
+        #expect(plan.provenance[0].contains("Casualties: Unknown Demo"))
+    }
+
+    @Test("User overrides win over GameDB fields")
+    func userOverridesWin() throws {
+        var user = ProgramOverrides()
+        user.graphicsBackend = .dxmt
+        user.dxvkAsync = false
+
+        let plan = try LaunchResolver.plan(
+            steamAppId: 4_576_510, userOverrides: user, entries: fixtureEntries()
+        )
+
+        #expect(plan.overrides.graphicsBackend == .dxmt)
+        #expect(plan.overrides.dxvkAsync == false)
+        // Fields the user left unset still come from the variant
+        #expect(plan.overrides.performancePreset == .unity)
+    }
+
+    @Test("No match passes user overrides through untouched")
+    func noMatchPassthrough() throws {
+        var user = ProgramOverrides()
+        user.graphicsBackend = .wined3d
+
+        let plan = try LaunchResolver.plan(
+            steamAppId: 1, userOverrides: user, entries: fixtureEntries()
+        )
+
+        #expect(plan.overrides.graphicsBackend == .wined3d)
+        #expect(plan.gameProfileEnvironment.isEmpty)
+        #expect(plan.provenance.isEmpty)
+    }
+
+    @Test("No match and no user overrides yields an empty plan")
+    func emptyPlan() throws {
+        let plan = try LaunchResolver.plan(steamAppId: 1, entries: fixtureEntries())
+
+        #expect(plan.overrides.isEmpty)
+        #expect(plan.gameProfileEnvironment.isEmpty)
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/LaunchResolverTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/LaunchResolverTests.swift
@@ -54,7 +54,7 @@ struct GameProfileLayerTests {
             gameProfileEnvironment: [
                 "GAME_PROFILE_ONLY": "1",
                 "CONTESTED": "gamedb",
-                "not a valid key!": "dropped",
+                "not a valid key!": "dropped"
             ]
         )
 


### PR DESCRIPTION
part of #158. gamedb config today mutates bottle-wide settings (two games in one bottle fight) and variant environmentVariables are recorded "for reference" without reaching the launch env. this adds:

- a `gameProfile` layer between launcherManaged and bottleUser: variant env beats defaults, loses to anything the user set. `runProgram`/`constructWineEnvironment` gain a defaulted param, all existing callers unchanged
- `LaunchResolver`: appid → gamedb best match → ephemeral `ProgramOverrides` (user's persisted overrides win field-by-field) + profile env + provenance strings. nothing persisted at launch

6 new swift-testing cases (layer ordering, resolver merge semantics), full kit suite green locally. swiftformat clean.