### PR TITLE
fix: key program settings by path identity, not filename

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Program.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Program.swift
@@ -16,6 +16,7 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
+import CryptoKit
 import Foundation
 import os.log
 import SwiftUI
@@ -155,6 +156,53 @@ public final class Program: ObservableObject, Equatable, Hashable, Identifiable 
         self.init(url: url, bottle: bottle, peFile: try? PEFile(url: url))
     }
 
+    /// The settings file for a program, keyed by the executable's
+    /// bottle-relative path so two programs sharing a filename
+    /// (the classic `Launch.exe` case) never collide. The name keeps the
+    /// executable's stem for readability: `Launch-3fa2b1c9.plist`.
+    ///
+    /// Legacy filename-keyed settings are migrated by copying (never moving)
+    /// the old plist to the identity-keyed name on first load, so downgrading
+    /// loses nothing.
+    static func settingsURL(for url: URL, in bottle: Bottle, legacyName: String) -> URL {
+        let settingsFolder = bottle.url.appending(path: "Program Settings")
+        try? FileManager.default.createDirectory(at: settingsFolder, withIntermediateDirectories: true)
+        let identityURL = settingsFolder
+            .appending(path: settingsIdentity(for: url, bottleURL: bottle.url))
+            .appendingPathExtension("plist")
+        let legacyURL = settingsFolder.appending(path: legacyName).appendingPathExtension("plist")
+
+        let fileManager = FileManager.default
+        if !fileManager.fileExists(atPath: identityURL.path(percentEncoded: false)),
+           fileManager.fileExists(atPath: legacyURL.path(percentEncoded: false)) {
+            do {
+                try fileManager.copyItem(at: legacyURL, to: identityURL)
+            } catch {
+                Logger.wineKit.error(
+                    "Failed to migrate settings for `\(legacyName)`: \(error.localizedDescription)"
+                )
+            }
+        }
+        return identityURL
+    }
+
+    /// A stable identity for a program: the executable's stem plus a short
+    /// hash of its bottle-relative path. Stable across bottle moves (the
+    /// relative path doesn't change) and across game updates (file contents
+    /// don't participate).
+    nonisolated static func settingsIdentity(for url: URL, bottleURL: URL) -> String {
+        let bottlePath = bottleURL.standardizedFileURL.path
+        let fullPath = url.standardizedFileURL.path
+        let relativePath = fullPath.hasPrefix(bottlePath)
+            ? String(fullPath.dropFirst(bottlePath.count))
+            : fullPath
+
+        let digest = SHA256.hash(data: Data(relativePath.utf8))
+        let shortHash = digest.prefix(4).map { String(format: "%02x", $0) }.joined()
+        let stem = url.deletingPathExtension().lastPathComponent
+        return "\(stem)-\(shortHash)"
+    }
+
     /// Creates a new program instance from an already-parsed PE file.
     ///
     /// Use this when the PE file was parsed off the main actor (e.g. during a
@@ -174,17 +222,10 @@ public final class Program: ObservableObject, Equatable, Hashable, Identifiable 
         self._displayName = nil
         self.pinned = bottle.settings.pins.contains(where: { $0.url == url })
 
