### PR TITLE
feat: steam library surface for bottles

### DIFF
--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		6E40495A29CCA19C006E3F1B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6E40495929CCA19C006E3F1B /* Assets.xcassets */; };
 		6E40495D29CCA19C006E3F1B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6E40495C29CCA19C006E3F1B /* Preview Assets.xcassets */; };
 		6E40498129CCA8B0006E3F1B /* BottleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E40498029CCA8B0006E3F1B /* BottleView.swift */; };
+		A5175A536850D4926FE4C480 /* SteamLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1453C3A95B17CD3DE867F7 /* SteamLibraryView.swift */; };
 		6E40498329CCA91B006E3F1B /* Bottle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E40498229CCA91B006E3F1B /* Bottle+Extensions.swift */; };
 		6E49E0212AECB7DB00009CAC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E49E0202AECB7DB00009CAC /* SettingsView.swift */; };
 		6E50D98329CD6066008C39F6 /* BottleVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E50D98229CD6066008C39F6 /* BottleVM.swift */; };
@@ -121,6 +122,7 @@
 		H1A2B3C4E5F61101A9B0C1D0 /* DependencyConfigSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = H1A2B3C4E5F61101A9B0C1D1 /* DependencyConfigSection.swift */; };
 		H1A2B3C4E5F61101A9B0C1D2 /* DependencyInstallSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = H1A2B3C4E5F61101A9B0C1D3 /* DependencyInstallSheet.swift */; };
 		I1A2B3C4E5F61201A9B0C1D0 /* SteamDownloadMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = I1A2B3C4E5F61201A9B0C1D1 /* SteamDownloadMonitor.swift */; };
+		129146529D772EC1C559C0CB /* SteamClientOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B94A3D15B907CF55C906C9A /* SteamClientOrchestrator.swift */; };
 		J1A2B3C4E5F61301A9B0C1D0 /* TroubleshootingWizardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = J1A2B3C4E5F61301A9B0C1D1 /* TroubleshootingWizardView.swift */; };
 		J1A2B3C4E5F61301A9B0C1D2 /* ProgressRailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = J1A2B3C4E5F61301A9B0C1D3 /* ProgressRailView.swift */; };
 		J1A2B3C4E5F61301A9B0C1D4 /* SymptomPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = J1A2B3C4E5F61301A9B0C1D5 /* SymptomPickerView.swift */; };
@@ -226,6 +228,7 @@
 		6E40495C29CCA19C006E3F1B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		6E40495E29CCA19C006E3F1B /* Whisky.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Whisky.entitlements; sourceTree = "<group>"; };
 		6E40498029CCA8B0006E3F1B /* BottleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleView.swift; sourceTree = "<group>"; };
+		BB1453C3A95B17CD3DE867F7 /* SteamLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteamLibraryView.swift; sourceTree = "<group>"; };
 		6E40498229CCA91B006E3F1B /* Bottle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bottle+Extensions.swift"; sourceTree = "<group>"; };
 		6E49E0202AECB7DB00009CAC /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		6E50D98229CD6066008C39F6 /* BottleVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleVM.swift; sourceTree = "<group>"; };
@@ -304,6 +307,7 @@
 		H1A2B3C4E5F61101A9B0C1D1 /* DependencyConfigSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyConfigSection.swift; sourceTree = "<group>"; };
 		H1A2B3C4E5F61101A9B0C1D3 /* DependencyInstallSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyInstallSheet.swift; sourceTree = "<group>"; };
 		I1A2B3C4E5F61201A9B0C1D1 /* SteamDownloadMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteamDownloadMonitor.swift; sourceTree = "<group>"; };
+		2B94A3D15B907CF55C906C9A /* SteamClientOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteamClientOrchestrator.swift; sourceTree = "<group>"; };
 		J1A2B3C4E5F61301A9B0C1D1 /* TroubleshootingWizardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TroubleshootingWizardView.swift; sourceTree = "<group>"; };
 		J1A2B3C4E5F61301A9B0C1D3 /* ProgressRailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressRailView.swift; sourceTree = "<group>"; };
 		J1A2B3C4E5F61301A9B0C1D5 /* SymptomPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymptomPickerView.swift; sourceTree = "<group>"; };
@@ -428,6 +432,7 @@
 			children = (
 				C1A2B3C4E5F60601A9B0C1D9 /* AudioConfigSection.swift */,
 				6E40498029CCA8B0006E3F1B /* BottleView.swift */,
+				BB1453C3A95B17CD3DE867F7 /* SteamLibraryView.swift */,
 				6365C4C22B1AA8CD00AAE1FD /* BottleListEntry.swift */,
 				6E50D98429CDF25B008C39F6 /* BottleCreationView.swift */,
 				6E355E5729D78249002D83BE /* ConfigView.swift */,
@@ -563,6 +568,7 @@
 				G1A2B3C4E5F60901A9B0C1D1 /* DependencyManager.swift */,
 				F1A2B3C4E5F60801A9B0C1D0 /* ControllerMonitor.swift */,
 				I1A2B3C4E5F61201A9B0C1D1 /* SteamDownloadMonitor.swift */,
+				2B94A3D15B907CF55C906C9A /* SteamClientOrchestrator.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -977,6 +983,7 @@
 				6E7C07C02AAF570100F6E66B /* FileOpenView.swift in Sources */,
 				6E6C0CF22A419A6800356232 /* WelcomeView.swift in Sources */,
 				6E40498129CCA8B0006E3F1B /* BottleView.swift in Sources */,
+				A5175A536850D4926FE4C480 /* SteamLibraryView.swift in Sources */,
 				6E355E5E29D7D85D002D83BE /* ProgramView.swift in Sources */,
 				954F64484BFDF7786A5B184E /* LauncherDetection.swift in Sources */,
 				689B4F6DF3B8006E89E1395F /* LauncherDiagnostics.swift in Sources */,
@@ -1018,6 +1025,7 @@
 				H1A2B3C4E5F61101A9B0C1D0 /* DependencyConfigSection.swift in Sources */,
 				H1A2B3C4E5F61101A9B0C1D2 /* DependencyInstallSheet.swift in Sources */,
 				I1A2B3C4E5F61201A9B0C1D0 /* SteamDownloadMonitor.swift in Sources */,
+				129146529D772EC1C559C0CB /* SteamClientOrchestrator.swift in Sources */,
 				J1A2B3C4E5F61301A9B0C1D0 /* TroubleshootingWizardView.swift in Sources */,
 				J1A2B3C4E5F61301A9B0C1D2 /* ProgressRailView.swift in Sources */,
 				J1A2B3C4E5F61301A9B0C1D4 /* SymptomPickerView.swift in Sources */,

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -19666,6 +19666,56 @@
         }
       }
     },
+    "steam.client.missing" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This bottle no longer contains a Steam installation."
+          }
+        }
+      }
+    },
+    "steam.client.timeout" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steam didn't start within 90 seconds. Check the launcher troubleshooting guide."
+          }
+        }
+      }
+    },
+    "steam.launch.failed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steam Launch"
+          }
+        }
+      }
+    },
+    "steam.launch.timeout" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The game didn't start within two minutes. It may still be loading, or the launch failed."
+          }
+        }
+      }
+    },
+    "steam.library.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No installed Steam games found in this bottle."
+          }
+        }
+      }
+    },
     "steam.stall.detected" : {
       "localizations" : {
         "en" : {
@@ -19712,6 +19762,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No progress for %lld minutes"
+          }
+        }
+      }
+    },
+    "steam.status.starting" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starting Steam…"
           }
         }
       }
@@ -20131,6 +20191,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已安裝的程式"
+          }
+        }
+      }
+    },
+    "tab.steamLibrary" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steam Library"
           }
         }
       }

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -19766,6 +19766,16 @@
         }
       }
     },
+    "steam.status.running" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Running"
+          }
+        }
+      }
+    },
     "steam.status.starting" : {
       "localizations" : {
         "en" : {

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -19666,6 +19666,26 @@
         }
       }
     },