-        // Warning: This will break if two programs share the same name such as "Launch.exe"
-        // Best to add some sort of UUID in the path or file
-        let settingsFolder = bottle.url.appending(path: "Program Settings")
-        let settingsUrl = settingsFolder.appending(path: name).appendingPathExtension("plist")
+        let settingsUrl = Self.settingsURL(for: url, in: bottle, legacyName: name)
         self.settingsURL = settingsUrl
 
         do {
-            if !FileManager.default.fileExists(atPath: settingsFolder.path(percentEncoded: false)) {
-                try FileManager.default.createDirectory(at: settingsFolder, withIntermediateDirectories: true)
-            }
-
             self.settings = try ProgramSettings.decode(from: settingsUrl)
         } catch {
             Logger.wineKit.error(
@@ -216,15 +257,10 @@ public final class Program: ObservableObject, Equatable, Hashable, Identifiable 
         self.pinned = bottle.settings.pins.contains(where: { $0.url == appRefURL })
         self.peFile = nil
 
-        let settingsFolder = bottle.url.appending(path: "Program Settings")
-        let settingsUrl = settingsFolder.appending(path: displayName).appendingPathExtension("plist")
+        let settingsUrl = Self.settingsURL(for: appRefURL, in: bottle, legacyName: displayName)
         self.settingsURL = settingsUrl
 
         do {
-            if !FileManager.default.fileExists(atPath: settingsFolder.path(percentEncoded: false)) {
-                try FileManager.default.createDirectory(at: settingsFolder, withIntermediateDirectories: true)
-            }
-
             self.settings = try ProgramSettings.decode(from: settingsUrl)
         } catch {
             Logger.wineKit.error(

--- a/WhiskyKit/Tests/WhiskyKitTests/ProgramSettingsIdentityTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ProgramSettingsIdentityTests.swift
@@ -1,0 +1,125 @@
+//
+//  ProgramSettingsIdentityTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("Program Settings Identity Tests")
+struct ProgramSettingsIdentityTests {
+    private func makeBottle() throws -> (bottle: URL, cleanup: () -> Void) {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: tempDir.appending(path: "drive_c"), withIntermediateDirectories: true
+        )
+        return (tempDir, { try? FileManager.default.removeItem(at: tempDir) })
+    }
+
+    private func makeExe(at path: String, in bottleURL: URL) throws -> URL {
+        let url = bottleURL.appending(path: path)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try Data("MZ".utf8).write(to: url)
+        return url
+    }
+
+    @Test("Two programs named Launch.exe get separate settings")
+    @MainActor func launchExeCollision() throws {
+        let (bottleURL, cleanup) = try makeBottle()
+        defer { cleanup() }
+        let bottle = Bottle(bottleUrl: bottleURL, inFlight: false, isAvailable: true)
+
+        let first = try makeExe(at: "drive_c/GameA/Launch.exe", in: bottleURL)
+        let second = try makeExe(at: "drive_c/GameB/Launch.exe", in: bottleURL)
+
+        let firstProgram = Program(url: first, bottle: bottle, peFile: nil)
+        let secondProgram = Program(url: second, bottle: bottle, peFile: nil)
+
+        #expect(firstProgram.settingsURL != secondProgram.settingsURL)
+        #expect(firstProgram.settingsURL.lastPathComponent.hasPrefix("Launch-"))
+        #expect(secondProgram.settingsURL.lastPathComponent.hasPrefix("Launch-"))
+    }
+
+    @Test("Identity is stable when the bottle moves")
+    func stableAcrossBottleMoves() {
+        let exeA = URL(fileURLWithPath: "/tmp/bottles/old/drive_c/Game/game.exe")
+        let exeB = URL(fileURLWithPath: "/somewhere/else/new/drive_c/Game/game.exe")
+
+        let identityA = Program.settingsIdentity(
+            for: exeA, bottleURL: URL(fileURLWithPath: "/tmp/bottles/old")
+        )
+        let identityB = Program.settingsIdentity(
+            for: exeB, bottleURL: URL(fileURLWithPath: "/somewhere/else/new")
+        )
+
+        #expect(identityA == identityB)
+        #expect(identityA.hasPrefix("game-"))
+    }
+
+    @Test("Legacy filename-keyed settings migrate on first load")
+    @MainActor func migratesLegacySettings() throws {
+        let (bottleURL, cleanup) = try makeBottle()
+        defer { cleanup() }
+        let bottle = Bottle(bottleUrl: bottleURL, inFlight: false, isAvailable: true)
+        let exe = try makeExe(at: "drive_c/Game/Launch.exe", in: bottleURL)
+
+        // A legacy plist under the old filename-keyed path
+        var legacySettings = ProgramSettings()
+        legacySettings.arguments = "-windowed"
+        let settingsFolder = bottleURL.appending(path: "Program Settings")
+        try FileManager.default.createDirectory(at: settingsFolder, withIntermediateDirectories: true)
+        let legacyURL = settingsFolder.appending(path: "Launch.exe").appendingPathExtension("plist")
+        try legacySettings.encode(to: legacyURL)
+
+        let program = Program(url: exe, bottle: bottle, peFile: nil)
+
+        #expect(program.settings.arguments == "-windowed")
+        // Copied, not moved: the legacy file survives for downgrades
+        #expect(FileManager.default.fileExists(atPath: legacyURL.path(percentEncoded: false)))
+        #expect(program.settingsURL != legacyURL)
+    }
+
+    @Test("Existing identity-keyed settings are never overwritten by legacy")
+    @MainActor func identityWinsOverLegacy() throws {
+        let (bottleURL, cleanup) = try makeBottle()
+        defer { cleanup() }
+        let bottle = Bottle(bottleUrl: bottleURL, inFlight: false, isAvailable: true)
+        let exe = try makeExe(at: "drive_c/Game/Launch.exe", in: bottleURL)
+
+        let settingsFolder = bottleURL.appending(path: "Program Settings")
+        try FileManager.default.createDirectory(at: settingsFolder, withIntermediateDirectories: true)
+
+        var identitySettings = ProgramSettings()
+        identitySettings.arguments = "-identity"
+        let identityName = Program.settingsIdentity(for: exe, bottleURL: bottleURL)
+        try identitySettings.encode(
+            to: settingsFolder.appending(path: identityName).appendingPathExtension("plist")
+        )
+
+        var legacySettings = ProgramSettings()
+        legacySettings.arguments = "-legacy"
+        try legacySettings.encode(
+            to: settingsFolder.appending(path: "Launch.exe").appendingPathExtension("plist")
+        )
+
+        let program = Program(url: exe, bottle: bottle, peFile: nil)
+
+        #expect(program.settings.arguments == "-identity")
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/ProgramTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ProgramTests.swift
@@ -149,7 +149,9 @@ final class ProgramCoreTests: XCTestCase {
         let program = Program(url: programURL, bottle: bottle)
 
         XCTAssertTrue(program.settingsURL.path.contains("Program Settings"))
-        XCTAssertTrue(program.settingsURL.path.contains("test_game.exe.plist"))
+        // Identity-keyed: exe stem plus a short path hash, not the bare filename
+        XCTAssertTrue(program.settingsURL.lastPathComponent.hasPrefix("test_game-"))
+        XCTAssertTrue(program.settingsURL.pathExtension == "plist")
     }
 
     // MARK: - Pinned Property Tests


### PR DESCRIPTION
the warning at Program.swift:177 made real: two programs named Launch.exe share one settings plist, and steam libraries make that common. settings files are now `<stem>-<8 char path hash>.plist`, hashed from the bottle-relative path so they survive bottle moves and game updates (content hashing would orphan settings on every update, which is why ExeFingerprint isn't used here). legacy filename-keyed plists migrate by copy on first load and the originals stay put, so nothing is lost on downgrade.

4 new tests (collision, move stability, migration, no-overwrite) plus the existing path-shape test updated. full kit suite green locally (1167 xctest + swift-testing), both linters clean, app builds.