+    "steam.button.play" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play"
+          }
+        }
+      }
+    },
+    "steam.button.stop" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop"
+          }
+        }
+      }
+    },
     "steam.client.missing" : {
       "localizations" : {
         "en" : {

--- a/Whisky/Utils/SteamClientOrchestrator.swift
+++ b/Whisky/Utils/SteamClientOrchestrator.swift
@@ -118,7 +118,7 @@ final class SteamClientOrchestrator: ObservableObject {
         trackingTask?.cancel()
         for game in games where executableNamesByAppId[game.appId] == nil {
             let installURL = game.installURL
-            executableNamesByAppId[game.appId] = Self.executableNames(under: installURL)
+            executableNamesByAppId[game.appId] = SteamLibrary.executableNames(under: installURL)
         }
         trackingTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -132,7 +132,7 @@ final class SteamClientOrchestrator: ObservableObject {
     /// Asks the game's processes to close, then refreshes the running state.
     func stop(_ game: SteamGame) async {
         let names = executableNamesByAppId[game.appId]
-            ?? Self.executableNames(under: game.installURL)
+            ?? SteamLibrary.executableNames(under: game.installURL)
         guard let output = try? await Wine.runWine(["tasklist.exe", "/FO", "CSV"], bottle: bottle) else {
             return
         }
@@ -198,7 +198,7 @@ final class SteamClientOrchestrator: ObservableObject {
     /// Returns `true` when the game shows up (or when no candidate exe names
     /// could be determined, in which case there is nothing to watch for).
     private func waitForGameProcess(installURL: URL) async -> Bool {
-        let candidates = Self.executableNames(under: installURL)
+        let candidates = SteamLibrary.executableNames(under: installURL)
         guard !candidates.isEmpty else { return true }
 
         let deadline = Date(timeIntervalSinceNow: launchGrace)
@@ -221,32 +221,5 @@ final class SteamClientOrchestrator: ObservableObject {
             return []
         }
         return Set(Wine.parseTasklistOutput(output).map { $0.imageName.lowercased() })
-    }
-
-    /// Lowercased executable names at the install root and one directory deep.
-    static func executableNames(under installURL: URL) -> Set<String> {
-        let fileManager = FileManager.default
-        var names: Set<String> = []
-        var subdirectories: [URL] = []
-
-        let top = (try? fileManager.contentsOfDirectory(
-            at: installURL, includingPropertiesForKeys: [.isDirectoryKey]
-        )) ?? []
-        for item in top {
-            if item.pathExtension.lowercased() == "exe" {
-                names.insert(item.lastPathComponent.lowercased())
-            } else if (try? item.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
-                subdirectories.append(item)
-            }
-        }
-        for directory in subdirectories {
-            let items = (try? fileManager.contentsOfDirectory(
-                at: directory, includingPropertiesForKeys: nil
-            )) ?? []
-            for item in items where item.pathExtension.lowercased() == "exe" {
-                names.insert(item.lastPathComponent.lowercased())
-            }
-        }
-        return names
     }
 }

--- a/Whisky/Utils/SteamClientOrchestrator.swift
+++ b/Whisky/Utils/SteamClientOrchestrator.swift
@@ -120,18 +120,35 @@ final class SteamClientOrchestrator: ObservableObject {
             let installURL = game.installURL
             executableNamesByAppId[game.appId] = Self.executableNames(under: installURL)
         }
-        let namesByAppId = executableNamesByAppId
         trackingTask = Task { [weak self] in
             while !Task.isCancelled {
-                guard let self else { return }
-                let running = await self.runningImageNames()
+                await self?.refreshRunningState()
                 guard !Task.isCancelled else { return }
-                self.runningAppIds = Set(
-                    namesByAppId.filter { !$0.value.isDisjoint(with: running) }.keys
-                )
                 try? await Task.sleep(for: .seconds(10))
             }
         }
+    }
+
+    /// Asks the game's processes to close, then refreshes the running state.
+    func stop(_ game: SteamGame) async {
+        let names = executableNamesByAppId[game.appId]
+            ?? Self.executableNames(under: game.installURL)
+        guard let output = try? await Wine.runWine(["tasklist.exe", "/FO", "CSV"], bottle: bottle) else {
+            return
+        }
+
+        for process in Wine.parseTasklistOutput(output)
+            where names.contains(process.imageName.lowercased()) {
+            await Wine.gracefulKillProcess(winePID: process.winePID, bottle: bottle)
+        }
+        await refreshRunningState()
+    }
+
+    private func refreshRunningState() async {
+        let running = await runningImageNames()
+        runningAppIds = Set(
+            executableNamesByAppId.filter { !$0.value.isDisjoint(with: running) }.keys
+        )
     }
 
     /// Stops download monitoring and process tracking. Call when the owning

--- a/Whisky/Utils/SteamClientOrchestrator.swift
+++ b/Whisky/Utils/SteamClientOrchestrator.swift
@@ -59,6 +59,10 @@ final class SteamClientOrchestrator: ObservableObject {
     private var trackingTask: Task<Void, Never>?
     private var executableNamesByAppId: [Int: Set<String>] = [:]
 
+    private lazy var watch = SteamProcessWatch(pollInterval: .seconds(2)) { [weak self] in
+        await self?.runningImageNames() ?? []
+    }
+
     private let clientReadyTimeout: TimeInterval = 90
     /// Steam forks the game and the -applaunch invocation returns immediately;
     /// shader precompilation can hold the real game process back for a long
@@ -145,10 +149,7 @@ final class SteamClientOrchestrator: ObservableObject {
     }
 
     private func refreshRunningState() async {
-        let running = await runningImageNames()
-        runningAppIds = Set(
-            executableNamesByAppId.filter { !$0.value.isDisjoint(with: running) }.keys
-        )
+        runningAppIds = await watch.runningKeys(byExecutables: executableNamesByAppId)
     }
 
     /// Stops download monitoring and process tracking. Call when the owning
@@ -178,13 +179,9 @@ final class SteamClientOrchestrator: ObservableObject {
             _ = try? await Wine.runProgram(at: steamExe, args: ["-silent"], bottle: bottle)
         }
 
-        let deadline = Date(timeIntervalSinceNow: clientReadyTimeout)
-        while Date() < deadline {
-            try? await Task.sleep(for: .seconds(2))
-            if await isClientRunning() {
-                startDownloadMonitoringIfNeeded()
-                return
-            }
+        if await watch.waitForAny(of: ["steam.exe"], timeout: clientReadyTimeout) {
+            startDownloadMonitoringIfNeeded()
+            return
         }
         throw SteamOrchestratorError.clientTimeout
     }
@@ -199,16 +196,7 @@ final class SteamClientOrchestrator: ObservableObject {
     /// could be determined, in which case there is nothing to watch for).
     private func waitForGameProcess(installURL: URL) async -> Bool {
         let candidates = SteamLibrary.executableNames(under: installURL)
-        guard !candidates.isEmpty else { return true }
-
-        let deadline = Date(timeIntervalSinceNow: launchGrace)
-        while Date() < deadline {
-            if await !runningImageNames().isDisjoint(with: candidates) {
-                return true
-            }
-            try? await Task.sleep(for: .seconds(3))
-        }
-        return false
+        return await watch.waitForAny(of: candidates, timeout: launchGrace)
     }
 
     private func startDownloadMonitoringIfNeeded() {

--- a/Whisky/Utils/SteamClientOrchestrator.swift
+++ b/Whisky/Utils/SteamClientOrchestrator.swift
@@ -42,12 +42,14 @@ enum SteamOrchestratorError: LocalizedError {
 @MainActor
 final class SteamClientOrchestrator: ObservableObject {
     enum Phase: Equatable {
-        case idle
         case startingClient
-        case launching(appId: Int)
+        case launching
     }
 
-    @Published private(set) var phase: Phase = .idle
+    /// Where each in-flight launch is, keyed by App ID. Per-game rather than
+    /// global: the grace period below runs for up to two minutes, and starting
+    /// a second game while the first precompiles shaders is normal.
+    @Published private(set) var phases: [Int: Phase] = [:]
     @Published private(set) var downloadStatus: StallStatus = .noDownloads
     /// App IDs whose executables are currently in the bottle's process list.
     @Published private(set) var runningAppIds: Set<Int> = []
@@ -58,6 +60,9 @@ final class SteamClientOrchestrator: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
     private var trackingTask: Task<Void, Never>?
     private var executableNamesByAppId: [Int: Set<String>] = [:]
+    /// The in-flight client startup, so concurrent launches await one attempt
+    /// instead of each racing to start their own client.
+    private var clientStartup: Task<Void, Error>?
 
     private lazy var watch = SteamProcessWatch(pollInterval: .seconds(2)) { [weak self] in
         await self?.runningImageNames() ?? []
@@ -79,9 +84,9 @@ final class SteamClientOrchestrator: ObservableObject {
 
     /// Launches a game via `-applaunch`, bringing the client up first if needed.
     func launch(_ game: SteamGame) async {
-        guard phase == .idle else { return }
-        phase = .startingClient
-        defer { phase = .idle }
+        guard phases[game.appId] == nil else { return }
+        phases[game.appId] = .startingClient
+        defer { phases[game.appId] = nil }
 
         guard let steamRoot = SteamLibrary.detectInstall(bottleURL: bottle.url) else {
             launchError = SteamOrchestratorError.steamNotInstalled.errorDescription
@@ -96,8 +101,11 @@ final class SteamClientOrchestrator: ObservableObject {
             return
         }
 
-        phase = .launching(appId: game.appId)
-        let plan = LaunchResolver.plan(steamAppId: game.appId)
+        phases[game.appId] = .launching
+        let plan = LaunchResolver.plan(
+            steamAppId: game.appId,
+            userOverrides: userOverrides(for: game)
+        )
         let bottle = self.bottle
         let appId = game.appId
         // With the client already up this invocation just forwards and exits,
@@ -160,7 +168,36 @@ final class SteamClientOrchestrator: ObservableObject {
         downloadMonitor.stopMonitoring()
     }
 
+    /// The user's persisted overrides for this game's executables, so settings
+    /// tuned in the Programs tab survive a launch from the library.
+    private func userOverrides(for game: SteamGame) -> ProgramOverrides? {
+        let scanned = Dictionary(
+            bottle.programs.compactMap { program in
+                program.settings.overrides.map { (program.url.standardizedFileURL, $0) }
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let candidates = SteamLibrary.executableURLs(under: game.installURL).map { url in
+            // Falls back to a direct load for executables the bottle scan has
+            // not reached, so Play works before the Programs tab is opened.
+            let overrides = scanned[url.standardizedFileURL]
+                ?? Program(url: url, bottle: bottle, peFile: nil).settings.overrides
+            return ProgramOverrideCandidate(url: url, overrides: overrides ?? ProgramOverrides())
+        }
+        return SteamLibrary.preferredOverrides(among: candidates)
+    }
+
     private func ensureClientRunning(steamExe: URL) async throws {
+        if let clientStartup {
+            return try await clientStartup.value
+        }
+        let startup = Task { try await startClient(steamExe: steamExe) }
+        clientStartup = startup
+        defer { clientStartup = nil }
+        try await startup.value
+    }
+
+    private func startClient(steamExe: URL) async throws {
         if await isClientRunning() {
             startDownloadMonitoringIfNeeded()
             return

--- a/Whisky/Utils/SteamClientOrchestrator.swift
+++ b/Whisky/Utils/SteamClientOrchestrator.swift
@@ -1,0 +1,206 @@
+//
+//  SteamClientOrchestrator.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Combine
+import Foundation
+import WhiskyKit
+
+enum SteamOrchestratorError: LocalizedError {
+    /// steam.exe did not appear in the process list within the ready timeout.
+    case clientTimeout
+    /// The bottle no longer contains a Steam installation.
+    case steamNotInstalled
+
+    var errorDescription: String? {
+        switch self {
+        case .clientTimeout:
+            String(localized: "steam.client.timeout")
+        case .steamNotInstalled:
+            String(localized: "steam.client.missing")
+        }
+    }
+}
+
+/// Runs Steam games through the Windows Steam client without making the user
+/// look at it: ensures the client is up (silently), fires `-applaunch`, and
+/// watches for the game process to actually appear.
+@MainActor
+final class SteamClientOrchestrator: ObservableObject {
+    enum Phase: Equatable {
+        case idle
+        case startingClient
+        case launching(appId: Int)
+    }
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var downloadStatus: StallStatus = .noDownloads
+    @Published var launchError: String?
+
+    private let bottle: Bottle
+    private let downloadMonitor = SteamDownloadMonitor()
+    private var cancellables: Set<AnyCancellable> = []
+
+    private let clientReadyTimeout: TimeInterval = 90
+    /// Steam forks the game and the -applaunch invocation returns immediately;
+    /// shader precompilation can hold the real game process back for a long
+    /// time. Lutris ships 120 seconds for this same wait.
+    private let launchGrace: TimeInterval = 120
+
+    init(bottle: Bottle) {
+        self.bottle = bottle
+        downloadMonitor.$status
+            .receive(on: RunLoop.main)
+            .sink { [weak self] status in self?.downloadStatus = status }
+            .store(in: &cancellables)
+    }
+
+    /// Launches a game via `-applaunch`, bringing the client up first if needed.
+    func launch(_ game: SteamGame) async {
+        guard phase == .idle else { return }
+        phase = .startingClient
+        defer { phase = .idle }
+
+        guard let steamRoot = SteamLibrary.detectInstall(bottleURL: bottle.url) else {
+            launchError = SteamOrchestratorError.steamNotInstalled.errorDescription
+            return
+        }
+        let steamExe = steamRoot.appending(path: "steam.exe")
+
+        do {
+            try await ensureClientRunning(steamExe: steamExe)
+        } catch {
+            launchError = error.localizedDescription
+            return
+        }
+
+        phase = .launching(appId: game.appId)
+        let plan = LaunchResolver.plan(steamAppId: game.appId)
+        let bottle = self.bottle
+        let appId = game.appId
+        // With the client already up this invocation just forwards and exits,
+        // but if the client died in between it becomes the client itself and
+        // runs for the whole session -- never await it.
+        Task {
+            _ = try? await Wine.runProgram(
+                at: steamExe, args: ["-applaunch", String(appId)], bottle: bottle,
+                programOverrides: plan.overrides,
+                gameProfileEnvironment: plan.gameProfileEnvironment
+            )
+        }
+
+        if await !waitForGameProcess(installURL: game.installURL) {
+            launchError = String(localized: "steam.launch.timeout")
+        }
+    }
+
+    /// Stops download monitoring. Call when the owning view disappears.
+    func stop() {
+        downloadMonitor.stopMonitoring()
+    }
+
+    private func ensureClientRunning(steamExe: URL) async throws {
+        if await isClientRunning() {
+            startDownloadMonitoringIfNeeded()
+            return
+        }
+
+        // The launcherManaged env recipe (UTF-8 locale, CEF sandbox flags) is
+        // what keeps steamwebhelper alive; make sure it applies to this launch.
+        if bottle.settings.detectedLauncher == nil {
+            bottle.settings.detectedLauncher = .steam
+        }
+        bottle.settings.launcherCompatibilityMode = true
+
+        let bottle = self.bottle
+        // steam.exe -silent runs for the whole session -- never await it.
+        Task {
+            _ = try? await Wine.runProgram(at: steamExe, args: ["-silent"], bottle: bottle)
+        }
+
+        let deadline = Date(timeIntervalSinceNow: clientReadyTimeout)
+        while Date() < deadline {
+            try? await Task.sleep(for: .seconds(2))
+            if await isClientRunning() {
+                startDownloadMonitoringIfNeeded()
+                return
+            }
+        }
+        throw SteamOrchestratorError.clientTimeout
+    }
+
+    private func isClientRunning() async -> Bool {
+        await runningImageNames().contains("steam.exe")
+    }
+
+    /// Waits for any of the game's executables to appear in the process list.
+    ///
+    /// Returns `true` when the game shows up (or when no candidate exe names
+    /// could be determined, in which case there is nothing to watch for).
+    private func waitForGameProcess(installURL: URL) async -> Bool {
+        let candidates = Self.executableNames(under: installURL)
+        guard !candidates.isEmpty else { return true }
+
+        let deadline = Date(timeIntervalSinceNow: launchGrace)
+        while Date() < deadline {
+            if await !runningImageNames().isDisjoint(with: candidates) {
+                return true
+            }
+            try? await Task.sleep(for: .seconds(3))
+        }
+        return false
+    }
+
+    private func startDownloadMonitoringIfNeeded() {
+        guard !downloadMonitor.isMonitoring else { return }
+        downloadMonitor.startMonitoring(bottleURL: bottle.url, detectedLauncher: .steam)
+    }
+
+    private func runningImageNames() async -> Set<String> {
+        guard let output = try? await Wine.runWine(["tasklist.exe", "/FO", "CSV"], bottle: bottle) else {
+            return []
+        }
+        return Set(Wine.parseTasklistOutput(output).map { $0.imageName.lowercased() })
+    }
+
+    /// Lowercased executable names at the install root and one directory deep.
+    static func executableNames(under installURL: URL) -> Set<String> {
+        let fileManager = FileManager.default
+        var names: Set<String> = []
+        var subdirectories: [URL] = []
+
+        let top = (try? fileManager.contentsOfDirectory(
+            at: installURL, includingPropertiesForKeys: [.isDirectoryKey]
+        )) ?? []
+        for item in top {
+            if item.pathExtension.lowercased() == "exe" {
+                names.insert(item.lastPathComponent.lowercased())
+            } else if (try? item.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+                subdirectories.append(item)
+            }
+        }
+        for directory in subdirectories {
+            let items = (try? fileManager.contentsOfDirectory(
+                at: directory, includingPropertiesForKeys: nil
+            )) ?? []
+            for item in items where item.pathExtension.lowercased() == "exe" {
+                names.insert(item.lastPathComponent.lowercased())
+            }
+        }
+        return names
+    }
+}

--- a/Whisky/Utils/SteamClientOrchestrator.swift
+++ b/Whisky/Utils/SteamClientOrchestrator.swift
@@ -49,11 +49,15 @@ final class SteamClientOrchestrator: ObservableObject {
 
     @Published private(set) var phase: Phase = .idle
     @Published private(set) var downloadStatus: StallStatus = .noDownloads
+    /// App IDs whose executables are currently in the bottle's process list.
+    @Published private(set) var runningAppIds: Set<Int> = []
     @Published var launchError: String?
 
     private let bottle: Bottle
     private let downloadMonitor = SteamDownloadMonitor()
     private var cancellables: Set<AnyCancellable> = []
+    private var trackingTask: Task<Void, Never>?
+    private var executableNamesByAppId: [Int: Set<String>] = [:]
 
     private let clientReadyTimeout: TimeInterval = 90
     /// Steam forks the game and the -applaunch invocation returns immediately;
@@ -108,8 +112,33 @@ final class SteamClientOrchestrator: ObservableObject {
         }
     }
 
-    /// Stops download monitoring. Call when the owning view disappears.
+    /// Polls the bottle's process list so the library can show which games
+    /// are running, including ones started outside Whisky.
+    func startTracking(games: [SteamGame]) {
+        trackingTask?.cancel()
+        for game in games where executableNamesByAppId[game.appId] == nil {
+            let installURL = game.installURL
+            executableNamesByAppId[game.appId] = Self.executableNames(under: installURL)
+        }
+        let namesByAppId = executableNamesByAppId
+        trackingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                let running = await self.runningImageNames()
+                guard !Task.isCancelled else { return }
+                self.runningAppIds = Set(
+                    namesByAppId.filter { !$0.value.isDisjoint(with: running) }.keys
+                )
+                try? await Task.sleep(for: .seconds(10))
+            }
+        }
+    }
+
+    /// Stops download monitoring and process tracking. Call when the owning
+    /// view disappears.
     func stop() {
+        trackingTask?.cancel()
+        trackingTask = nil
         downloadMonitor.stopMonitoring()
     }
 

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -285,7 +285,6 @@ struct BottleView: View {
             }
         }
     }
-
 }
 
 extension BottleView {

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -286,6 +286,9 @@ struct BottleView: View {
         }
     }
 
+}
+
+extension BottleView {
     private func updateStartMenu() async {
         await bottle.updateInstalledPrograms()
 

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -25,12 +25,14 @@ enum BottleStage {
     case programs
     case processes
     case gameConfigs
+    case steamLibrary
 }
 
 struct BottleView: View {
     @ObservedObject var bottle: Bottle
     @State private var path = NavigationPath()
     @State private var programLoading: Bool = false
+    @State private var hasSteamLibrary: Bool = false
     @State private var showWinetricksSheet: Bool = false
     @State private var showDuplicate: Bool = false
     @State private var toast: ToastData?
@@ -58,6 +60,12 @@ struct BottleView: View {
                         Label("tab.programs", systemImage: "list.bullet")
                     }
                     .accessibilityIdentifier("nav.installedPrograms")
+                    if hasSteamLibrary {
+                        NavigationLink(value: BottleStage.steamLibrary) {
+                            Label("tab.steamLibrary", systemImage: "gamecontroller")
+                        }
+                        .accessibilityIdentifier("nav.steamLibrary")
+                    }
                     NavigationLink(value: BottleStage.config) {
                         Label("tab.config", systemImage: "gearshape")
                     }
@@ -249,6 +257,13 @@ struct BottleView: View {
                 // Trigger a reload
                 BottleVM.shared.bottles = BottleVM.shared.bottles
             }
+            .task(id: bottle.url) {
+                // Filesystem check kept out of body evaluation
+                let bottleURL = bottle.url
+                hasSteamLibrary = await Task.detached {
+                    SteamLibrary.detectInstall(bottleURL: bottleURL) != nil
+                }.value
+            }
             .navigationDestination(for: BottleStage.self) { stage in
                 switch stage {
                 case .config:
@@ -261,6 +276,8 @@ struct BottleView: View {
                     RunningProcessesView(bottle: bottle)
                 case .gameConfigs:
                     GameConfigurationView(bottle: bottle)
+                case .steamLibrary:
+                    SteamLibraryView(bottle: bottle)
                 }
             }
             .navigationDestination(for: Program.self) { program in

--- a/Whisky/Views/Bottle/SteamLibraryView.swift
+++ b/Whisky/Views/Bottle/SteamLibraryView.swift
@@ -76,13 +76,24 @@ struct SteamLibraryView: View {
             }
             Spacer()
             statusView(for: game)
-            Button {
-                Task { await orchestrator.launch(game) }
-            } label: {
-                Image(systemName: "play.fill")
+            if orchestrator.runningAppIds.contains(game.appId) {
+                Button {
+                    Task { await orchestrator.stop(game) }
+                } label: {
+                    Image(systemName: "stop.fill")
+                }
+                .accessibilityIdentifier("steamLibrary.stop.\(game.appId)")
+                .help("steam.button.stop")
+            } else {
+                Button {
+                    Task { await orchestrator.launch(game) }
+                } label: {
+                    Image(systemName: "play.fill")
+                }
+                .disabled(orchestrator.phase != .idle)
+                .accessibilityIdentifier("steamLibrary.play.\(game.appId)")
+                .help("steam.button.play")
             }
-            .disabled(orchestrator.phase != .idle)
-            .accessibilityIdentifier("steamLibrary.play.\(game.appId)")
         }
     }
 

--- a/Whisky/Views/Bottle/SteamLibraryView.swift
+++ b/Whisky/Views/Bottle/SteamLibraryView.swift
@@ -90,7 +90,7 @@ struct SteamLibraryView: View {
                 } label: {
                     Image(systemName: "play.fill")
                 }
-                .disabled(orchestrator.phase != .idle)
+                .disabled(orchestrator.phases[game.appId] != nil)
                 .accessibilityIdentifier("steamLibrary.play.\(game.appId)")
                 .help("steam.button.play")
             }
@@ -106,15 +106,15 @@ struct SteamLibraryView: View {
                 .imageScale(.small)
                 .foregroundStyle(.green)
         } else {
-            switch orchestrator.phase {
+            switch orchestrator.phases[game.appId] {
             case .startingClient:
                 Text("steam.status.starting")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-            case let .launching(appId) where appId == game.appId:
+            case .launching:
                 ProgressView()
                     .controlSize(.small)
-            default:
+            case nil:
                 if case .confirmedStall = orchestrator.downloadStatus {
                     Image(systemName: "exclamationmark.arrow.circlepath")
                         .foregroundStyle(.orange)

--- a/Whisky/Views/Bottle/SteamLibraryView.swift
+++ b/Whisky/Views/Bottle/SteamLibraryView.swift
@@ -1,0 +1,115 @@
+//
+//  SteamLibraryView.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import WhiskyKit
+
+struct SteamLibraryView: View {
+    @ObservedObject var bottle: Bottle
+    @StateObject private var orchestrator: SteamClientOrchestrator
+    @State private var games: [SteamGame] = []
+    @State private var loaded = false
+
+    init(bottle: Bottle) {
+        self.bottle = bottle
+        _orchestrator = StateObject(wrappedValue: SteamClientOrchestrator(bottle: bottle))
+    }
+
+    var body: some View {
+        Form {
+            if loaded, games.isEmpty {
+                Text("steam.library.empty")
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(games) { game in
+                gameRow(game)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("tab.steamLibrary")
+        .task { await refresh() }
+        .onDisappear { orchestrator.stop() }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    Task { await refresh() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .accessibilityIdentifier("steamLibrary.refresh")
+            }
+        }
+        .alert(
+            "steam.launch.failed",
+            isPresented: Binding(
+                get: { orchestrator.launchError != nil },
+                set: { if !$0 { orchestrator.launchError = nil } }
+            )
+        ) {} message: {
+            Text(orchestrator.launchError ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private func gameRow(_ game: SteamGame) -> some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(game.name)
+                Text(verbatim: String(game.appId))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            statusView(for: game)
+            Button {
+                Task { await orchestrator.launch(game) }
+            } label: {
+                Image(systemName: "play.fill")
+            }
+            .disabled(orchestrator.phase != .idle)
+            .accessibilityIdentifier("steamLibrary.play.\(game.appId)")
+        }
+    }
+
+    @ViewBuilder
+    private func statusView(for game: SteamGame) -> some View {
+        switch orchestrator.phase {
+        case .startingClient:
+            Text("steam.status.starting")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case let .launching(appId) where appId == game.appId:
+            ProgressView()
+                .controlSize(.small)
+        default:
+            if case .confirmedStall = orchestrator.downloadStatus {
+                Image(systemName: "exclamationmark.arrow.circlepath")
+                    .foregroundStyle(.orange)
+            } else if case .downloading = orchestrator.downloadStatus {
+                Image(systemName: "arrow.down.circle")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func refresh() async {
+        let bottleURL = bottle.url
+        games = await Task.detached { SteamLibrary.enumerate(bottleURL: bottleURL) }.value
+        loaded = true
+    }
+}

--- a/Whisky/Views/Bottle/SteamLibraryView.swift
+++ b/Whisky/Views/Bottle/SteamLibraryView.swift
@@ -88,21 +88,29 @@ struct SteamLibraryView: View {
 
     @ViewBuilder
     private func statusView(for game: SteamGame) -> some View {
-        switch orchestrator.phase {
-        case .startingClient:
-            Text("steam.status.starting")
+        if orchestrator.runningAppIds.contains(game.appId) {
+            Label("steam.status.running", systemImage: "circle.fill")
+                .labelStyle(.titleAndIcon)
                 .font(.caption)
-                .foregroundStyle(.secondary)
-        case let .launching(appId) where appId == game.appId:
-            ProgressView()
-                .controlSize(.small)
-        default:
-            if case .confirmedStall = orchestrator.downloadStatus {
-                Image(systemName: "exclamationmark.arrow.circlepath")
-                    .foregroundStyle(.orange)
-            } else if case .downloading = orchestrator.downloadStatus {
-                Image(systemName: "arrow.down.circle")
+                .imageScale(.small)
+                .foregroundStyle(.green)
+        } else {
+            switch orchestrator.phase {
+            case .startingClient:
+                Text("steam.status.starting")
+                    .font(.caption)
                     .foregroundStyle(.secondary)
+            case let .launching(appId) where appId == game.appId:
+                ProgressView()
+                    .controlSize(.small)
+            default:
+                if case .confirmedStall = orchestrator.downloadStatus {
+                    Image(systemName: "exclamationmark.arrow.circlepath")
+                        .foregroundStyle(.orange)
+                } else if case .downloading = orchestrator.downloadStatus {
+                    Image(systemName: "arrow.down.circle")
+                        .foregroundStyle(.secondary)
+                }
             }
         }
     }
@@ -111,5 +119,6 @@ struct SteamLibraryView: View {
         let bottleURL = bottle.url
         games = await Task.detached { SteamLibrary.enumerate(bottleURL: bottleURL) }.value
         loaded = true
+        orchestrator.startTracking(games: games)
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/GameDatabase/SteamAppManifest.swift
+++ b/WhiskyKit/Sources/WhiskyKit/GameDatabase/SteamAppManifest.swift
@@ -18,11 +18,12 @@
 
 import Foundation
 
-/// Utilities for extracting Steam App IDs from manifest files.
+/// A parsed Steam application manifest (`appmanifest_<appid>.acf`).
 ///
 /// Steam stores application metadata in ACF/VDF format files alongside
-/// installed games. This enum provides methods to parse those files and
-/// locate Steam App IDs within a Wine bottle or executable directory.
+/// installed games. This type parses those files fully via ``VDFParser``,
+/// and also provides the legacy fast-path helpers for extracting App IDs
+/// from manifest text and `steam_appid.txt` files.
 ///
 /// ## ACF Format
 ///
@@ -34,7 +35,48 @@ import Foundation
 ///     "name"      "Elden Ring"
 /// }
 /// ```
-public enum SteamAppManifest {
+public struct SteamAppManifest: Equatable, Sendable {
+    /// The Steam App ID.
+    public let appId: Int
+    /// The display name of the app.
+    public let name: String
+    /// The install directory name, relative to `<library>/steamapps/common/`.
+    public let installDir: String
+    /// Steam's install-state bitmask. Bit 4 means fully installed.
+    public let stateFlags: Int
+    /// The installed build number, when present.
+    public let buildID: Int?
+    /// The size on disk in bytes, when present.
+    public let sizeOnDisk: Int64?
+
+    /// Whether Steam considers the app fully installed (not downloading,
+    /// updating, or partially removed).
+    public var isFullyInstalled: Bool {
+        stateFlags & 4 != 0
+    }
+
+    /// Parses a manifest file.
+    ///
+    /// - Parameter url: The URL to an `appmanifest_*.acf` file.
+    /// - Returns: `nil` if the file can't be read, isn't valid VDF, or lacks
+    ///   the required `appid`, `name`, or `installdir` fields.
+    public init?(contentsOf url: URL) {
+        guard let text = try? String(contentsOf: url, encoding: .utf8),
+              let root = try? VDFParser.parse(text),
+              let appState = root["appstate"]?.objectValue,
+              let appId = appState["appid"]?.intValue,
+              let name = appState["name"]?.stringValue,
+              let installDir = appState["installdir"]?.stringValue
+        else { return nil }
+
+        self.appId = appId
+        self.name = name
+        self.installDir = installDir
+        self.stateFlags = appState["stateflags"]?.intValue ?? 0
+        self.buildID = appState["buildid"]?.intValue
+        self.sizeOnDisk = appState["sizeondisk"]?.stringValue.flatMap(Int64.init)
+    }
+
     /// Parses a Steam App ID from ACF/VDF format text.
     ///
     /// Looks for a `"appid"` key followed by its value in Valve's
@@ -74,37 +116,13 @@ public enum SteamAppManifest {
         return nil
     }
 
-    /// Searches a Wine bottle for Steam App ID by scanning manifest files.
-    ///
-    /// Looks for `appmanifest_*.acf` files in the standard Steam library
-    /// directory within the bottle's `drive_c`. Also checks for
-    /// `steam_appid.txt` in common locations.
+    /// Searches a Wine bottle for a Steam App ID by scanning manifest files.
     ///
     /// - Parameter bottleURL: The root URL of the Wine bottle.
     /// - Returns: The first App ID found, or `nil` if none found.
+    @available(*, deprecated, message: "Use SteamLibrary.enumerate(bottleURL:) instead")
     public static func findAppId(in bottleURL: URL) -> Int? {
-        let steamAppsDir = bottleURL
-            .appending(path: "drive_c/Program Files (x86)/Steam/steamapps")
-
-        let fileManager = FileManager.default
-        let steamAppsPath = steamAppsDir.path(percentEncoded: false)
-
-        guard fileManager.fileExists(atPath: steamAppsPath) else { return nil }
-
-        // Scan for appmanifest_*.acf files
-        guard let contents = try? fileManager.contentsOfDirectory(atPath: steamAppsPath) else {
-            return nil
-        }
-
-        for filename in contents where filename.hasPrefix("appmanifest_") && filename.hasSuffix(".acf") {
-            let fileURL = steamAppsDir.appending(path: filename)
-            guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
-            if let appId = parseAppId(from: text) {
-                return appId
-            }
-        }
-
-        return nil
+        SteamLibrary.enumerate(bottleURL: bottleURL).first?.appId
     }
 
     /// Searches for a Steam App ID near a specific executable.

--- a/WhiskyKit/Sources/WhiskyKit/Steam/LaunchResolver.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/LaunchResolver.swift
@@ -1,0 +1,106 @@
+//
+//  LaunchResolver.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// The resolved configuration for launching one game once.
+///
+/// Nothing in a plan is persisted: GameDB recommendations are applied
+/// per launch, so two games in the same bottle never fight over
+/// bottle-wide settings.
+public struct LaunchPlan {
+    /// Per-launch program overrides: the user's persisted overrides with
+    /// GameDB variant settings filling any field the user left unset.
+    public let overrides: ProgramOverrides
+    /// Extra environment for the ``EnvironmentLayer/gameProfile`` layer.
+    public let gameProfileEnvironment: [String: String]
+    /// Human-readable notes on where the configuration came from, for
+    /// logging and provenance UI.
+    public let provenance: [String]
+}
+
+/// Turns a Steam App ID into a ``LaunchPlan`` by matching the GameDB and
+/// merging its recommended variant under the user's own overrides.
+public enum LaunchResolver {
+    /// Builds the launch plan for a game.
+    ///
+    /// - Parameters:
+    ///   - steamAppId: The game's Steam App ID (a hard identifier for
+    ///     ``GameMatcher``, so no fuzzy-match risk).
+    ///   - exeName: Optional executable name hint for matching.
+    ///   - userOverrides: The user's persisted per-program overrides. Every
+    ///     non-nil field wins over the GameDB recommendation.
+    ///   - entries: The GameDB entries to match against. Defaults to the
+    ///     bundled database.
+    /// - Returns: A plan; without a GameDB match it simply carries the user
+    ///   overrides and empty profile environment.
+    public static func plan(
+        steamAppId: Int,
+        exeName: String? = nil,
+        userOverrides: ProgramOverrides? = nil,
+        entries: [GameDBEntry]? = nil
+    ) -> LaunchPlan {
+        let database = entries ?? GameDBLoader.loadDefaults()
+        let metadata = ProgramMetadata(exeName: exeName ?? "", steamAppId: steamAppId)
+
+        guard let match = GameMatcher.bestMatch(metadata: metadata, against: database),
+              let variant = match.recommendedVariant
+        else {
+            return LaunchPlan(
+                overrides: userOverrides ?? ProgramOverrides(),
+                gameProfileEnvironment: [:],
+                provenance: []
+            )
+        }
+
+        let overrides = merge(variant: variant.settings, dllOverrides: variant.dllOverrides, under: userOverrides)
+
+        return LaunchPlan(
+            overrides: overrides,
+            gameProfileEnvironment: variant.environmentVariables ?? [:],
+            provenance: [
+                "gamedb: \(match.entry.title) — \(variant.label) (\(match.explanation))",
+            ]
+        )
+    }
+
+    /// Fills GameDB variant settings into every field the user left unset.
+    ///
+    /// Bottle-level variant settings (`avxEnabled`, `sequoiaCompatMode`) and
+    /// `winetricksVerbs` are not mapped: the first two have no per-program
+    /// equivalent and verbs are an install-time action, not launch config.
+    static func merge(
+        variant: GameConfigVariantSettings,
+        dllOverrides: [DLLOverrideEntry]?,
+        under userOverrides: ProgramOverrides?
+    ) -> ProgramOverrides {
+        var merged = userOverrides ?? ProgramOverrides()
+
+        merged.graphicsBackend = merged.graphicsBackend ?? variant.graphicsBackend
+        merged.dxvk = merged.dxvk ?? variant.dxvk
+        merged.dxvkAsync = merged.dxvkAsync ?? variant.dxvkAsync
+        merged.enhancedSync = merged.enhancedSync ?? variant.enhancedSync
+        merged.forceD3D11 = merged.forceD3D11 ?? variant.forceD3D11
+        merged.shaderCacheEnabled = merged.shaderCacheEnabled ?? variant.shaderCacheEnabled
+        merged.performancePreset = merged.performancePreset
+            ?? variant.performancePreset.flatMap(PerformancePreset.init(rawValue:))
+        merged.dllOverrides = merged.dllOverrides ?? dllOverrides
+
+        return merged
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Steam/LaunchResolver.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/LaunchResolver.swift
@@ -74,7 +74,7 @@ public enum LaunchResolver {
             overrides: overrides,
             gameProfileEnvironment: variant.environmentVariables ?? [:],
             provenance: [
-                "gamedb: \(match.entry.title) — \(variant.label) (\(match.explanation))",
+                "gamedb: \(match.entry.title) — \(variant.label) (\(match.explanation))"
             ]
         )
     }

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLibrary.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLibrary.swift
@@ -37,7 +37,7 @@ public enum SteamLibrary {
     /// Candidate Steam install locations under `drive_c`.
     private static let installCandidates = [
         "Program Files (x86)/Steam",
-        "Program Files/Steam",
+        "Program Files/Steam"
     ]
 
     /// Locates the Steam installation inside a bottle.
@@ -89,7 +89,7 @@ public enum SteamLibrary {
 
         let vdfCandidates = [
             steamRoot.appending(path: "config").appending(path: "libraryfolders.vdf"),
-            steamRoot.appending(path: "steamapps").appending(path: "libraryfolders.vdf"),
+            steamRoot.appending(path: "steamapps").appending(path: "libraryfolders.vdf")
         ]
 
         for vdfURL in vdfCandidates {

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLibrary.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLibrary.swift
@@ -173,4 +173,32 @@ public enum SteamLibrary {
         }
         return found
     }
+
+    /// Lowercased executable names at the install root and one directory
+    /// deep. Used to match a game's processes in the bottle's task list.
+    public static func executableNames(under installURL: URL) -> Set<String> {
+        let fileManager = FileManager.default
+        var names: Set<String> = []
+        var subdirectories: [URL] = []
+
+        let top = (try? fileManager.contentsOfDirectory(
+            at: installURL, includingPropertiesForKeys: [.isDirectoryKey]
+        )) ?? []
+        for item in top {
+            if item.pathExtension.lowercased() == "exe" {
+                names.insert(item.lastPathComponent.lowercased())
+            } else if (try? item.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+                subdirectories.append(item)
+            }
+        }
+        for directory in subdirectories {
+            let items = (try? fileManager.contentsOfDirectory(
+                at: directory, includingPropertiesForKeys: nil
+            )) ?? []
+            for item in items where item.pathExtension.lowercased() == "exe" {
+                names.insert(item.lastPathComponent.lowercased())
+            }
+        }
+        return names
+    }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLibrary.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLibrary.swift
@@ -120,9 +120,23 @@ public enum SteamLibrary {
         return roots
     }
 
+    /// Whether `component` is a plain name safe to join onto a trusted root.
+    ///
+    /// Manifest and VDF contents are not trusted input (spoofed
+    /// `appmanifest_*.acf` files are common in the repack ecosystem) and
+    /// `URL.appending(path:)` does not collapse `..`, so an unchecked component
+    /// escapes the library and reaches the games list, the running-state
+    /// matcher, and the executable set handed to taskkill.
+    static func isSafePathComponent(_ component: String) -> Bool {
+        guard !component.isEmpty, component != ".", component != ".." else { return false }
+        return !component.contains("/") && !component.contains("\\") && !component.contains("\0")
+    }
+
     /// Maps a Windows path from a VDF file (`D:\\SteamLibrary`) to its
     /// location inside the prefix: `drive_c` for the C drive, the
     /// `dosdevices/<letter>:` symlink for everything else.
+    ///
+    /// Returns `nil` when any component would escape the prefix.
     static func mapWindowsPath(_ windowsPath: String, bottleURL: URL) -> URL? {
         let normalized = windowsPath.replacingOccurrences(of: "\\", with: "/")
         guard normalized.count >= 2 else { return nil }
@@ -133,6 +147,8 @@ public enum SteamLibrary {
         else { return nil }
 
         let rest = String(normalized.dropFirst(2)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let components = rest.split(separator: "/").map(String.init)
+        guard components.allSatisfy(isSafePathComponent) else { return nil }
 
         let base: URL = if driveLetter == "c" {
             bottleURL.appending(path: "drive_c")
@@ -140,7 +156,7 @@ public enum SteamLibrary {
             bottleURL.appending(path: "dosdevices").appending(path: "\(driveLetter):")
         }
 
-        return rest.isEmpty ? base : base.appending(path: rest)
+        return components.reduce(base) { $0.appending(path: $1) }
     }
 
     /// Fully installed games in one library root whose install directory exists.
@@ -154,7 +170,8 @@ public enum SteamLibrary {
         var found: [SteamGame] = []
         for filename in contents where filename.hasPrefix("appmanifest_") && filename.hasSuffix(".acf") {
             guard let manifest = SteamAppManifest(contentsOf: steamApps.appending(path: filename)),
-                  manifest.isFullyInstalled
+                  manifest.isFullyInstalled,
+                  isSafePathComponent(manifest.installDir)
             else { continue }
 
             let installURL = steamApps.appending(path: "common").appending(path: manifest.installDir)
@@ -174,11 +191,10 @@ public enum SteamLibrary {
         return found
     }
 
-    /// Lowercased executable names at the install root and one directory
-    /// deep. Used to match a game's processes in the bottle's task list.
-    public static func executableNames(under installURL: URL) -> Set<String> {
+    /// Executables at the install root and one directory deep.
+    public static func executableURLs(under installURL: URL) -> [URL] {
         let fileManager = FileManager.default
-        var names: Set<String> = []
+        var executables: [URL] = []
         var subdirectories: [URL] = []
 
         let top = (try? fileManager.contentsOfDirectory(
@@ -186,7 +202,7 @@ public enum SteamLibrary {
         )) ?? []
         for item in top {
             if item.pathExtension.lowercased() == "exe" {
-                names.insert(item.lastPathComponent.lowercased())
+                executables.append(item)
             } else if (try? item.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
                 subdirectories.append(item)
             }
@@ -195,10 +211,44 @@ public enum SteamLibrary {
             let items = (try? fileManager.contentsOfDirectory(
                 at: directory, includingPropertiesForKeys: nil
             )) ?? []
-            for item in items where item.pathExtension.lowercased() == "exe" {
-                names.insert(item.lastPathComponent.lowercased())
-            }
+            executables.append(contentsOf: items.filter { $0.pathExtension.lowercased() == "exe" })
         }
-        return names
+        return executables
+    }
+
+    /// Lowercased executable names at the install root and one directory
+    /// deep. Used to match a game's processes in the bottle's task list.
+    public static func executableNames(under installURL: URL) -> Set<String> {
+        Set(executableURLs(under: installURL).map { $0.lastPathComponent.lowercased() })
+    }
+
+    /// Picks the overrides a library launch should carry from the game's
+    /// executables' persisted settings: the shallowest one that has any, ties
+    /// broken by name so the pick does not move between scans.
+    ///
+    /// Steam games surface as ordinary Programs, so a user can tune one in the
+    /// Programs tab, and those settings have to survive the Play button.
+    public static func preferredOverrides(among candidates: [ProgramOverrideCandidate]) -> ProgramOverrides? {
+        candidates
+            .filter { !$0.overrides.isEmpty }
+            .min { lhs, rhs in
+                let left = lhs.url.pathComponents.count
+                let right = rhs.url.pathComponents.count
+                guard left == right else { return left < right }
+                return lhs.url.lastPathComponent
+                    .localizedCaseInsensitiveCompare(rhs.url.lastPathComponent) == .orderedAscending
+            }?
+            .overrides
+    }
+}
+
+/// One executable's persisted overrides, for ``SteamLibrary/preferredOverrides(among:)``.
+public struct ProgramOverrideCandidate: Equatable, Sendable {
+    public let url: URL
+    public let overrides: ProgramOverrides
+
+    public init(url: URL, overrides: ProgramOverrides) {
+        self.url = url
+        self.overrides = overrides
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLibrary.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLibrary.swift
@@ -1,0 +1,176 @@
+//
+//  SteamLibrary.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// A fully installed Steam game discovered inside a Wine bottle.
+public struct SteamGame: Identifiable, Equatable, Sendable {
+    public var id: Int { appId }
+    /// The Steam App ID.
+    public let appId: Int
+    /// The display name from the manifest.
+    public let name: String
+    /// The resolved absolute URL of the game's install directory.
+    public let installURL: URL
+    /// The full parsed manifest.
+    public let manifest: SteamAppManifest
+}
+
+/// Discovers a Windows Steam installation inside a Wine bottle and
+/// enumerates its installed games across all configured library folders.
+public enum SteamLibrary {
+    /// Candidate Steam install locations under `drive_c`.
+    private static let installCandidates = [
+        "Program Files (x86)/Steam",
+        "Program Files/Steam",
+    ]
+
+    /// Locates the Steam installation inside a bottle.
+    ///
+    /// - Parameter bottleURL: The root URL of the Wine bottle.
+    /// - Returns: The Steam root directory (the one containing `steam.exe`),
+    ///   or `nil` if no install is found.
+    public static func detectInstall(bottleURL: URL) -> URL? {
+        for candidate in installCandidates {
+            let root = bottleURL.appending(path: "drive_c").appending(path: candidate)
+            let steamExe = root.appending(path: "steam.exe")
+            if FileManager.default.fileExists(atPath: steamExe.path(percentEncoded: false)) {
+                return root
+            }
+        }
+        return nil
+    }
+
+    /// Enumerates fully installed games across every Steam library in the bottle.
+    ///
+    /// Reads `libraryfolders.vdf` for configured library locations (mapping
+    /// Windows paths through the prefix), scans each library's
+    /// `steamapps/appmanifest_*.acf`, keeps fully installed games whose
+    /// install directory actually exists, and de-duplicates by App ID.
+    ///
+    /// - Parameter bottleURL: The root URL of the Wine bottle.
+    /// - Returns: Installed games sorted by name, empty if Steam isn't installed.
+    public static func enumerate(bottleURL: URL) -> [SteamGame] {
+        guard let steamRoot = detectInstall(bottleURL: bottleURL) else { return [] }
+
+        var byAppId: [Int: SteamGame] = [:]
+        for library in libraryRoots(steamRoot: steamRoot, bottleURL: bottleURL) {
+            for game in games(inLibrary: library) where byAppId[game.appId] == nil {
+                byAppId[game.appId] = game
+            }
+        }
+
+        return byAppId.values.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
+    /// The Steam root plus every existing library folder referenced by
+    /// `libraryfolders.vdf` (checked in its current `config/` home and its
+    /// legacy `steamapps/` location).
+    static func libraryRoots(steamRoot: URL, bottleURL: URL) -> [URL] {
+        var roots = [steamRoot]
+        var seen: Set<String> = [steamRoot.standardizedFileURL.path]
+
+        let vdfCandidates = [
+            steamRoot.appending(path: "config").appending(path: "libraryfolders.vdf"),
+            steamRoot.appending(path: "steamapps").appending(path: "libraryfolders.vdf"),
+        ]
+
+        for vdfURL in vdfCandidates {
+            guard let text = try? String(contentsOf: vdfURL, encoding: .utf8),
+                  let root = try? VDFParser.parse(text),
+                  let folders = root["libraryfolders"]?.objectValue
+            else { continue }
+
+            for value in folders.values {
+                guard let windowsPath = value.objectValue?["path"]?.stringValue,
+                      let mapped = mapWindowsPath(windowsPath, bottleURL: bottleURL)
+                else { continue }
+
+                let standardized = mapped.standardizedFileURL.path
+                var isDirectory: ObjCBool = false
+                if !seen.contains(standardized),
+                   FileManager.default.fileExists(
+                       atPath: mapped.path(percentEncoded: false),
+                       isDirectory: &isDirectory
+                   ),
+                   isDirectory.boolValue {
+                    seen.insert(standardized)
+                    roots.append(mapped)
+                }
+            }
+        }
+
+        return roots
+    }
+
+    /// Maps a Windows path from a VDF file (`D:\\SteamLibrary`) to its
+    /// location inside the prefix: `drive_c` for the C drive, the
+    /// `dosdevices/<letter>:` symlink for everything else.
+    static func mapWindowsPath(_ windowsPath: String, bottleURL: URL) -> URL? {
+        let normalized = windowsPath.replacingOccurrences(of: "\\", with: "/")
+        guard normalized.count >= 2 else { return nil }
+
+        let driveLetter = normalized.prefix(1).lowercased()
+        guard normalized[normalized.index(normalized.startIndex, offsetBy: 1)] == ":",
+              driveLetter.first?.isLetter == true
+        else { return nil }
+
+        let rest = String(normalized.dropFirst(2)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        let base: URL = if driveLetter == "c" {
+            bottleURL.appending(path: "drive_c")
+        } else {
+            bottleURL.appending(path: "dosdevices").appending(path: "\(driveLetter):")
+        }
+
+        return rest.isEmpty ? base : base.appending(path: rest)
+    }
+
+    /// Fully installed games in one library root whose install directory exists.
+    private static func games(inLibrary library: URL) -> [SteamGame] {
+        let steamApps = library.appending(path: "steamapps")
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            atPath: steamApps.path(percentEncoded: false)
+        )
+        else { return [] }
+
+        var found: [SteamGame] = []
+        for filename in contents where filename.hasPrefix("appmanifest_") && filename.hasSuffix(".acf") {
+            guard let manifest = SteamAppManifest(contentsOf: steamApps.appending(path: filename)),
+                  manifest.isFullyInstalled
+            else { continue }
+
+            let installURL = steamApps.appending(path: "common").appending(path: manifest.installDir)
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(
+                atPath: installURL.path(percentEncoded: false), isDirectory: &isDirectory
+            ), isDirectory.boolValue
+            else { continue }
+
+            found.append(SteamGame(
+                appId: manifest.appId,
+                name: manifest.name,
+                installURL: installURL,
+                manifest: manifest
+            ))
+        }
+        return found
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamProcessWatch.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamProcessWatch.swift
@@ -1,0 +1,67 @@
+//
+//  SteamProcessWatch.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// The polling half of Steam client orchestration: watches a bottle's process
+/// list for executables to appear. The process-list source is injected so the
+/// waiting and matching logic is testable without a live Wine bottle.
+public struct SteamProcessWatch: Sendable {
+    private let pollInterval: Duration
+    private let runningImageNames: @Sendable () async -> Set<String>
+
+    /// Creates a watch.
+    ///
+    /// - Parameters:
+    ///   - pollInterval: How long to sleep between polls.
+    ///   - runningImageNames: Source of the bottle's current lowercased
+    ///     process image names (in production, tasklist.exe output).
+    public init(
+        pollInterval: Duration = .seconds(3),
+        runningImageNames: @escaping @Sendable () async -> Set<String>
+    ) {
+        self.pollInterval = pollInterval
+        self.runningImageNames = runningImageNames
+    }
+
+    /// Polls until any of `names` is running, up to `timeout`.
+    ///
+    /// Always checks at least once, so a zero timeout still observes the
+    /// current state. An empty `names` set reports `true` immediately: there
+    /// is nothing to wait for.
+    public func waitForAny(of names: Set<String>, timeout: TimeInterval) async -> Bool {
+        guard !names.isEmpty else { return true }
+
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        repeat {
+            if await !runningImageNames().isDisjoint(with: names) {
+                return true
+            }
+            try? await Task.sleep(for: pollInterval)
+        } while Date() < deadline
+        return false
+    }
+
+    /// The keys whose executable-name sets intersect the running processes.
+    ///
+    /// Used to mark which games are currently running, keyed by App ID.
+    public func runningKeys(byExecutables: [Int: Set<String>]) async -> Set<Int> {
+        let running = await runningImageNames()
+        return Set(byExecutables.filter { !$0.value.isDisjoint(with: running) }.keys)
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Steam/VDFParser.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/VDFParser.swift
@@ -189,21 +189,25 @@ public enum VDFParser {
                 return result
 
             case let .string(key):
-                guard let valueToken = try scanner.nextToken() else {
-                    throw VDFParseError.unexpectedEnd
-                }
-                switch valueToken {
-                case let .string(value):
-                    result[key.lowercased()] = .string(value)
-                case .openBrace:
-                    result[key.lowercased()] = try .object(parseObjectBody(&scanner, isTopLevel: false))
-                case .closeBrace:
-                    throw VDFParseError.unexpectedToken(line: scanner.line)
-                }
+                result[key.lowercased()] = try parseValue(&scanner)
 
             case .openBrace:
                 throw VDFParseError.unexpectedToken(line: scanner.line)
             }
+        }
+    }
+
+    private static func parseValue(_ scanner: inout Scanner) throws -> VDFValue {
+        guard let token = try scanner.nextToken() else {
+            throw VDFParseError.unexpectedEnd
+        }
+        switch token {
+        case let .string(value):
+            return .string(value)
+        case .openBrace:
+            return try .object(parseObjectBody(&scanner, isTopLevel: false))
+        case .closeBrace:
+            throw VDFParseError.unexpectedToken(line: scanner.line)
         }
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Steam/VDFParser.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/VDFParser.swift
@@ -1,0 +1,209 @@
+//
+//  VDFParser.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// A value in a parsed Valve Data Format (VDF) document: either a string or a
+/// nested key-value object.
+public enum VDFValue: Equatable, Sendable {
+    case string(String)
+    indirect case object([String: VDFValue])
+
+    /// The string content, or `nil` for objects.
+    public var stringValue: String? {
+        if case let .string(value) = self { return value }
+        return nil
+    }
+
+    /// The nested object, or `nil` for strings.
+    public var objectValue: [String: VDFValue]? {
+        if case let .object(value) = self { return value }
+        return nil
+    }
+
+    /// The string content converted to `Int`, or `nil`.
+    public var intValue: Int? {
+        stringValue.flatMap(Int.init)
+    }
+}
+
+/// Errors thrown by ``VDFParser``.
+public enum VDFParseError: LocalizedError, Equatable {
+    /// A token appeared where the grammar doesn't allow it.
+    case unexpectedToken(line: Int)
+    /// A quoted string reached the end of its line or the document unclosed.
+    case unterminatedString(line: Int)
+    /// The document ended inside an unclosed object.
+    case unexpectedEnd
+
+    public var errorDescription: String? {
+        switch self {
+        case let .unexpectedToken(line):
+            "Unexpected token at line \(line)"
+        case let .unterminatedString(line):
+            "Unterminated string at line \(line)"
+        case .unexpectedEnd:
+            "Unexpected end of document inside an unclosed object"
+        }
+    }
+}
+
+/// Parses the text flavor of Valve's KeyValues format ("VDF"), the format of
+/// Steam's `appmanifest_*.acf`, `libraryfolders.vdf`, and `config.vdf`.
+///
+/// Supported grammar: quoted keys, quoted string values, `{}` nesting,
+/// `\\` and `\"` escapes, and `//` line comments. Keys are lowercased on
+/// parse because Valve's own files are case-inconsistent (`"AppState"`,
+/// `"appid"`, `"StateFlags"`). Duplicate keys keep the last occurrence.
+/// Binary VDF is not supported.
+public enum VDFParser {
+    /// Parses a VDF document into its top-level key-value pairs.
+    ///
+    /// - Parameter text: The document text.
+    /// - Returns: The top-level object, typically a single key like
+    ///   `"appstate"` or `"libraryfolders"` mapping to a nested object.
+    /// - Throws: ``VDFParseError`` if the document is malformed.
+    public static func parse(_ text: String) throws -> [String: VDFValue] {
+        var scanner = Scanner(text: text)
+        return try parseObjectBody(&scanner, isTopLevel: true)
+    }
+
+    // MARK: - Tokenizer
+
+    private enum Token: Equatable {
+        case string(String)
+        case openBrace
+        case closeBrace
+    }
+
+    private struct Scanner {
+        let characters: [Character]
+        var index = 0
+        var line = 1
+
+        init(text: String) {
+            self.characters = Array(text)
+        }
+
+        mutating func skipWhitespaceAndComments() {
+            while index < characters.count {
+                let character = characters[index]
+                if character == "\n" {
+                    line += 1
+                    index += 1
+                } else if character.isWhitespace {
+                    index += 1
+                } else if character == "/", index + 1 < characters.count, characters[index + 1] == "/" {
+                    while index < characters.count, characters[index] != "\n" {
+                        index += 1
+                    }
+                } else {
+                    break
+                }
+            }
+        }
+
+        /// Returns the next token, or `nil` at end of document.
+        mutating func nextToken() throws -> Token? {
+            skipWhitespaceAndComments()
+            guard index < characters.count else { return nil }
+
+            switch characters[index] {
+            case "{":
+                index += 1
+                return .openBrace
+            case "}":
+                index += 1
+                return .closeBrace
+            case "\"":
+                return try .string(scanQuotedString())
+            default:
+                throw VDFParseError.unexpectedToken(line: line)
+            }
+        }
+
+        private mutating func scanQuotedString() throws -> String {
+            let startLine = line
+            index += 1 // consume the opening quote
+            var value = ""
+
+            while index < characters.count {
+                let character = characters[index]
+                switch character {
+                case "\"":
+                    index += 1
+                    return value
+                case "\\":
+                    // Escape: append the next character literally. This maps
+                    // \\ to \ and \" to " — the two escapes Valve emits.
+                    guard index + 1 < characters.count else {
+                        throw VDFParseError.unterminatedString(line: startLine)
+                    }
+                    value.append(characters[index + 1])
+                    index += 2
+                case "\n":
+                    throw VDFParseError.unterminatedString(line: startLine)
+                default:
+                    value.append(character)
+                    index += 1
+                }
+            }
+            throw VDFParseError.unterminatedString(line: startLine)
+        }
+    }
+
+    // MARK: - Parser
+
+    private static func parseObjectBody(
+        _ scanner: inout Scanner,
+        isTopLevel: Bool
+    ) throws -> [String: VDFValue] {
+        var result: [String: VDFValue] = [:]
+
+        while true {
+            guard let token = try scanner.nextToken() else {
+                if isTopLevel { return result }
+                throw VDFParseError.unexpectedEnd
+            }
+
+            switch token {
+            case .closeBrace:
+                if isTopLevel {
+                    throw VDFParseError.unexpectedToken(line: scanner.line)
+                }
+                return result
+
+            case let .string(key):
+                guard let valueToken = try scanner.nextToken() else {
+                    throw VDFParseError.unexpectedEnd
+                }
+                switch valueToken {
+                case let .string(value):
+                    result[key.lowercased()] = .string(value)
+                case .openBrace:
+                    result[key.lowercased()] = try .object(parseObjectBody(&scanner, isTopLevel: false))
+                case .closeBrace:
+                    throw VDFParseError.unexpectedToken(line: scanner.line)
+                }
+
+            case .openBrace:
+                throw VDFParseError.unexpectedToken(line: scanner.line)
+            }
+        }
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Wine/EnvironmentBuilder.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/EnvironmentBuilder.swift
@@ -30,15 +30,17 @@ import Foundation
 /// 2. ``platform`` -- macOS compatibility fixes
 /// 3. ``bottleManaged`` -- Toggles/presets Whisky owns (DXVK, Metal, sync, performance)
 /// 4. ``launcherManaged`` -- Launcher compatibility mode and detected overrides
-/// 5. ``bottleUser`` -- User-defined bottle-level environment variables
-/// 6. ``programUser`` -- Program settings environment variables and locale
-/// 7. ``featureRuntime`` -- Launch-time feature injectors (ClickOnce, one-off modes)
-/// 8. ``callsiteOverride`` -- Explicit overrides passed to `Wine.runProgram(environment:)`
+/// 5. ``gameProfile`` -- GameDB variant environment applied for a single launch
+/// 6. ``bottleUser`` -- User-defined bottle-level environment variables
+/// 7. ``programUser`` -- Program settings environment variables and locale
+/// 8. ``featureRuntime`` -- Launch-time feature injectors (ClickOnce, one-off modes)
+/// 9. ``callsiteOverride`` -- Explicit overrides passed to `Wine.runProgram(environment:)`
 public enum EnvironmentLayer: Int, CaseIterable, Comparable, Sendable, Hashable {
     case base = 0
     case platform
     case bottleManaged
     case launcherManaged
+    case gameProfile
     case bottleUser
     case programUser
     case featureRuntime

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -238,7 +238,8 @@ public class Wine {
     @MainActor
     public static func runProgram(
         at url: URL, args: [String] = [], bottle: Bottle, environment: [String: String] = [:],
-        programOverrides: ProgramOverrides? = nil, programSettings: ProgramSettings? = nil
+        programOverrides: ProgramOverrides? = nil, programSettings: ProgramSettings? = nil,
+        gameProfileEnvironment: [String: String] = [:]
     ) async throws -> ProgramRunResult {
         // Note: Launcher detection is handled at the app level (FileOpenView/BottleView)
         // before calling this method. The detection logic uses LauncherDetection utility
@@ -296,7 +297,7 @@ public class Wine {
 
         let wineEnvironment = constructWineEnvironment(
             for: bottle, environment: environment, programOverrides: programOverrides,
-            programSettings: programSettings
+            programSettings: programSettings, gameProfileEnvironment: gameProfileEnvironment
         )
 
         // Create a run log entry to track this session

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
@@ -45,7 +45,8 @@ extension Wine {
         for bottle: Bottle,
         environment: [String: String] = [:],
         programOverrides: ProgramOverrides? = nil,
-        programSettings: ProgramSettings? = nil
+        programSettings: ProgramSettings? = nil,
+        gameProfileEnvironment: [String: String] = [:]
     ) -> [String: String] {
         var builder = EnvironmentBuilder()
         var dllResolver = DLLOverrideResolver(managed: [], bottleCustom: [], programCustom: [])
@@ -90,9 +91,19 @@ extension Wine {
         // Input compatibility (bottleManaged layer -- input settings are bottle-managed toggles)
         bottle.settings.populateInputCompatibilityLayer(builder: &builder)
 
-        // Layer 5: Bottle user (empty for now -- no bottle-level custom env vars UI yet)
+        // Layer 5: Game profile -- GameDB variant environment for this launch.
+        // Beats bottle/launcher defaults, loses to anything the user set.
+        for (key, value) in gameProfileEnvironment {
+            if isValidEnvKey(key) {
+                builder.set(key, value, layer: .gameProfile, reason: "GameDB profile")
+            } else {
+                envLogger.debug("Skipping invalid game profile key '\(key)' in constructWineEnvironment")
+            }
+        }
 
-        // Layer 6: Program user (caller-provided environment dict, typically from Program.generateEnvironment())
+        // Layer 6: Bottle user (empty for now -- no bottle-level custom env vars UI yet)
+
+        // Layer 7: Program user (caller-provided environment dict, typically from Program.generateEnvironment())
         if !environment.isEmpty {
             for (key, value) in environment {
                 if isValidEnvKey(key) {
@@ -108,12 +119,12 @@ extension Wine {
             applyProgramOverrides(overrides, builder: &builder, dllResolver: &dllResolver)
         }
 
-        // Layer 7: featureRuntime -- diagnostic WINEDEBUG preset override
+        // Layer 8: featureRuntime -- diagnostic WINEDEBUG preset override
         if let preset = programSettings?.activeWineDebugPreset, preset != .normal {
             builder.set("WINEDEBUG", preset.winedebugValue, layer: .featureRuntime)
         }
 
-        // Layer 8: callsiteOverride is left empty (populated by direct callers)
+        // Layer 9: callsiteOverride is left empty (populated by direct callers)
 
         // Collect bottle custom DLL overrides for the resolver
         dllResolver.bottleCustom = bottle.settings.dllOverrides
@@ -322,6 +333,7 @@ extension Wine {
             case .platform: "platform"
             case .bottleManaged: "bottleManaged"
             case .launcherManaged: "launcherManaged"
+            case .gameProfile: "gameProfile"
             case .bottleUser: "bottleUser"
             case .programUser: "programUser"
             case .featureRuntime: "featureRuntime"

--- a/WhiskyKit/Tests/WhiskyKitTests/LaunchResolverTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/LaunchResolverTests.swift
@@ -1,0 +1,159 @@
+//
+//  LaunchResolverTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("GameProfile Layer Tests")
+struct GameProfileLayerTests {
+    @Test("Game profile beats launcher defaults, loses to user layers")
+    func layerOrdering() {
+        var builder = EnvironmentBuilder()
+
+        builder.set("SHARED", "launcher", layer: .launcherManaged)
+        builder.set("SHARED", "gamedb", layer: .gameProfile)
+        builder.set("USER_WINS", "gamedb", layer: .gameProfile)
+        builder.set("USER_WINS", "bottle-user", layer: .bottleUser)
+        builder.set("PROGRAM_WINS", "gamedb", layer: .gameProfile)
+        builder.set("PROGRAM_WINS", "program", layer: .programUser)
+
+        let (resolved, _) = builder.resolve()
+
+        #expect(resolved["SHARED"] == "gamedb")
+        #expect(resolved["USER_WINS"] == "bottle-user")
+        #expect(resolved["PROGRAM_WINS"] == "program")
+    }
+
+    @Test("constructWineEnvironment carries the game profile environment")
+    @MainActor func constructCarriesProfile() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let bottle = Bottle(bottleUrl: tempDir, inFlight: false, isAvailable: true)
+
+        let env = Wine.constructWineEnvironment(
+            for: bottle,
+            environment: ["CONTESTED": "program-user"],
+            gameProfileEnvironment: [
+                "GAME_PROFILE_ONLY": "1",
+                "CONTESTED": "gamedb",
+                "not a valid key!": "dropped",
+            ]
+        )
+
+        #expect(env["GAME_PROFILE_ONLY"] == "1")
+        #expect(env["CONTESTED"] == "program-user")
+        #expect(env["not a valid key!"] == nil)
+    }
+}
+
+@Suite("LaunchResolver Tests")
+struct LaunchResolverTests {
+    private func fixtureEntries() throws -> [GameDBEntry] {
+        let json = """
+        {
+            "version": 1,
+            "entries": [
+                {
+                    "id": "casualties-unknown-demo",
+                    "title": "Casualties: Unknown Demo",
+                    "rating": "unverified",
+                    "steamAppId": 4576510,
+                    "variants": [
+                        {
+                            "id": "recommended",
+                            "label": "Recommended",
+                            "isDefault": true,
+                            "settings": {
+                                "graphicsBackend": "dxvk",
+                                "dxvkAsync": true,
+                                "forceD3D11": false,
+                                "performancePreset": "unity"
+                            },
+                            "environmentVariables": {
+                                "DXVK_FRAME_RATE": "120"
+                            },
+                            "dllOverrides": []
+                        }
+                    ]
+                }
+            ]
+        }
+        """
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let url = tempDir.appending(path: "gamedb.json")
+        try Data(json.utf8).write(to: url)
+        return try GameDBLoader.loadEntries(from: url)
+    }
+
+    @Test("Plans from a GameDB match by App ID")
+    func plansFromMatch() throws {
+        let plan = try LaunchResolver.plan(steamAppId: 4_576_510, entries: fixtureEntries())
+
+        #expect(plan.overrides.graphicsBackend == .dxvk)
+        #expect(plan.overrides.dxvkAsync == true)
+        #expect(plan.overrides.forceD3D11 == false)
+        #expect(plan.overrides.performancePreset == .unity)
+        #expect(plan.gameProfileEnvironment["DXVK_FRAME_RATE"] == "120")
+        #expect(plan.provenance.count == 1)
+        #expect(plan.provenance[0].contains("Casualties: Unknown Demo"))
+    }
+
+    @Test("User overrides win over GameDB fields")
+    func userOverridesWin() throws {
+        var user = ProgramOverrides()
+        user.graphicsBackend = .dxmt
+        user.dxvkAsync = false
+
+        let plan = try LaunchResolver.plan(
+            steamAppId: 4_576_510, userOverrides: user, entries: fixtureEntries()
+        )
+
+        #expect(plan.overrides.graphicsBackend == .dxmt)
+        #expect(plan.overrides.dxvkAsync == false)
+        // Fields the user left unset still come from the variant
+        #expect(plan.overrides.performancePreset == .unity)
+    }
+
+    @Test("No match passes user overrides through untouched")
+    func noMatchPassthrough() throws {
+        var user = ProgramOverrides()
+        user.graphicsBackend = .wined3d
+
+        let plan = try LaunchResolver.plan(
+            steamAppId: 1, userOverrides: user, entries: fixtureEntries()
+        )
+
+        #expect(plan.overrides.graphicsBackend == .wined3d)
+        #expect(plan.gameProfileEnvironment.isEmpty)
+        #expect(plan.provenance.isEmpty)
+    }
+
+    @Test("No match and no user overrides yields an empty plan")
+    func emptyPlan() throws {
+        let plan = try LaunchResolver.plan(steamAppId: 1, entries: fixtureEntries())
+
+        #expect(plan.overrides.isEmpty)
+        #expect(plan.gameProfileEnvironment.isEmpty)
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/LaunchResolverTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/LaunchResolverTests.swift
@@ -54,7 +54,7 @@ struct GameProfileLayerTests {
             gameProfileEnvironment: [
                 "GAME_PROFILE_ONLY": "1",
                 "CONTESTED": "gamedb",
-                "not a valid key!": "dropped",
+                "not a valid key!": "dropped"
             ]
         )
 

--- a/WhiskyKit/Tests/WhiskyKitTests/SteamLibraryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamLibraryTests.swift
@@ -144,28 +144,7 @@ struct SteamLibraryTests {
         try Data(acf(appId: 777, name: "Ghost Game", installDir: "Ghost", stateFlags: 4).utf8)
             .write(to: steamApps.appending(path: "appmanifest_777.acf"))
 
-        // Second library on D:, reached through the dosdevices symlink
-        let secondLibrary = tempRoot.appending(path: "second-library")
-        let secondApps = secondLibrary.appending(path: "steamapps")
-        try fileManager.createDirectory(
-            at: secondApps.appending(path: "common").appending(path: "ELDEN RING"),
-            withIntermediateDirectories: true
-        )
-        try Data(acf(appId: 1_245_620, name: "ELDEN RING", installDir: "ELDEN RING", stateFlags: 4).utf8)
-            .write(to: secondApps.appending(path: "appmanifest_1245620.acf"))
-
-        // Duplicate App ID in the second library: first discovery wins
-        try Data(acf(
-            appId: 4_576_510, name: "Casualties Duplicate",
-            installDir: "ELDEN RING", stateFlags: 4
-        ).utf8).write(to: secondApps.appending(path: "appmanifest_dup.acf"))
-
-        let dosDevices = bottle.appending(path: "dosdevices")
-        try fileManager.createDirectory(at: dosDevices, withIntermediateDirectories: true)
-        try fileManager.createSymbolicLink(
-            at: dosDevices.appending(path: "d:"),
-            withDestinationURL: secondLibrary
-        )
+        try makeSecondLibrary(tempRoot: tempRoot, bottle: bottle)
 
         let config = steamRoot.appending(path: "config")
         try fileManager.createDirectory(at: config, withIntermediateDirectories: true)
@@ -185,6 +164,32 @@ struct SteamLibraryTests {
         try Data(vdf.utf8).write(to: config.appending(path: "libraryfolders.vdf"))
 
         return (bottle, tempRoot)
+    }
+
+    /// A second library on D: reached through the dosdevices symlink, holding
+    /// another installed game plus a duplicate of the first library's App ID.
+    private func makeSecondLibrary(tempRoot: URL, bottle: URL) throws {
+        let fileManager = FileManager.default
+        let secondLibrary = tempRoot.appending(path: "second-library")
+        let secondApps = secondLibrary.appending(path: "steamapps")
+        try fileManager.createDirectory(
+            at: secondApps.appending(path: "common").appending(path: "ELDEN RING"),
+            withIntermediateDirectories: true
+        )
+        try Data(acf(appId: 1_245_620, name: "ELDEN RING", installDir: "ELDEN RING", stateFlags: 4).utf8)
+            .write(to: secondApps.appending(path: "appmanifest_1245620.acf"))
+
+        try Data(acf(
+            appId: 4_576_510, name: "Casualties Duplicate",
+            installDir: "ELDEN RING", stateFlags: 4
+        ).utf8).write(to: secondApps.appending(path: "appmanifest_dup.acf"))
+
+        let dosDevices = bottle.appending(path: "dosdevices")
+        try fileManager.createDirectory(at: dosDevices, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(
+            at: dosDevices.appending(path: "d:"),
+            withDestinationURL: secondLibrary
+        )
     }
 
     @Test("Detects a Steam install")

--- a/WhiskyKit/Tests/WhiskyKitTests/SteamLibraryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamLibraryTests.swift
@@ -228,6 +228,24 @@ struct SteamLibraryTests {
         #expect(!games.contains { $0.appId == 999 || $0.appId == 777 })
     }
 
+    @Test("Collects executable names at root and one level deep")
+    func collectsExecutableNames() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let bin = tempDir.appending(path: "bin")
+        let deep = tempDir.appending(path: "bin").appending(path: "too-deep")
+        try FileManager.default.createDirectory(at: deep, withIntermediateDirectories: true)
+
+        try Data().write(to: tempDir.appending(path: "Game.exe"))
+        try Data().write(to: tempDir.appending(path: "readme.txt"))
+        try Data().write(to: bin.appending(path: "Helper.EXE"))
+        try Data().write(to: deep.appending(path: "ignored.exe"))
+
+        let names = SteamLibrary.executableNames(under: tempDir)
+
+        #expect(names == ["game.exe", "helper.exe"])
+    }
+
     @Test("Maps Windows paths through the prefix")
     func mapsWindowsPaths() {
         let bottle = URL(fileURLWithPath: "/tmp/bottle")

--- a/WhiskyKit/Tests/WhiskyKitTests/SteamLibraryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamLibraryTests.swift
@@ -1,0 +1,242 @@
+//
+//  SteamLibraryTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+private func acf(appId: Int, name: String, installDir: String, stateFlags: Int) -> String {
+    """
+    "AppState"
+    {
+        "appid"        "\(appId)"
+        "name"        "\(name)"
+        "installdir"        "\(installDir)"
+        "StateFlags"        "\(stateFlags)"
+        "buildid"        "1785187029"
+        "SizeOnDisk"        "541968407"
+    }
+    """
+}
+
+@Suite("SteamAppManifest Tests")
+struct SteamAppManifestTests {
+    @Test("Parses a full manifest file")
+    func parsesFullManifest() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let url = tempDir.appending(path: "appmanifest_4576510.acf")
+        try Data(acf(
+            appId: 4_576_510, name: "Casualties: Unknown Demo",
+            installDir: "Casualties Unknown Demo", stateFlags: 4
+        ).utf8).write(to: url)
+
+        let manifest = try #require(SteamAppManifest(contentsOf: url))
+
+        #expect(manifest.appId == 4_576_510)
+        #expect(manifest.name == "Casualties: Unknown Demo")
+        #expect(manifest.installDir == "Casualties Unknown Demo")
+        #expect(manifest.stateFlags == 4)
+        #expect(manifest.buildID == 1_785_187_029)
+        #expect(manifest.sizeOnDisk == 541_968_407)
+        #expect(manifest.isFullyInstalled)
+    }
+
+    @Test("Downloading state is not fully installed")
+    func downloadingNotInstalled() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let url = tempDir.appending(path: "appmanifest_999.acf")
+        try Data(acf(appId: 999, name: "Downloading", installDir: "dl", stateFlags: 2).utf8)
+            .write(to: url)
+
+        let manifest = try #require(SteamAppManifest(contentsOf: url))
+        #expect(!manifest.isFullyInstalled)
+    }
+
+    @Test("Returns nil for missing required fields or garbage")
+    func returnsNilForBadInput() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let noName = tempDir.appending(path: "noname.acf")
+        try Data("\"AppState\" { \"appid\" \"1\" \"installdir\" \"x\" }".utf8).write(to: noName)
+        #expect(SteamAppManifest(contentsOf: noName) == nil)
+
+        let garbage = tempDir.appending(path: "garbage.acf")
+        try Data("not vdf at all".utf8).write(to: garbage)
+        #expect(SteamAppManifest(contentsOf: garbage) == nil)
+
+        #expect(SteamAppManifest(contentsOf: tempDir.appending(path: "missing.acf")) == nil)
+    }
+
+    @Test("Legacy parseAppId fast path still works")
+    func parseAppIdCompat() {
+        let text = acf(appId: 1_245_620, name: "ELDEN RING", installDir: "ELDEN RING", stateFlags: 4)
+        #expect(SteamAppManifest.parseAppId(from: text) == 1_245_620)
+        #expect(SteamAppManifest.parseAppId(from: "no appid here") == nil)
+    }
+
+    @Test("findAppIdForProgram walks parent directories")
+    func findsAppIdNearExe() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let exeDir = tempDir.appending(path: "game").appending(path: "bin")
+        try FileManager.default.createDirectory(at: exeDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        try Data("4576510\n".utf8).write(to: tempDir.appending(path: "game").appending(path: "steam_appid.txt"))
+
+        let found = SteamAppManifest.findAppIdForProgram(at: exeDir.appending(path: "game.exe"))
+        #expect(found == 4_576_510)
+    }
+}
+
+@Suite("SteamLibrary Tests")
+struct SteamLibraryTests {
+    /// Builds a fixture bottle: a default Steam install with one installed
+    /// game, one downloading game, one manifest whose install dir is missing,
+    /// plus a second library on D: (via dosdevices symlink) with another
+    /// installed game and a duplicate of the first game's App ID.
+    private func makeFixtureBottle() throws -> (bottle: URL, tempRoot: URL) {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appending(path: "steamlib_\(UUID().uuidString)")
+        let bottle = tempRoot.appending(path: "bottle")
+        let steamRoot = bottle.appending(path: "drive_c")
+            .appending(path: "Program Files (x86)").appending(path: "Steam")
+        let steamApps = steamRoot.appending(path: "steamapps")
+
+        try fileManager.createDirectory(
+            at: steamApps.appending(path: "common").appending(path: "Casualties Unknown Demo"),
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: steamRoot.appending(path: "steam.exe"))
+
+        try Data(acf(
+            appId: 4_576_510, name: "Casualties: Unknown Demo",
+            installDir: "Casualties Unknown Demo", stateFlags: 4
+        ).utf8).write(to: steamApps.appending(path: "appmanifest_4576510.acf"))
+
+        // Downloading: filtered by state
+        try Data(acf(appId: 999, name: "Downloading Game", installDir: "dl", stateFlags: 2).utf8)
+            .write(to: steamApps.appending(path: "appmanifest_999.acf"))
+
+        // Claims installed but common dir is missing: filtered
+        try Data(acf(appId: 777, name: "Ghost Game", installDir: "Ghost", stateFlags: 4).utf8)
+            .write(to: steamApps.appending(path: "appmanifest_777.acf"))
+
+        // Second library on D:, reached through the dosdevices symlink
+        let secondLibrary = tempRoot.appending(path: "second-library")
+        let secondApps = secondLibrary.appending(path: "steamapps")
+        try fileManager.createDirectory(
+            at: secondApps.appending(path: "common").appending(path: "ELDEN RING"),
+            withIntermediateDirectories: true
+        )
+        try Data(acf(appId: 1_245_620, name: "ELDEN RING", installDir: "ELDEN RING", stateFlags: 4).utf8)
+            .write(to: secondApps.appending(path: "appmanifest_1245620.acf"))
+
+        // Duplicate App ID in the second library: first discovery wins
+        try Data(acf(
+            appId: 4_576_510, name: "Casualties Duplicate",
+            installDir: "ELDEN RING", stateFlags: 4
+        ).utf8).write(to: secondApps.appending(path: "appmanifest_dup.acf"))
+
+        let dosDevices = bottle.appending(path: "dosdevices")
+        try fileManager.createDirectory(at: dosDevices, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(
+            at: dosDevices.appending(path: "d:"),
+            withDestinationURL: secondLibrary
+        )
+
+        let config = steamRoot.appending(path: "config")
+        try fileManager.createDirectory(at: config, withIntermediateDirectories: true)
+        let vdf = """
+        "libraryfolders"
+        {
+            "0"
+            {
+                "path"        "C:\\\\Program Files (x86)\\\\Steam"
+            }
+            "1"
+            {
+                "path"        "D:\\\\"
+            }
+        }
+        """
+        try Data(vdf.utf8).write(to: config.appending(path: "libraryfolders.vdf"))
+
+        return (bottle, tempRoot)
+    }
+
+    @Test("Detects a Steam install")
+    func detectsInstall() throws {
+        let (bottle, tempRoot) = try makeFixtureBottle()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let root = try #require(SteamLibrary.detectInstall(bottleURL: bottle))
+        #expect(root.lastPathComponent == "Steam")
+    }
+
+    @Test("Returns nil for a bottle without Steam")
+    func noSteamNoInstall() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: tempDir.appending(path: "drive_c"), withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        #expect(SteamLibrary.detectInstall(bottleURL: tempDir) == nil)
+        #expect(SteamLibrary.enumerate(bottleURL: tempDir).isEmpty)
+    }
+
+    @Test("Enumerates installed games across libraries, filtered and sorted")
+    func enumeratesAcrossLibraries() throws {
+        let (bottle, tempRoot) = try makeFixtureBottle()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let games = SteamLibrary.enumerate(bottleURL: bottle)
+
+        #expect(games.map(\.appId) == [4_576_510, 1_245_620])
+        #expect(games.map(\.name) == ["Casualties: Unknown Demo", "ELDEN RING"])
+        // The duplicate App ID in the second library lost to the first discovery
+        #expect(games[0].name != "Casualties Duplicate")
+        // Downloading (999) and missing-install-dir (777) games are filtered
+        #expect(!games.contains { $0.appId == 999 || $0.appId == 777 })
+    }
+
+    @Test("Maps Windows paths through the prefix")
+    func mapsWindowsPaths() {
+        let bottle = URL(fileURLWithPath: "/tmp/bottle")
+
+        let cPath = SteamLibrary.mapWindowsPath(#"C:\Program Files (x86)\Steam"#, bottleURL: bottle)
+        #expect(cPath?.path == "/tmp/bottle/drive_c/Program Files (x86)/Steam")
+
+        let dPath = SteamLibrary.mapWindowsPath(#"D:\SteamLibrary"#, bottleURL: bottle)
+        #expect(dPath?.path == "/tmp/bottle/dosdevices/d:/SteamLibrary")
+
+        let driveOnly = SteamLibrary.mapWindowsPath(#"D:\"#, bottleURL: bottle)
+        #expect(driveOnly?.path == "/tmp/bottle/dosdevices/d:")
+
+        #expect(SteamLibrary.mapWindowsPath("not a path", bottleURL: bottle) == nil)
+        #expect(SteamLibrary.mapWindowsPath("", bottleURL: bottle) == nil)
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/SteamLibraryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamLibraryTests.swift
@@ -262,4 +262,61 @@ struct SteamLibraryTests {
         #expect(SteamLibrary.mapWindowsPath("not a path", bottleURL: bottle) == nil)
         #expect(SteamLibrary.mapWindowsPath("", bottleURL: bottle) == nil)
     }
+
+    @Test("Library paths that would escape the prefix are rejected")
+    func rejectsTraversingLibraryPaths() {
+        let bottle = URL(fileURLWithPath: "/tmp/bottle")
+
+        #expect(SteamLibrary.mapWindowsPath(#"D:\..\..\..\etc"#, bottleURL: bottle) == nil)
+        #expect(SteamLibrary.mapWindowsPath(#"C:\Steam\..\..\Library"#, bottleURL: bottle) == nil)
+        #expect(SteamLibrary.mapWindowsPath(#"D:\Games\."#, bottleURL: bottle) == nil)
+    }
+
+    @Test("A manifest whose installdir escapes the library is skipped")
+    func rejectsTraversingInstallDir() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let steamRoot = tempDir.appending(path: "drive_c").appending(path: "Program Files (x86)")
+            .appending(path: "Steam")
+        let steamApps = steamRoot.appending(path: "steamapps")
+        try FileManager.default.createDirectory(at: steamApps, withIntermediateDirectories: true)
+        try Data().write(to: steamRoot.appending(path: "steam.exe"))
+
+        // The escape target exists, so only the component check can reject this.
+        let outside = tempDir.appending(path: "outside")
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+
+        try Data(acf(
+            appId: 4_576_510, name: "Escaper", installDir: "../../../outside", stateFlags: 4
+        ).utf8).write(to: steamApps.appending(path: "appmanifest_4576510.acf"))
+
+        #expect(SteamLibrary.enumerate(bottleURL: tempDir).isEmpty)
+    }
+
+    @Test("Preferred overrides come from the shallowest executable that has any")
+    func picksPreferredOverrides() {
+        var deep = ProgramOverrides()
+        deep.dxvk = true
+        var shallow = ProgramOverrides()
+        shallow.forceD3D11 = true
+
+        let candidates = [
+            ProgramOverrideCandidate(url: URL(fileURLWithPath: "/g/bin/Helper.exe"), overrides: deep),
+            ProgramOverrideCandidate(url: URL(fileURLWithPath: "/g/Game.exe"), overrides: shallow),
+            ProgramOverrideCandidate(url: URL(fileURLWithPath: "/g/Aardvark.exe"), overrides: ProgramOverrides())
+        ]
+
+        #expect(SteamLibrary.preferredOverrides(among: candidates) == shallow)
+    }
+
+    @Test("Preferred overrides are nil when no executable carries any")
+    func picksNoOverrides() {
+        let candidates = [
+            ProgramOverrideCandidate(url: URL(fileURLWithPath: "/g/Game.exe"), overrides: ProgramOverrides())
+        ]
+
+        #expect(SteamLibrary.preferredOverrides(among: candidates) == nil)
+        #expect(SteamLibrary.preferredOverrides(among: []) == nil)
+    }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/SteamProcessWatchTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamProcessWatchTests.swift
@@ -1,0 +1,92 @@
+//
+//  SteamProcessWatchTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+/// Scripts the process-list responses, returning each set once and the last
+/// set forever after.
+private actor ProcessScript {
+    private var responses: [Set<String>]
+
+    init(_ responses: [Set<String>]) {
+        self.responses = responses
+    }
+
+    func next() -> Set<String> {
+        responses.count > 1 ? responses.removeFirst() : responses.first ?? []
+    }
+}
+
+@Suite("SteamProcessWatch Tests")
+struct SteamProcessWatchTests {
+    private func makeWatch(
+        responses: [Set<String>],
+        pollInterval: Duration = .milliseconds(5)
+    ) -> SteamProcessWatch {
+        let script = ProcessScript(responses)
+        return SteamProcessWatch(pollInterval: pollInterval) {
+            await script.next()
+        }
+    }
+
+    @Test("Reports true when the process appears before the timeout")
+    func appearsBeforeTimeout() async {
+        let watch = makeWatch(responses: [[], [], ["steam.exe", "svchost.exe"]])
+
+        let found = await watch.waitForAny(of: ["steam.exe"], timeout: 1)
+
+        #expect(found)
+    }
+
+    @Test("Times out when the process never appears")
+    func timesOut() async {
+        let watch = makeWatch(responses: [["svchost.exe"]])
+
+        let found = await watch.waitForAny(of: ["game.exe"], timeout: 0.05)
+
+        #expect(!found)
+    }
+
+    @Test("Empty name set has nothing to wait for")
+    func emptyNames() async {
+        let watch = makeWatch(responses: [[]])
+
+        #expect(await watch.waitForAny(of: [], timeout: 0))
+    }
+
+    @Test("Checks at least once even with a zero timeout")
+    func zeroTimeoutStillChecks() async {
+        let watch = makeWatch(responses: [["game.exe"]])
+
+        #expect(await watch.waitForAny(of: ["game.exe"], timeout: 0))
+    }
+
+    @Test("Maps running processes back to their keys")
+    func mapsRunningKeys() async {
+        let watch = makeWatch(responses: [["casualtiesunknown.exe", "steam.exe"]])
+
+        let running = await watch.runningKeys(byExecutables: [
+            4_576_510: ["casualtiesunknown.exe"],
+            1_245_620: ["eldenring.exe"]
+        ])
+
+        #expect(running == [4_576_510])
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/VDFParserTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/VDFParserTests.swift
@@ -142,6 +142,19 @@ struct VDFParserTests {
         #expect(try VDFParser.parse("// only a comment\n").isEmpty)
     }
 
+    // MARK: - Accessors
+
+    @Test("Accessors return nil for mismatched kinds")
+    func accessorsMismatch() {
+        let string = VDFValue.string("text")
+        let object = VDFValue.object([:])
+
+        #expect(string.objectValue == nil)
+        #expect(string.intValue == nil)
+        #expect(object.stringValue == nil)
+        #expect(object.intValue == nil)
+    }
+
     // MARK: - Malformed input
 
     @Test("Throws on unclosed object")
@@ -177,5 +190,33 @@ struct VDFParserTests {
         #expect(throws: VDFParseError.unexpectedEnd) {
             try VDFParser.parse("\"lonely\"")
         }
+    }
+
+    @Test("Throws on escape at end of document")
+    func throwsOnTrailingEscape() {
+        #expect(throws: VDFParseError.unterminatedString(line: 1)) {
+            try VDFParser.parse("\"key\" \"value\\")
+        }
+    }
+
+    @Test("Throws on object opening without a key")
+    func throwsOnBraceWithoutKey() {
+        #expect(throws: VDFParseError.unexpectedToken(line: 1)) {
+            try VDFParser.parse("{ \"a\" \"b\" }")
+        }
+    }
+
+    @Test("Errors carry descriptions")
+    func errorsCarryDescriptions() {
+        #expect(
+            VDFParseError.unexpectedToken(line: 3).errorDescription == "Unexpected token at line 3"
+        )
+        #expect(
+            VDFParseError.unterminatedString(line: 7).errorDescription == "Unterminated string at line 7"
+        )
+        #expect(
+            VDFParseError.unexpectedEnd.errorDescription
+                == "Unexpected end of document inside an unclosed object"
+        )
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/VDFParserTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/VDFParserTests.swift
@@ -1,0 +1,181 @@
+//
+//  VDFParserTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("VDFParser Tests")
+struct VDFParserTests {
+    // MARK: - Real-world shapes
+
+    @Test("Parses an app manifest")
+    func parsesAppManifest() throws {
+        let acf = """
+        "AppState"
+        {
+            "appid"        "4576510"
+            "name"        "Casualties: Unknown Demo"
+            "installdir"        "Casualties Unknown Demo"
+            "StateFlags"        "4"
+            "buildid"        "1785187029"
+            "SizeOnDisk"        "541968407"
+        }
+        """
+
+        let root = try VDFParser.parse(acf)
+        let appState = try #require(root["appstate"]?.objectValue)
+
+        #expect(appState["appid"]?.intValue == 4_576_510)
+        #expect(appState["name"]?.stringValue == "Casualties: Unknown Demo")
+        #expect(appState["installdir"]?.stringValue == "Casualties Unknown Demo")
+        #expect(appState["stateflags"]?.intValue == 4)
+        #expect(appState["sizeondisk"]?.intValue == 541_968_407)
+    }
+
+    @Test("Parses libraryfolders with multiple libraries")
+    func parsesLibraryFolders() throws {
+        let vdf = """
+        "libraryfolders"
+        {
+            "0"
+            {
+                "path"        "C:\\\\Program Files (x86)\\\\Steam"
+                "apps"
+                {
+                    "4576510"        "541968407"
+                }
+            }
+            "1"
+            {
+                "path"        "D:\\\\SteamLibrary"
+                "apps"
+                {
+                    "1245620"        "49061246523"
+                }
+            }
+        }
+        """
+
+        let root = try VDFParser.parse(vdf)
+        let folders = try #require(root["libraryfolders"]?.objectValue)
+
+        let first = try #require(folders["0"]?.objectValue)
+        #expect(first["path"]?.stringValue == "C:\\Program Files (x86)\\Steam")
+        #expect(first["apps"]?.objectValue?["4576510"]?.intValue == 541_968_407)
+
+        let second = try #require(folders["1"]?.objectValue)
+        #expect(second["path"]?.stringValue == "D:\\SteamLibrary")
+        #expect(second["apps"]?.objectValue?.count == 1)
+    }
+
+    // MARK: - Grammar details
+
+    @Test("Lowercases keys but preserves value case")
+    func lowercasesKeysOnly() throws {
+        let root = try VDFParser.parse("\"AppState\"  \"Mixed Case Value\"")
+
+        #expect(root["appstate"]?.stringValue == "Mixed Case Value")
+        #expect(root["AppState"] == nil)
+    }
+
+    @Test("Handles escaped quotes and backslashes")
+    func handlesEscapes() throws {
+        let root = try VDFParser.parse(#""name"  "a \"quoted\" path\\here""#)
+
+        #expect(root["name"]?.stringValue == #"a "quoted" path\here"#)
+    }
+
+    @Test("Skips line comments")
+    func skipsComments() throws {
+        let vdf = """
+        // header comment
+        "key"        "value" // trailing comment
+        "other"        "thing"
+        """
+
+        let root = try VDFParser.parse(vdf)
+
+        #expect(root["key"]?.stringValue == "value")
+        #expect(root["other"]?.stringValue == "thing")
+    }
+
+    @Test("Handles CRLF line endings")
+    func handlesCRLF() throws {
+        let root = try VDFParser.parse("\"a\"\r\n{\r\n\"b\"\t\"c\"\r\n}\r\n")
+
+        #expect(root["a"]?.objectValue?["b"]?.stringValue == "c")
+    }
+
+    @Test("Parses an empty object")
+    func parsesEmptyObject() throws {
+        let root = try VDFParser.parse("\"apps\" {}")
+
+        #expect(root["apps"]?.objectValue?.isEmpty == true)
+    }
+
+    @Test("Duplicate keys keep the last occurrence")
+    func duplicateKeysLastWins() throws {
+        let root = try VDFParser.parse("\"key\" \"first\"\n\"key\" \"second\"")
+
+        #expect(root["key"]?.stringValue == "second")
+    }
+
+    @Test("Parses an empty document")
+    func parsesEmptyDocument() throws {
+        #expect(try VDFParser.parse("").isEmpty)
+        #expect(try VDFParser.parse("// only a comment\n").isEmpty)
+    }
+
+    // MARK: - Malformed input
+
+    @Test("Throws on unclosed object")
+    func throwsOnUnclosedObject() {
+        #expect(throws: VDFParseError.unexpectedEnd) {
+            try VDFParser.parse("\"root\" { \"key\" \"value\"")
+        }
+    }
+
+    @Test("Throws on unterminated string with its line")
+    func throwsOnUnterminatedString() {
+        #expect(throws: VDFParseError.unterminatedString(line: 2)) {
+            try VDFParser.parse("\"a\" \"b\"\n\"unclosed")
+        }
+    }
+
+    @Test("Throws on bare token with its line")
+    func throwsOnBareToken() {
+        #expect(throws: VDFParseError.unexpectedToken(line: 1)) {
+            try VDFParser.parse("bare")
+        }
+    }
+
+    @Test("Throws on stray closing brace at top level")
+    func throwsOnStrayClosingBrace() {
+        #expect(throws: VDFParseError.self) {
+            try VDFParser.parse("\"a\" \"b\" }")
+        }
+    }
+
+    @Test("Throws on key without a value")
+    func throwsOnKeyWithoutValue() {
+        #expect(throws: VDFParseError.unexpectedEnd) {
+            try VDFParser.parse("\"lonely\"")
+        }
+    }
+}


### PR DESCRIPTION
phase 1 of #158. supersedes #157 and #159, both folded in here as their own commits.

bottles with steam installed get a games list: open it, see your installed games, hit play, the game starts with its gamedb config applied and the client stays out of the way.

what's in it:

- **vdf parser** for the keyvalues format (acf, libraryfolders.vdf), replacing line scraping for single keys
- **SteamAppManifest v2 + SteamLibrary**: full manifest fields, enumeration across every library in libraryfolders.vdf, windows paths mapped through drive_c and dosdevices, uninstalled and ghost entries filtered
- **gameProfile env layer + LaunchResolver**: gamedb variants become per launch overrides instead of bottle wide mutations, and variant env vars finally reach the launch env through a layer that beats bottle/launcher defaults and loses to anything user set
- **SteamClientOrchestrator**: brings the client up silently if needed (launcher compat env applied first), fires `-applaunch`, then watches the process list for the game's own exe. neither invocation is awaited since the client owns the session, and the wait carries a 120s grace for shader precompilation (same value lutris landed on for this exact problem)
- **games list ui** in BottleView behind a steam detection gate kept out of body evaluation, with running status polled from the process list so games started outside whisky show up too, plus download and stall badges from SteamDownloadMonitor, which was dead code until now

tested: full kit suite green locally (1167 xctest + 56 swift-testing), app target builds, and the library section lists and launches a real game in a real bottle here. swiftformat clean.

not in scope, happy to discuss separately: per game identity and routing, whisky:// scheme, steam_appid.txt direct launch without the client.