### PR TITLE
feat: import apple's gptk payload for the d3dmetal backend

### DIFF
--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		6E40498129CCA8B0006E3F1B /* BottleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E40498029CCA8B0006E3F1B /* BottleView.swift */; };
 		6E40498329CCA91B006E3F1B /* Bottle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E40498229CCA91B006E3F1B /* Bottle+Extensions.swift */; };
 		6E49E0212AECB7DB00009CAC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E49E0202AECB7DB00009CAC /* SettingsView.swift */; };
+		D4E5F6A7B8C90113A9B0C1F4 /* GPTKSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C90113A9B0C1F5 /* GPTKSettingsSection.swift */; };
 		6E50D98329CD6066008C39F6 /* BottleVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E50D98229CD6066008C39F6 /* BottleVM.swift */; };
 		6E50D98529CDF25B008C39F6 /* BottleCreationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E50D98429CDF25B008C39F6 /* BottleCreationView.swift */; };
 		6E59676B2A9A424900D64F70 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 6E59676A2A9A424900D64F70 /* ArgumentParser */; };
@@ -74,6 +75,7 @@
 		8C73E1342AF472FC00B6FB45 /* ProgramMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C73E1332AF472FC00B6FB45 /* ProgramMenuView.swift */; };
 		8CB681E72AED7CD00018D319 /* WhiskyKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8CB681E62AED7CD00018D319 /* WhiskyKit */; };
 		954F64484BFDF7786A5B184E /* LauncherDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 366E8BD2A51FD444160DFC10 /* LauncherDetection.swift */; };
+		D4E5F6A7B8C90113A9B0C1F2 /* GPTKDiskImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C90113A9B0C1F3 /* GPTKDiskImage.swift */; };
 		A1B2C3D4E5F60718A9B0C1D2 /* DLLOverrideEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718A9B0C1D3 /* DLLOverrideEditor.swift */; };
 		A1B2C3D4E5F60718A9B0C1D4 /* DLLOverrideConfigSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718A9B0C1D5 /* DLLOverrideConfigSection.swift */; };
 		A1B2C3D4E5F60718A9B0C1D6 /* ProgramOverrideSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718A9B0C1D7 /* ProgramOverrideSettingsView.swift */; };
@@ -195,6 +197,7 @@
 		1C3B8A506869998F3FE0FC74 /* WhiskyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WhiskyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		258BF9104045ED48882E009D /* WineConfigSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WineConfigSection.swift; sourceTree = "<group>"; };
 		366E8BD2A51FD444160DFC10 /* LauncherDetection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LauncherDetection.swift; sourceTree = "<group>"; };
+		D4E5F6A7B8C90113A9B0C1F3 /* GPTKDiskImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GPTKDiskImage.swift; sourceTree = "<group>"; };
 		3724CE6DD2C1B22D80442DB6 /* PerformanceConfigSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceConfigSection.swift; sourceTree = "<group>"; };
 		407A01251379955919903C3F /* CleanupConfigSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupConfigSection.swift; sourceTree = "<group>"; };
 		4D93508A9C8E5B94200BA068 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -228,6 +231,7 @@
 		6E40498029CCA8B0006E3F1B /* BottleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleView.swift; sourceTree = "<group>"; };
 		6E40498229CCA91B006E3F1B /* Bottle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bottle+Extensions.swift"; sourceTree = "<group>"; };
 		6E49E0202AECB7DB00009CAC /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		D4E5F6A7B8C90113A9B0C1F5 /* GPTKSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTKSettingsSection.swift; sourceTree = "<group>"; };
 		6E50D98229CD6066008C39F6 /* BottleVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleVM.swift; sourceTree = "<group>"; };
 		6E50D98429CDF25B008C39F6 /* BottleCreationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleCreationView.swift; sourceTree = "<group>"; };
 		6E621CEE2A5F631200C9AAB3 /* Winetricks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Winetricks.swift; sourceTree = "<group>"; };
@@ -509,6 +513,7 @@
 			isa = PBXGroup;
 			children = (
 				6E49E0202AECB7DB00009CAC /* SettingsView.swift */,
+				D4E5F6A7B8C90113A9B0C1F5 /* GPTKSettingsSection.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -559,6 +564,7 @@
 				7A0510A42F5A000000000004 /* Telemetry.swift */,
 				F1A2B3C4E5F61601A9B0C1F1 /* SparkleUpdaterDelegate.swift */,
 				366E8BD2A51FD444160DFC10 /* LauncherDetection.swift */,
+				D4E5F6A7B8C90113A9B0C1F3 /* GPTKDiskImage.swift */,
 				AA88CFEB38031323229CD377 /* LauncherDiagnostics.swift */,
 				G1A2B3C4E5F60901A9B0C1D1 /* DependencyManager.swift */,
 				F1A2B3C4E5F60801A9B0C1D0 /* ControllerMonitor.swift */,
@@ -974,11 +980,13 @@
 				B1A2C3D4E5F60302A9B0C1D3 /* ProcessesViewModel.swift in Sources */,
 				6E2B25C12B0E20F50084A67A /* PinAddView.swift in Sources */,
 				6E49E0212AECB7DB00009CAC /* SettingsView.swift in Sources */,
+				D4E5F6A7B8C90113A9B0C1F4 /* GPTKSettingsSection.swift in Sources */,
 				6E7C07C02AAF570100F6E66B /* FileOpenView.swift in Sources */,
 				6E6C0CF22A419A6800356232 /* WelcomeView.swift in Sources */,
 				6E40498129CCA8B0006E3F1B /* BottleView.swift in Sources */,
 				6E355E5E29D7D85D002D83BE /* ProgramView.swift in Sources */,
 				954F64484BFDF7786A5B184E /* LauncherDetection.swift in Sources */,
+				D4E5F6A7B8C90113A9B0C1F2 /* GPTKDiskImage.swift in Sources */,
 				689B4F6DF3B8006E89E1395F /* LauncherDiagnostics.swift in Sources */,
 				160B41C4006351293AAEEF27 /* LauncherConfigSection.swift in Sources */,
 				F748991F03BA464CFCDA99F3 /* StatusToast.swift in Sources */,

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -9368,6 +9368,7 @@
       }
     },
     "gptk.error.forwarderNotBuiltin" : {
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -9378,6 +9379,7 @@
       }
     },
     "gptk.error.payloadIncomplete" : {
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -9388,6 +9390,7 @@
       }
     },
     "gptk.error.payloadNotFound" : {
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -9398,6 +9401,7 @@
       }
     },
     "gptk.error.storeEmpty" : {
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -9408,6 +9412,7 @@
       }
     },
     "gptk.error.versionUnreadable" : {
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -9357,6 +9357,66 @@
         }
       }
     },
+    "gptk.error.attachFailed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not open the disk image:"
+          }
+        }
+      }
+    },
+    "gptk.error.forwarderNotBuiltin" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This is not a Game Porting Toolkit payload, a DLL has the wrong variant:"
+          }
+        }
+      }
+    },
+    "gptk.error.payloadIncomplete" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Game Porting Toolkit payload is missing files:"
+          }
+        }
+      }
+    },
+    "gptk.error.payloadNotFound" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Game Porting Toolkit payload was found at this location. Select Apple's evaluation environment disk image or its redist folder."
+          }
+        }
+      }
+    },
+    "gptk.error.storeEmpty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No imported Game Porting Toolkit payload to deploy."
+          }
+        }
+      }
+    },
+    "gptk.error.versionUnreadable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not read the D3DMetal version from the payload."
+          }
+        }
+      }
+    },
     "help.github" : {
       "localizations" : {
         "ar" : {
@@ -15075,6 +15135,86 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "一般"
+          }
+        }
+      }
+    },
+    "settings.gptk" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Game Porting Toolkit"
+          }
+        }
+      }
+    },
+    "settings.gptk.capability.blocked" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The installed engine build cannot run D3DMetal yet. Imported payloads are kept and deploy automatically once a GPTK-capable engine is installed."
+          }
+        }
+      }
+    },
+    "settings.gptk.capability.ok" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The installed engine can run D3DMetal. Imported payloads deploy automatically."
+          }
+        }
+      }
+    },
+    "settings.gptk.import" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import from Game Porting Toolkit…"
+          }
+        }
+      }
+    },
+    "settings.gptk.import.failed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import Failed"
+          }
+        }
+      }
+    },
+    "settings.gptk.remove" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Imported Payload"
+          }
+        }
+      }
+    },
+    "settings.gptk.status.none" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No D3DMetal payload imported"
+          }
+        }
+      }
+    },
+    "settings.gptk.version" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "D3DMetal Version"
           }
         }
       }

--- a/Whisky/Utils/GPTKDiskImage.swift
+++ b/Whisky/Utils/GPTKDiskImage.swift
@@ -1,0 +1,123 @@
+//
+//  GPTKDiskImage.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WhiskyKit
+
+/// Mounts Apple's GPTK disk images long enough to import their payload.
+///
+/// The user may hand us the outer Game Porting Toolkit image (which contains
+/// the evaluation-environment image), the evaluation-environment image
+/// itself, an already-mounted volume, or a bare folder. Everything resolves
+/// to the `redist/lib` payload root, plus the list of mount points to detach
+/// once the import completes.
+enum GPTKDiskImage {
+    /// A resolved payload location and the mounts holding it open.
+    struct ResolvedPayload {
+        let libRoot: URL
+        let mounts: [URL]
+    }
+
+    enum DiskImageError: LocalizedError {
+        case attachFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .attachFailed(detail):
+                String(localized: "gptk.error.attachFailed") + " " + detail
+            }
+        }
+    }
+
+    /// Resolves `url` (image or folder) to a GPTK payload root, attaching
+    /// images as needed. Callers must ``detach(_:)`` every returned mount.
+    static func resolvePayload(at url: URL) throws -> ResolvedPayload {
+        guard url.pathExtension.lowercased() == "dmg" else {
+            guard let lib = GPTKImporter.locatePayload(under: url) else {
+                throw GPTKImportError.payloadNotFound
+            }
+            return ResolvedPayload(libRoot: lib, mounts: [])
+        }
+
+        var mounts: [URL] = []
+        do {
+            let outer = try attach(url)
+            mounts.append(outer)
+            if let lib = GPTKImporter.locatePayload(under: outer) {
+                return ResolvedPayload(libRoot: lib, mounts: mounts)
+            }
+
+            // The outer GPTK image carries the evaluation environment as a
+            // nested image; attach the first one that yields a payload.
+            let contents = try FileManager.default.contentsOfDirectory(
+                at: outer, includingPropertiesForKeys: nil
+            )
+            for nested in contents where nested.pathExtension.lowercased() == "dmg" {
+                let inner = try attach(nested)
+                mounts.append(inner)
+                if let lib = GPTKImporter.locatePayload(under: inner) {
+                    return ResolvedPayload(libRoot: lib, mounts: mounts)
+                }
+            }
+            throw GPTKImportError.payloadNotFound
+        } catch {
+            for mount in mounts.reversed() {
+                detach(mount)
+            }
+            throw error
+        }
+    }
+
+    /// Attaches a disk image read-only and returns its mount point.
+    static func attach(_ image: URL) throws -> URL {
+        let process = Process()
+        process.executableURL = URL(filePath: "/usr/bin/hdiutil")
+        process.arguments = [
+            "attach", "-readonly", "-nobrowse", "-plist", image.path(percentEncoded: false)
+        ]
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+        try process.run()
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0,
+              let plist = try? PropertyListSerialization.propertyList(
+                  from: data, format: nil
+              ) as? [String: Any],
+              let entities = plist["system-entities"] as? [[String: Any]],
+              let mountPoint = entities.compactMap({ $0["mount-point"] as? String }).first
+        else {
+            throw DiskImageError.attachFailed(image.lastPathComponent)
+        }
+        return URL(filePath: mountPoint)
+    }
+
+    /// Detaches a mount point; failures are ignored (the mount stays behind
+    /// for the user, nothing is lost).
+    static func detach(_ mountPoint: URL) {
+        let process = Process()
+        process.executableURL = URL(filePath: "/usr/bin/hdiutil")
+        process.arguments = ["detach", mountPoint.path(percentEncoded: false)]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try? process.run()
+        process.waitUntilExit()
+    }
+}

--- a/Whisky/Views/Settings/GPTKSettingsSection.swift
+++ b/Whisky/Views/Settings/GPTKSettingsSection.swift
@@ -1,0 +1,146 @@
+//
+//  GPTKSettingsSection.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+import WhiskyKit
+
+/// Settings for Apple's Game Porting Toolkit payload: import from the
+/// user-supplied disk image, show what is stored, and deploy it only when the
+/// installed engine build can actually execute it.
+struct GPTKSettingsSection: View {
+    @State private var storedRecord: GPTKStoreRecord?
+    @State private var runtimeCapable = false
+    @State private var importing = false
+    @State private var showImporter = false
+    @State private var importError: String?
+
+    var body: some View {
+        Section {
+            if let storedRecord {
+                LabeledContent("settings.gptk.version", value: storedRecord.gptkVersion)
+            } else {
+                Text("settings.gptk.status.none")
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                Button("settings.gptk.import") {
+                    showImporter = true
+                }
+                .disabled(importing)
+
+                if importing {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                if storedRecord != nil {
+                    Button("settings.gptk.remove", role: .destructive) {
+                        removePayload()
+                    }
+                    .disabled(importing)
+                }
+            }
+        } header: {
+            Text("settings.gptk")
+        } footer: {
+            Text(runtimeCapable ? "settings.gptk.capability.ok" : "settings.gptk.capability.blocked")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .task { refresh() }
+        .fileImporter(
+            isPresented: $showImporter,
+            allowedContentTypes: [.diskImage, .folder]
+        ) { result in
+            guard case let .success(url) = result else { return }
+            importPayload(from: url)
+        }
+        .alert(
+            "settings.gptk.import.failed",
+            isPresented: .init(
+                get: { importError != nil },
+                set: { if !$0 { importError = nil } }
+            )
+        ) {
+            Button("button.ok", role: .cancel) {}
+        } message: {
+            Text(importError ?? "")
+        }
+    }
+
+    private func refresh() {
+        storedRecord = GPTKImporter.storedRecord()
+        runtimeCapable = GPTKImporter.isRuntimeGPTKCapable()
+    }
+
+    private func importPayload(from url: URL) {
+        importing = true
+        Task.detached(priority: .userInitiated) {
+            let accessing = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessing {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+
+            var mounts: [URL] = []
+            do {
+                let resolved = try GPTKDiskImage.resolvePayload(at: url)
+                mounts = resolved.mounts
+                let payload = try GPTKImporter.validatePayload(at: resolved.libRoot)
+                try GPTKImporter.importPayload(payload)
+                // Deployment into the Wine tree is gated: on an engine build
+                // without GPTK exception-unwind support the payload would
+                // crash every process that touches it.
+                if GPTKImporter.isRuntimeGPTKCapable() {
+                    try GPTKImporter.deployStoredPayload()
+                }
+                for mount in mounts.reversed() {
+                    GPTKDiskImage.detach(mount)
+                }
+                await MainActor.run {
+                    importing = false
+                    refresh()
+                }
+            } catch {
+                for mount in mounts.reversed() {
+                    GPTKDiskImage.detach(mount)
+                }
+                await MainActor.run {
+                    importing = false
+                    importError = error.localizedDescription
+                    refresh()
+                }
+            }
+        }
+    }
+
+    private func removePayload() {
+        do {
+            if GPTKImporter.isDeployed() {
+                try GPTKImporter.removeDeployedPayload()
+            }
+            try GPTKImporter.removeStore()
+        } catch {
+            importError = error.localizedDescription
+        }
+        refresh()
+    }
+}

--- a/Whisky/Views/Settings/GPTKSettingsSection.swift
+++ b/Whisky/Views/Settings/GPTKSettingsSection.swift
@@ -64,7 +64,12 @@ struct GPTKSettingsSection: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
-        .task { refresh() }
+        .task {
+            await Task.detached(priority: .utility) {
+                GPTKImporter.deployStoredPayloadIfCapable()
+            }.value
+            refresh()
+        }
         .fileImporter(
             isPresented: $showImporter,
             allowedContentTypes: [.diskImage, .folder]
@@ -134,9 +139,11 @@ struct GPTKSettingsSection: View {
 
     private func removePayload() {
         do {
-            if GPTKImporter.isDeployed() {
-                try GPTKImporter.removeDeployedPayload()
-            }
+            // Unconditional: isDeployed() reads files written late in deploy, so
+            // a half-finished deploy looks undeployed while forwarders are
+            // already swapped, and skipping cleanup would delete originals/ with
+            // the store. The removal is idempotent per file.
+            try GPTKImporter.removeDeployedPayload()
             try GPTKImporter.removeStore()
         } catch {
             importError = error.localizedDescription

--- a/Whisky/Views/Settings/SettingsView.swift
+++ b/Whisky/Views/Settings/SettingsView.swift
@@ -73,6 +73,7 @@ struct SettingsView: View {
                 Toggle("settings.toggle.whisky.updates", isOn: $whiskyUpdate)
                 Toggle("settings.toggle.whiskywine.updates", isOn: $checkWhiskyWineUpdates)
             }
+            GPTKSettingsSection()
             Section("settings.privacy") {
                 Toggle("settings.toggle.telemetry", isOn: telemetryOptIn)
                     .help("setup.telemetry.consent.help")

--- a/Whisky/Views/Setup/WhiskyWineInstallView.swift
+++ b/Whisky/Views/Setup/WhiskyWineInstallView.swift
@@ -216,6 +216,9 @@ struct WhiskyWineInstallView: View {
                     // Extraction reported success but the runtime isn't usable.
                     return .failure(reason: .runtimeIncomplete, message: nil)
                 }
+                // The install replaced Libraries, so any deployed GPTK payload
+                // went with it; the store outlives it and redeploys here.
+                GPTKImporter.deployStoredPayloadIfCapable()
                 return .success
             } catch {
                 let reason: Telemetry.InstallFailureReason =

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
@@ -19,6 +19,13 @@
 import Foundation
 import os.log
 
+/// Which runtime the backed-up Wine originals were taken from. The store now
+/// outlives the runtime, so a backup can outlive the engine it came from, and
+/// restoring a Wine 10 builtin into a Wine 11 tree breaks it silently.
+struct GPTKOriginalsRecord: Codable, Equatable, Sendable {
+    let runtimeVersion: String
+}
+
 /// Runtime capability gating and deployment of the stored payload into the
 /// Wine tree (Apple's documented layout).
 extension GPTKImporter {
@@ -61,6 +68,61 @@ extension GPTKImporter {
         try deploy(fromStore: storeFolder, intoLibraryFolder: WhiskyWineInstaller.libraryFolder)
     }
 
+    /// Deploys the stored payload if there is one and the runtime can execute
+    /// it, reporting whether it deployed.
+    ///
+    /// The store survives a runtime install but the deployed copy does not, so
+    /// every install has to re-evaluate. Idempotent and safe to call anywhere.
+    @discardableResult
+    public static func deployStoredPayloadIfCapable() -> Bool {
+        guard storedRecord() != nil, isRuntimeGPTKCapable() else { return false }
+        do {
+            try deployStoredPayload()
+            return true
+        } catch {
+            logger.error("Deploying the stored GPTK payload failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// The runtime version under `folder`, or `nil` if none is readable.
+    static func runtimeVersionStamp(inLibraryFolder folder: URL) -> String? {
+        let plist = folder.appending(path: "WhiskyWineVersion").appendingPathExtension("plist")
+        guard let info = WhiskyWineInstaller.whiskyWineInfo(at: plist) else { return nil }
+        return "\(info.version.major).\(info.version.minor).\(info.version.patch)"
+    }
+
+    static func originalsRecordURL(inStore store: URL) -> URL {
+        store.appending(path: "originals").appending(path: "OriginalsVersion.plist")
+    }
+
+    static func originalsRecord(inStore store: URL) -> GPTKOriginalsRecord? {
+        guard let data = try? Data(contentsOf: originalsRecordURL(inStore: store)) else { return nil }
+        return try? PropertyListDecoder().decode(GPTKOriginalsRecord.self, from: data)
+    }
+
+    /// Readies the `originals/` folder for a deploy against `folder`, dropping
+    /// backups left by a previous engine: restoring those would put that
+    /// engine's DLLs into this one's tree. The stamp is written before the first
+    /// backup so an interrupted deploy still leaves originals remove will
+    /// recognise and restore.
+    private static func prepareOriginals(inStore store: URL, forLibraryFolder folder: URL) throws {
+        let fileManager = FileManager.default
+        let originals = store.appending(path: "originals")
+        let runtimeStamp = runtimeVersionStamp(inLibraryFolder: folder)
+
+        if originalsRecord(inStore: store)?.runtimeVersion != runtimeStamp {
+            try? fileManager.removeItem(at: originals)
+        }
+        try fileManager.createDirectory(at: originals, withIntermediateDirectories: true)
+
+        guard let runtimeStamp else { return }
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        try encoder.encode(GPTKOriginalsRecord(runtimeVersion: runtimeStamp))
+            .write(to: originalsRecordURL(inStore: store))
+    }
+
     /// Testable seam for ``deployStoredPayload()``.
     static func deploy(fromStore store: URL, intoLibraryFolder folder: URL) throws {
         guard storedRecord(inStore: store) != nil else {
@@ -72,8 +134,7 @@ extension GPTKImporter {
         let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
         let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
         let originals = store.appending(path: "originals")
-
-        try fileManager.createDirectory(at: originals, withIntermediateDirectories: true)
+        try prepareOriginals(inStore: store, forLibraryFolder: folder)
 
         for name in forwarderDLLNames {
             let target = peDir.appending(path: name)
@@ -138,13 +199,25 @@ extension GPTKImporter {
         let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
         let originals = store.appending(path: "originals")
 
+        let originalsAreCurrent = originalsRecord(inStore: store)?.runtimeVersion
+            == runtimeVersionStamp(inLibraryFolder: folder)
+
         for name in forwarderDLLNames {
+            let backup = originals.appending(path: name)
+            let hasBackup = fileManager.fileExists(atPath: backup.path(percentEncoded: false))
+
+            // Backups from a replaced engine: drop them and leave the tree,
+            // which this store never deployed into, untouched.
+            guard originalsAreCurrent else {
+                if hasBackup { try fileManager.removeItem(at: backup) }
+                continue
+            }
+
             let deployed = peDir.appending(path: name)
             if fileManager.fileExists(atPath: deployed.path(percentEncoded: false)) {
                 try fileManager.removeItem(at: deployed)
             }
-            let backup = originals.appending(path: name)
-            if fileManager.fileExists(atPath: backup.path(percentEncoded: false)) {
+            if hasBackup {
                 try fileManager.moveItem(at: backup, to: deployed)
             }
         }

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
@@ -1,0 +1,164 @@
+//
+//  GPTKImporter+Deployment.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import os.log
+
+/// Runtime capability gating and deployment of the stored payload into the
+/// Wine tree (Apple's documented layout).
+extension GPTKImporter {
+    // MARK: - Runtime capability
+
+    /// Whether the installed runtime's Wine build can execute GPTK payloads.
+    ///
+    /// Advertised by `gptkCapable` in the runtime's version plist; absent means
+    /// no. This is a build property (exception-unwind support), not something
+    /// the payload or the app can add.
+    public static func isRuntimeGPTKCapable() -> Bool {
+        WhiskyWineInstaller.whiskyWineInfo()?.gptkCapable == true
+    }
+
+    // MARK: - Deployment
+
+    /// Whether the payload is deployed into the runtime tree.
+    public static func isDeployed() -> Bool {
+        isDeployed(inLibraryFolder: WhiskyWineInstaller.libraryFolder)
+    }
+
+    /// Testable seam for ``isDeployed()``: the unix bridge for dxgi and the
+    /// shared dylib both present in the Wine tree.
+    static func isDeployed(inLibraryFolder folder: URL) -> Bool {
+        let lib = folder.appending(path: "Wine").appending(path: "lib")
+        let bridge = lib.appending(path: "wine").appending(path: "x86_64-unix").appending(path: "dxgi.so")
+        let dylib = lib.appending(path: "external").appending(path: "libd3dshared.dylib")
+        let fileManager = FileManager.default
+        return fileManager.fileExists(atPath: bridge.path(percentEncoded: false)) &&
+            fileManager.fileExists(atPath: dylib.path(percentEncoded: false))
+    }
+
+    /// Deploys the stored payload into the runtime tree per Apple's documented
+    /// layout: forwarders replace the Wine builtins (originals are backed up in
+    /// the store), the unix bridges and `external/` are added alongside.
+    ///
+    /// Callers gate this on ``isRuntimeGPTKCapable()`` — deploying to an
+    /// incapable runtime turns every D3DMetal launch into a crash.
+    public static func deployStoredPayload() throws {
+        try deploy(fromStore: storeFolder, intoLibraryFolder: WhiskyWineInstaller.libraryFolder)
+    }
+
+    /// Testable seam for ``deployStoredPayload()``.
+    static func deploy(fromStore store: URL, intoLibraryFolder folder: URL) throws {
+        guard storedRecord(inStore: store) != nil else {
+            throw GPTKImportError.storeEmpty
+        }
+        let fileManager = FileManager.default
+        let storeLib = store.appending(path: "lib")
+        let wineLib = folder.appending(path: "Wine").appending(path: "lib")
+        let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
+        let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
+        let originals = store.appending(path: "originals")
+
+        try fileManager.createDirectory(at: originals, withIntermediateDirectories: true)
+
+        for name in forwarderDLLNames {
+            let target = peDir.appending(path: name)
+            let backup = originals.appending(path: name)
+            // Back up whatever Wine shipped, once; a redeploy over an existing
+            // GPTK forwarder must not overwrite the original with Apple's copy.
+            if fileManager.fileExists(atPath: target.path(percentEncoded: false)) {
+                if !fileManager.fileExists(atPath: backup.path(percentEncoded: false)),
+                   !isGPTKForwarder(target, matching: storeLib) {
+                    try fileManager.moveItem(at: target, to: backup)
+                } else {
+                    try fileManager.removeItem(at: target)
+                }
+            }
+            try fileManager.copyItem(
+                at: storeLib.appending(path: "wine").appending(path: "x86_64-windows").appending(path: name),
+                to: target
+            )
+        }
+
+        try fileManager.createDirectory(at: unixDir, withIntermediateDirectories: true)
+        for name in unixLibraryNames {
+            let link = unixDir.appending(path: name)
+            try? fileManager.removeItem(at: link)
+            try fileManager.createSymbolicLink(
+                atPath: link.path(percentEncoded: false),
+                withDestinationPath: unixLinkDestination
+            )
+        }
+
+        let externalDest = wineLib.appending(path: "external")
+        if fileManager.fileExists(atPath: externalDest.path(percentEncoded: false)) {
+            try fileManager.removeItem(at: externalDest)
+        }
+        try fileManager.copyItem(at: storeLib.appending(path: "external"), to: externalDest)
+        logger.info("Deployed GPTK payload into the runtime tree")
+    }
+
+    /// Whether `dll` is byte-identical to the store's forwarder of the same
+    /// name — used so redeploys never mistake an already-deployed Apple DLL
+    /// for a Wine original worth backing up.
+    private static func isGPTKForwarder(_ dll: URL, matching storeLib: URL) -> Bool {
+        let storeDLL = storeLib.appending(path: "wine").appending(path: "x86_64-windows")
+            .appending(path: dll.lastPathComponent)
+        return FileManager.default.contentsEqual(
+            atPath: dll.path(percentEncoded: false),
+            andPath: storeDLL.path(percentEncoded: false)
+        )
+    }
+
+    /// Removes the payload from the runtime tree and restores the backed-up
+    /// Wine originals.
+    public static func removeDeployedPayload() throws {
+        try remove(fromLibraryFolder: WhiskyWineInstaller.libraryFolder, usingStore: storeFolder)
+    }
+
+    /// Testable seam for ``removeDeployedPayload()``.
+    static func remove(fromLibraryFolder folder: URL, usingStore store: URL) throws {
+        let fileManager = FileManager.default
+        let wineLib = folder.appending(path: "Wine").appending(path: "lib")
+        let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
+        let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
+        let originals = store.appending(path: "originals")
+
+        for name in forwarderDLLNames {
+            let deployed = peDir.appending(path: name)
+            if fileManager.fileExists(atPath: deployed.path(percentEncoded: false)) {
+                try fileManager.removeItem(at: deployed)
+            }
+            let backup = originals.appending(path: name)
+            if fileManager.fileExists(atPath: backup.path(percentEncoded: false)) {
+                try fileManager.moveItem(at: backup, to: deployed)
+            }
+        }
+
+        // removeItem operates on the link itself, so this also clears a
+        // dangling symlink that fileExists (which follows links) would miss.
+        for name in unixLibraryNames {
+            try? fileManager.removeItem(at: unixDir.appending(path: name))
+        }
+
+        let external = wineLib.appending(path: "external")
+        if fileManager.fileExists(atPath: external.path(percentEncoded: false)) {
+            try fileManager.removeItem(at: external)
+        }
+        logger.info("Removed GPTK payload from the runtime tree")
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
@@ -174,8 +174,8 @@ extension GPTKImporter {
     }
 
     /// Whether `dll` is byte-identical to the store's forwarder of the same
-    /// name — used so redeploys never mistake an already-deployed Apple DLL
-    /// for a Wine original worth backing up.
+    /// name, so deploy never mistakes an already-deployed Apple DLL for a Wine
+    /// original worth backing up and remove only deletes what it put there.
     private static func isGPTKForwarder(_ dll: URL, matching storeLib: URL) -> Bool {
         let storeDLL = storeLib.appending(path: "wine").appending(path: "x86_64-windows")
             .appending(path: dll.lastPathComponent)
@@ -198,6 +198,7 @@ extension GPTKImporter {
         let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
         let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
         let originals = store.appending(path: "originals")
+        let storeLib = store.appending(path: "lib")
 
         let originalsAreCurrent = originalsRecord(inStore: store)?.runtimeVersion
             == runtimeVersionStamp(inLibraryFolder: folder)
@@ -213,8 +214,12 @@ extension GPTKImporter {
                 continue
             }
 
+            // An interrupted deploy leaves some names still holding Wine's own
+            // DLL, never backed up; deleting one loses a builtin with nothing
+            // to put back. Only what byte-matches the store came from here.
             let deployed = peDir.appending(path: name)
             if fileManager.fileExists(atPath: deployed.path(percentEncoded: false)) {
+                guard isGPTKForwarder(deployed, matching: storeLib) else { continue }
                 try fileManager.removeItem(at: deployed)
             }
             if hasBackup {

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
@@ -84,17 +84,21 @@ public struct GPTKStoreRecord: Codable, Equatable, Sendable {
 public enum GPTKImporter {
     static let logger = Logger(subsystem: Bundle.whiskyBundleIdentifier, category: "GPTKImporter")
 
-    /// The PE forwarders Apple ships (GPTK 4 has no d3d9 forwarder).
-    static let forwarderDLLNames = [
-        "d3d10.dll", "d3d11.dll", "d3d12.dll", "dxgi.dll", "nvapi64.dll", "nvngx-on-metalfx.dll"
-    ]
+    /// The D3D forwarders Apple ships, and the only ones deployed. GPTK 4 has
+    /// no d3d9 forwarder.
+    static let forwarderDLLNames = ["d3d10.dll", "d3d11.dll", "d3d12.dll", "dxgi.dll"]
+
+    /// Apple's NVIDIA bridges, which back the experimental DLSS-to-MetalFX
+    /// path. Kept in the store but never deployed: a stock runtime ships no
+    /// `nvapi64` at all, so placing Apple's makes every process that probes for
+    /// an NVIDIA GPU load D3DMetal — Chromium does exactly that, which takes
+    /// Steam's helper process down with it. Opt-in territory, not a default.
+    static let nvidiaBridgeDLLNames = ["nvapi64.dll", "nvngx-on-metalfx.dll"]
 
     /// The unix-side bridge names; each is a symlink to
     /// `../../external/libd3dshared.dylib`, whose `@loader_path` rpath then
     /// finds the framework beside it.
-    static let unixLibraryNames = [
-        "d3d10.so", "d3d11.so", "d3d12.so", "dxgi.so", "nvapi64.so", "nvngx-on-metalfx.so"
-    ]
+    static let unixLibraryNames = ["d3d10.so", "d3d11.so", "d3d12.so", "dxgi.so"]
 
     /// The symlink target for every unix bridge name, relative to
     /// `wine/x86_64-unix/`.

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
@@ -1,0 +1,266 @@
+//
+//  GPTKImporter.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import os.log
+
+/// Errors thrown while importing or deploying a GPTK payload.
+public enum GPTKImportError: LocalizedError, Equatable {
+    /// No `redist/lib`-shaped payload was found under the given location.
+    case payloadNotFound
+    /// The payload is missing required files (names are payload-relative paths).
+    case payloadIncomplete(missing: [String])
+    /// A forwarder DLL is not the winebuild builtin variant Apple ships — the
+    /// source is not a real GPTK payload (or is damaged).
+    case forwarderNotBuiltin(String)
+    /// The D3DMetal framework's version could not be read.
+    case versionUnreadable
+    /// No imported payload exists in the store to deploy or remove.
+    case storeEmpty
+
+    public var errorDescription: String? {
+        switch self {
+        case .payloadNotFound:
+            String(localized: "gptk.error.payloadNotFound")
+        case let .payloadIncomplete(missing):
+            String(localized: "gptk.error.payloadIncomplete") + " " + missing.joined(separator: ", ")
+        case let .forwarderNotBuiltin(name):
+            String(localized: "gptk.error.forwarderNotBuiltin") + " " + name
+        case .versionUnreadable:
+            String(localized: "gptk.error.versionUnreadable")
+        case .storeEmpty:
+            String(localized: "gptk.error.storeEmpty")
+        }
+    }
+}
+
+/// A located and validated GPTK payload (Apple's `redist/lib` layout).
+public struct GPTKPayload: Equatable, Sendable {
+    /// The folder containing `external/` and `wine/`.
+    public let libRoot: URL
+    /// The D3DMetal framework version, e.g. `"4.0b2"`.
+    public let version: String
+}
+
+/// What the store holds after a successful import.
+public struct GPTKStoreRecord: Codable, Equatable, Sendable {
+    /// The imported D3DMetal framework version, e.g. `"4.0b2"`.
+    public let gptkVersion: String
+    /// When the payload was imported.
+    public let importedAt: Date
+}
+
+/// Imports Apple's Game Porting Toolkit evaluation environment so the
+/// D3DMetal backend can become real.
+///
+/// The user supplies the payload (nothing of Apple's is redistributed): the
+/// evaluation-environment disk image's `redist/lib` tree, containing
+/// `external/` (D3DMetal.framework + `libd3dshared.dylib`), six builtin-marked
+/// PE forwarder DLLs, and six unix-side names that all resolve to
+/// `libd3dshared.dylib`.
+///
+/// Importing copies the payload verbatim into a pristine store
+/// (`Libraries/D3DMetal/`), surviving runtime reinstalls. Deployment — placing
+/// the payload into the Wine tree the way Apple documents — is a separate,
+/// gated step: the payload's DLLs are C++ with exception handling, and a Wine
+/// build without personality-routine support for builtin modules kills every
+/// process that runs D3DMetal code. Only runtimes that advertise
+/// `gptkCapable` in their version plist get the payload deployed.
+public enum GPTKImporter {
+    static let logger = Logger(subsystem: Bundle.whiskyBundleIdentifier, category: "GPTKImporter")
+
+    /// The PE forwarders Apple ships (GPTK 4 has no d3d9 forwarder).
+    static let forwarderDLLNames = [
+        "d3d10.dll", "d3d11.dll", "d3d12.dll", "dxgi.dll", "nvapi64.dll", "nvngx-on-metalfx.dll"
+    ]
+
+    /// The unix-side bridge names; each is a symlink to
+    /// `../../external/libd3dshared.dylib`, whose `@loader_path` rpath then
+    /// finds the framework beside it.
+    static let unixLibraryNames = [
+        "d3d10.so", "d3d11.so", "d3d12.so", "dxgi.so", "nvapi64.so", "nvngx-on-metalfx.so"
+    ]
+
+    /// The symlink target for every unix bridge name, relative to
+    /// `wine/x86_64-unix/`.
+    static let unixLinkDestination = "../../external/libd3dshared.dylib"
+
+    /// The pristine payload store: `Libraries/D3DMetal/`.
+    public static var storeFolder: URL {
+        WhiskyWineInstaller.libraryFolder.appending(path: "D3DMetal")
+    }
+
+    // MARK: - Locating
+
+    /// Finds Apple's `lib` payload root at or under `url`.
+    ///
+    /// Accepts the `lib` folder itself, a `redist` folder, or a mounted
+    /// evaluation-environment volume root.
+    public static func locatePayload(under url: URL) -> URL? {
+        let candidates = [
+            url,
+            url.appending(path: "lib"),
+            url.appending(path: "redist").appending(path: "lib")
+        ]
+        return candidates.first(where: isPayloadRoot)
+    }
+
+    /// A payload root has the shared dylib and at least one forwarder in
+    /// Apple's layout. Full completeness is ``validatePayload(at:)``'s job.
+    static func isPayloadRoot(_ url: URL) -> Bool {
+        let fileManager = FileManager.default
+        let dylib = url.appending(path: "external").appending(path: "libd3dshared.dylib")
+        let dxgi = url.appending(path: "wine").appending(path: "x86_64-windows").appending(path: "dxgi.dll")
+        return fileManager.fileExists(atPath: dylib.path(percentEncoded: false)) &&
+            fileManager.fileExists(atPath: dxgi.path(percentEncoded: false))
+    }
+
+    // MARK: - Validation
+
+    /// Validates completeness and authenticity of the payload at `libRoot` and
+    /// reads its version.
+    ///
+    /// - Throws: ``GPTKImportError`` when files are missing, a forwarder is not
+    ///   the builtin variant, or the version is unreadable.
+    public static func validatePayload(at libRoot: URL) throws -> GPTKPayload {
+        let fileManager = FileManager.default
+        let peDir = libRoot.appending(path: "wine").appending(path: "x86_64-windows")
+        let external = libRoot.appending(path: "external")
+
+        var missing: [String] = []
+        for name in forwarderDLLNames
+            where !fileManager.fileExists(atPath: peDir.appending(path: name).path(percentEncoded: false)) {
+            missing.append("wine/x86_64-windows/\(name)")
+        }
+        for path in ["libd3dshared.dylib", "D3DMetal.framework"]
+            where !fileManager.fileExists(atPath: external.appending(path: path).path(percentEncoded: false)) {
+            missing.append("external/\(path)")
+        }
+        guard missing.isEmpty else {
+            throw GPTKImportError.payloadIncomplete(missing: missing)
+        }
+
+        // Apple's forwarders are winebuild builtins; a native-marked file here
+        // means this is not a GPTK payload (or a corrupted one). The inverse of
+        // the DXMT gate, which requires native PEs.
+        for name in forwarderDLLNames {
+            let dll = peDir.appending(path: name)
+            guard (try? Wine.isNativePE(dll)) == false else {
+                throw GPTKImportError.forwarderNotBuiltin(name)
+            }
+        }
+
+        guard let version = frameworkVersion(inExternal: external) else {
+            throw GPTKImportError.versionUnreadable
+        }
+        return GPTKPayload(libRoot: libRoot, version: version)
+    }
+
+    /// Reads `CFBundleShortVersionString` from the framework's Info.plist,
+    /// looking in the versioned bundle layout first and the flat layout second.
+    static func frameworkVersion(inExternal external: URL) -> String? {
+        let framework = external.appending(path: "D3DMetal.framework")
+        let candidates = [
+            framework.appending(path: "Versions").appending(path: "A")
+                .appending(path: "Resources").appending(path: "Info.plist"),
+            framework.appending(path: "Resources").appending(path: "Info.plist")
+        ]
+        for plist in candidates {
+            guard let data = try? Data(contentsOf: plist),
+                  let dict = try? PropertyListSerialization.propertyList(
+                      from: data, format: nil
+                  ) as? [String: Any],
+                  let version = dict["CFBundleShortVersionString"] as? String,
+                  !version.isEmpty
+            else { continue }
+            return version
+        }
+        return nil
+    }
+
+    // MARK: - Import
+
+    /// Copies a validated payload into the store and records its version.
+    ///
+    /// Reimporting replaces the previous store contents. The six unix bridge
+    /// names are recreated as symlinks regardless of what the source held: a
+    /// copy pipeline that resolved them into file duplicates would break the
+    /// dylib's `@loader_path` rpath, which must land in `external/` to find
+    /// the framework.
+    @discardableResult
+    public static func importPayload(_ payload: GPTKPayload) throws -> GPTKStoreRecord {
+        try importPayload(payload, intoStore: storeFolder)
+    }
+
+    /// Testable seam for ``importPayload(_:)``.
+    @discardableResult
+    static func importPayload(_ payload: GPTKPayload, intoStore store: URL) throws -> GPTKStoreRecord {
+        let fileManager = FileManager.default
+        let libDest = store.appending(path: "lib")
+
+        try fileManager.createDirectory(at: store, withIntermediateDirectories: true)
+        if fileManager.fileExists(atPath: libDest.path(percentEncoded: false)) {
+            try fileManager.removeItem(at: libDest)
+        }
+        try fileManager.copyItem(at: payload.libRoot, to: libDest)
+
+        let unixDir = libDest.appending(path: "wine").appending(path: "x86_64-unix")
+        try fileManager.createDirectory(at: unixDir, withIntermediateDirectories: true)
+        for name in unixLibraryNames {
+            let link = unixDir.appending(path: name)
+            try? fileManager.removeItem(at: link)
+            try fileManager.createSymbolicLink(
+                atPath: link.path(percentEncoded: false),
+                withDestinationPath: unixLinkDestination
+            )
+        }
+
+        let record = GPTKStoreRecord(gptkVersion: payload.version, importedAt: Date())
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        try encoder.encode(record).write(to: recordURL(inStore: store))
+        logger.info("Imported GPTK payload \(record.gptkVersion, privacy: .public) into store")
+        return record
+    }
+
+    /// The stored payload's record, or `nil` when the store is absent or its
+    /// payload is incomplete.
+    public static func storedRecord() -> GPTKStoreRecord? {
+        storedRecord(inStore: storeFolder)
+    }
+
+    /// Testable seam for ``storedRecord()``.
+    static func storedRecord(inStore store: URL) -> GPTKStoreRecord? {
+        guard let data = try? Data(contentsOf: recordURL(inStore: store)),
+              let record = try? PropertyListDecoder().decode(GPTKStoreRecord.self, from: data),
+              isPayloadRoot(store.appending(path: "lib"))
+        else { return nil }
+        return record
+    }
+
+    /// Deletes the store, payload and record together.
+    public static func removeStore() throws {
+        let store = storeFolder
+        guard FileManager.default.fileExists(atPath: store.path(percentEncoded: false)) else { return }
+        try FileManager.default.removeItem(at: store)
+    }
+
+    private static func recordURL(inStore store: URL) -> URL {
+        store.appending(path: "D3DMetalVersion.plist")
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
@@ -74,9 +74,9 @@ public struct GPTKStoreRecord: Codable, Equatable, Sendable {
 /// PE forwarder DLLs, and six unix-side names that all resolve to
 /// `libd3dshared.dylib`.
 ///
-/// Importing copies the payload verbatim into a pristine store
-/// (`Libraries/D3DMetal/`), surviving runtime reinstalls. Deployment — placing
-/// the payload into the Wine tree the way Apple documents — is a separate,
+/// Importing copies the payload verbatim into a pristine store (`D3DMetal/`,
+/// a sibling of `Libraries/`), surviving runtime reinstalls. Deployment, placing
+/// the payload into the Wine tree the way Apple documents, is a separate,
 /// gated step: the payload's DLLs are C++ with exception handling, and a Wine
 /// build without personality-routine support for builtin modules kills every
 /// process that runs D3DMetal code. Only runtimes that advertise
@@ -95,6 +95,9 @@ public enum GPTKImporter {
     /// Steam's helper process down with it. Opt-in territory, not a default.
     static let nvidiaBridgeDLLNames = ["nvapi64.dll", "nvngx-on-metalfx.dll"]
 
+    /// Enough bytes to hold the winebuild marker at offset 0x40.
+    static let builtinMarkerMinimumLength = 0x50
+
     /// The unix-side bridge names; each is a symlink to
     /// `../../external/libd3dshared.dylib`, whose `@loader_path` rpath then
     /// finds the framework beside it.
@@ -104,9 +107,18 @@ public enum GPTKImporter {
     /// `wine/x86_64-unix/`.
     static let unixLinkDestination = "../../external/libd3dshared.dylib"
 
-    /// The pristine payload store: `Libraries/D3DMetal/`.
+    /// The pristine payload store: `D3DMetal/`, a sibling of `Libraries/`.
+    ///
+    /// Outside `Libraries/` because ``WhiskyWineInstaller/install(from:)``
+    /// removes that whole folder before untarring, which would destroy the
+    /// store and its `originals/` backups on every engine update.
     public static var storeFolder: URL {
-        WhiskyWineInstaller.libraryFolder.appending(path: "D3DMetal")
+        storeFolder(inApplicationFolder: WhiskyWineInstaller.applicationFolder)
+    }
+
+    /// Testable seam for ``storeFolder``.
+    static func storeFolder(inApplicationFolder folder: URL) -> URL {
+        folder.appending(path: "D3DMetal")
     }
 
     // MARK: - Locating
@@ -132,6 +144,15 @@ public enum GPTKImporter {
         let dxgi = url.appending(path: "wine").appending(path: "x86_64-windows").appending(path: "dxgi.dll")
         return fileManager.fileExists(atPath: dylib.path(percentEncoded: false)) &&
             fileManager.fileExists(atPath: dxgi.path(percentEncoded: false))
+    }
+
+    /// Whether `url` is readable and long enough for the marker check.
+    static func canHoldBuiltinMarker(_ url: URL) -> Bool {
+        let path = url.path(percentEncoded: false)
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let size = attributes[.size] as? Int
+        else { return false }
+        return size >= builtinMarkerMinimumLength
     }
 
     // MARK: - Validation
@@ -161,10 +182,12 @@ public enum GPTKImporter {
 
         // Apple's forwarders are winebuild builtins; a native-marked file here
         // means this is not a GPTK payload (or a corrupted one). The inverse of
-        // the DXMT gate, which requires native PEs.
+        // the DXMT gate, which requires native PEs. isNativePE fails closed to
+        // false for a file too short to hold the marker, and false is the
+        // passing answer here, so check the length or a 3-byte DLL validates.
         for name in forwarderDLLNames {
             let dll = peDir.appending(path: name)
-            guard (try? Wine.isNativePE(dll)) == false else {
+            guard canHoldBuiltinMarker(dll), (try? Wine.isNativePE(dll)) == false else {
                 throw GPTKImportError.forwarderNotBuiltin(name)
             }
         }

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -314,6 +314,10 @@ public class WhiskyWineInstaller {
             }
         }
 
+        // The GPTK store sits outside Libraries so it survives engine updates;
+        // a full uninstall is the one case where it should not.
+        try? FileManager.default.removeItem(at: GPTKImporter.storeFolder)
+
         // BottleData.plist registers bottle paths; remove it so a reinstall
         // starts with no orphaned entries pointing at deleted directories.
         let bottleData = applicationFolder.appending(path: "BottleData.plist")

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineVersion.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineVersion.swift
@@ -53,23 +53,35 @@ public struct WhiskyWineVersion: Codable {
     /// path stays backward-compatible when no hash is advertised).
     public var sha256: String?
 
+    /// Whether this runtime's Wine build can execute Apple's GPTK/D3DMetal
+    /// payload. The payload's forwarder DLLs are C++ with exception handling,
+    /// and unwinding them requires personality-routine support for builtin
+    /// modules that upstream Wine lacks — on a build without it, every process
+    /// that runs D3DMetal code dies on its first internal throw. Absent (all
+    /// runtimes to date) means not capable; a future GPTK-ready runtime build
+    /// advertises `true` here.
+    public var gptkCapable: Bool?
+
     enum CodingKeys: String, CodingKey {
         case version
         case dxvkVersion
         case dxmtVersion
         case sha256
+        case gptkCapable
     }
 
     public init(
         version: SemanticVersion,
         dxvkVersion: String? = nil,
         dxmtVersion: String? = nil,
-        sha256: String? = nil
+        sha256: String? = nil,
+        gptkCapable: Bool? = nil
     ) {
         self.version = version
         self.dxvkVersion = Self.normalized(dxvkVersion)
         self.dxmtVersion = Self.normalized(dxmtVersion)
         self.sha256 = Self.normalizedDigest(sha256)
+        self.gptkCapable = gptkCapable
     }
 
     public init(from decoder: Decoder) throws {
@@ -82,6 +94,7 @@ public struct WhiskyWineVersion: Codable {
         dxvkVersion = try Self.normalized(container.decodeIfPresent(String.self, forKey: .dxvkVersion))
         dxmtVersion = try Self.normalized(container.decodeIfPresent(String.self, forKey: .dxmtVersion))
         sha256 = try Self.normalizedDigest(container.decodeIfPresent(String.self, forKey: .sha256))
+        gptkCapable = try container.decodeIfPresent(Bool.self, forKey: .gptkCapable)
     }
 
     /// Collapses an empty string to `nil` so "absent" and "blank" map to the
@@ -119,6 +132,7 @@ public struct WhiskyWineVersion: Codable {
         try container.encodeIfPresent(dxvkVersion, forKey: .dxvkVersion)
         try container.encodeIfPresent(dxmtVersion, forKey: .dxmtVersion)
         try container.encodeIfPresent(sha256, forKey: .sha256)
+        try container.encodeIfPresent(gptkCapable, forKey: .gptkCapable)
     }
 
     private enum VersionKeys: String, CodingKey {

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKDeploymentTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKDeploymentTests.swift
@@ -1,0 +1,186 @@
+//
+//  GPTKDeploymentTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("GPTK Deployment Tests")
+struct GPTKDeploymentTests {
+    private let tempDir: URL
+
+    init() throws {
+        tempDir = try makeGPTKTempDir()
+    }
+
+    // MARK: - Deployment
+
+    @Test("Deploy backs up Wine's originals and places the payload")
+    func deploy() throws {
+        let store = try makeImportedStore(in: tempDir)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        let backup = store.appending(path: "originals").appending(path: "d3d11.dll")
+        let backupData = try Data(contentsOf: backup)
+        #expect(backupData.suffix(13) == Data("wine original".utf8))
+
+        let wineLib = runtime.appending(path: "Wine").appending(path: "lib")
+        let deployed = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
+            .appending(path: "dxgi.dll")
+        #expect(FileManager.default.fileExists(atPath: deployed.path(percentEncoded: false)))
+        #expect(GPTKImporter.isDeployed(inLibraryFolder: runtime))
+
+        let link = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
+            .appending(path: "d3d12.so")
+        let destination = try FileManager.default.destinationOfSymbolicLink(
+            atPath: link.path(percentEncoded: false)
+        )
+        #expect(destination == GPTKImporter.unixLinkDestination)
+    }
+
+    @Test("Redeploying never overwrites the backed-up originals")
+    func redeployKeepsOriginals() throws {
+        let store = try makeImportedStore(in: tempDir)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        let backup = store.appending(path: "originals").appending(path: "d3d11.dll")
+        let backupData = try Data(contentsOf: backup)
+        #expect(backupData.suffix(13) == Data("wine original".utf8))
+    }
+
+    @Test("Deploying from an empty store fails")
+    func deployEmptyStore() throws {
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+
+        #expect(throws: GPTKImportError.storeEmpty) {
+            try GPTKImporter.deploy(
+                fromStore: tempDir.appending(path: "missing"), intoLibraryFolder: runtime
+            )
+        }
+    }
+
+    @Test("Remove restores the originals and clears the payload")
+    func removeRestores() throws {
+        let store = try makeImportedStore(in: tempDir)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        try GPTKImporter.remove(fromLibraryFolder: runtime, usingStore: store)
+
+        let wineLib = runtime.appending(path: "Wine").appending(path: "lib")
+        let restored = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
+            .appending(path: "d3d11.dll")
+        let restoredData = try Data(contentsOf: restored)
+        #expect(restoredData.suffix(13) == Data("wine original".utf8))
+        #expect(!GPTKImporter.isDeployed(inLibraryFolder: runtime))
+
+        let external = wineLib.appending(path: "external")
+        #expect(!FileManager.default.fileExists(atPath: external.path(percentEncoded: false)))
+    }
+
+    // MARK: - Surviving a runtime install
+
+    @Test("The store and its backups survive a runtime reinstall")
+    func storeSurvivesRuntimeInstall() throws {
+        let appSupport = tempDir.appending(path: "AppSupport")
+        let store = GPTKImporter.storeFolder(inApplicationFolder: appSupport)
+        let lib = tempDir.appending(path: "payload")
+        try makePayload(at: lib)
+        try GPTKImporter.importPayload(GPTKImporter.validatePayload(at: lib), intoStore: store)
+
+        let runtime = appSupport.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        let tarball = try makeLibrariesTarball(in: tempDir.appending(path: "archive"))
+        try WhiskyWineInstaller.install(tarball: tarball, into: appSupport)
+
+        #expect(GPTKImporter.storedRecord(inStore: store)?.gptkVersion == "4.0b2")
+        let backup = store.appending(path: "originals").appending(path: "d3d11.dll")
+        #expect(FileManager.default.fileExists(atPath: backup.path(percentEncoded: false)))
+    }
+
+    @Test("A new engine discards backups taken from the previous one")
+    func redeployAfterEngineChangeRetakesOriginals() throws {
+        let store = try makeImportedStore(in: tempDir)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        try writeRuntimeVersion(at: runtime, 4, 0, 0)
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        try makeRuntime(at: runtime, marker: "wine 11 original")
+        try writeRuntimeVersion(at: runtime, 5, 0, 0)
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        let backup = store.appending(path: "originals").appending(path: "d3d11.dll")
+        let backupData = try Data(contentsOf: backup)
+        #expect(backupData.suffix(16) == Data("wine 11 original".utf8))
+    }
+
+    @Test("Remove drops backups from a replaced engine instead of restoring them")
+    func removeDiscardsStaleOriginals() throws {
+        let store = try makeImportedStore(in: tempDir)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        try writeRuntimeVersion(at: runtime, 4, 0, 0)
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        // A runtime install replaced the tree without a redeploy in between.
+        try makeRuntime(at: runtime, marker: "wine 11 original")
+        try writeRuntimeVersion(at: runtime, 5, 0, 0)
+
+        try GPTKImporter.remove(fromLibraryFolder: runtime, usingStore: store)
+
+        let current = runtime.appending(path: "Wine").appending(path: "lib")
+            .appending(path: "wine").appending(path: "x86_64-windows").appending(path: "d3d11.dll")
+        let currentData = try Data(contentsOf: current)
+        #expect(currentData.suffix(16) == Data("wine 11 original".utf8))
+
+        let backup = store.appending(path: "originals").appending(path: "d3d11.dll")
+        #expect(!FileManager.default.fileExists(atPath: backup.path(percentEncoded: false)))
+    }
+
+    // MARK: - Runtime capability flag
+
+    @Test("gptkCapable decodes when present and stays nil when absent")
+    func gptkCapableDecoding() throws {
+        let capable = WhiskyWineVersion(
+            version: .init(4, 0, 0), gptkCapable: true
+        )
+        let encoder = PropertyListEncoder()
+        let decoded = try PropertyListDecoder().decode(
+            WhiskyWineVersion.self, from: encoder.encode(capable)
+        )
+        #expect(decoded.gptkCapable == true)
+
+        let legacy = WhiskyWineVersion(version: .init(3, 1, 1))
+        let decodedLegacy = try PropertyListDecoder().decode(
+            WhiskyWineVersion.self, from: encoder.encode(legacy)
+        )
+        #expect(decodedLegacy.gptkCapable == nil)
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKDeploymentTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKDeploymentTests.swift
@@ -164,6 +164,23 @@ struct GPTKDeploymentTests {
         #expect(!FileManager.default.fileExists(atPath: backup.path(percentEncoded: false)))
     }
 
+    @Test("Remove spares Wine builtins an interrupted deploy never swapped")
+    func removeSparesUntouchedBuiltins() throws {
+        let store = try makeImportedStore(in: tempDir)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        try writeRuntimeVersion(at: runtime, 4, 0, 0)
+        let peDir = try makePartialDeploy(store: store, runtime: runtime, runtimeVersion: "4.0.0")
+
+        try GPTKImporter.remove(fromLibraryFolder: runtime, usingStore: store)
+
+        // Swapped, backed up only, and never touched all end as Wine's own.
+        for name in ["d3d10.dll", "d3d11.dll", "d3d12.dll"] {
+            let data = try Data(contentsOf: peDir.appending(path: name))
+            #expect(data.suffix(13) == Data("wine original".utf8))
+        }
+    }
+
     // MARK: - Runtime capability flag
 
     @Test("gptkCapable decodes when present and stays nil when absent")

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKFixtures.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKFixtures.swift
@@ -1,0 +1,134 @@
+//
+//  GPTKFixtures.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WhiskyKit
+
+/// Builds a fake PE: 0x40 bytes of stub, then either winebuild's marker
+/// (Apple's forwarders and Wine's builtins carry it) or filler (a native PE).
+func fakePE(builtin: Bool) -> Data {
+    var data = Data(count: 0x40)
+    data.append(builtin ? Data("Wine builtin DLL".utf8) : Data(count: 16))
+    data.append(Data(count: 16))
+    return data
+}
+
+/// Assembles Apple's `redist/lib` payload layout under `libRoot`.
+func makePayload(
+    at libRoot: URL,
+    version: String? = "4.0b2",
+    builtinForwarders: Bool = true,
+    omitting: Set<String> = [],
+    unixEntriesAsFiles: Bool = false
+) throws {
+    let fileManager = FileManager.default
+    let peDir = libRoot.appending(path: "wine").appending(path: "x86_64-windows")
+    let unixDir = libRoot.appending(path: "wine").appending(path: "x86_64-unix")
+    let external = libRoot.appending(path: "external")
+    try fileManager.createDirectory(at: peDir, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: unixDir, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: external, withIntermediateDirectories: true)
+
+    for name in GPTKImporter.forwarderDLLNames where !omitting.contains(name) {
+        try fakePE(builtin: builtinForwarders).write(to: peDir.appending(path: name))
+    }
+
+    if !omitting.contains("libd3dshared.dylib") {
+        try Data("fake dylib".utf8).write(to: external.appending(path: "libd3dshared.dylib"))
+    }
+
+    if !omitting.contains("D3DMetal.framework") {
+        let resources = external.appending(path: "D3DMetal.framework")
+            .appending(path: "Versions").appending(path: "A").appending(path: "Resources")
+        try fileManager.createDirectory(at: resources, withIntermediateDirectories: true)
+        if let version {
+            let plist: [String: Any] = ["CFBundleShortVersionString": version]
+            let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+            try data.write(to: resources.appending(path: "Info.plist"))
+        }
+    }
+
+    for name in GPTKImporter.unixLibraryNames where !omitting.contains(name) {
+        let entry = unixDir.appending(path: name)
+        if unixEntriesAsFiles {
+            try Data("resolved copy".utf8).write(to: entry)
+        } else {
+            try fileManager.createSymbolicLink(
+                atPath: entry.path(percentEncoded: false),
+                withDestinationPath: GPTKImporter.unixLinkDestination
+            )
+        }
+    }
+}
+
+/// Assembles a minimal Wine runtime tree with builtin-marked d3d DLLs.
+func makeRuntime(at libraryFolder: URL, marker: String = "wine original") throws {
+    let fileManager = FileManager.default
+    let wineLib = libraryFolder.appending(path: "Wine").appending(path: "lib")
+    let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
+    let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
+    try fileManager.createDirectory(at: peDir, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: unixDir, withIntermediateDirectories: true)
+    for name in ["d3d10.dll", "d3d11.dll", "d3d12.dll", "dxgi.dll"] {
+        var wineBuiltin = fakePE(builtin: true)
+        wineBuiltin.append(Data(marker.utf8))
+        try wineBuiltin.write(to: peDir.appending(path: name))
+    }
+}
+
+/// Writes the runtime version plist deploy stamps its backups against.
+func writeRuntimeVersion(at libraryFolder: URL, _ major: Int, _ minor: Int, _ patch: Int) throws {
+    let plist: [String: Any] = ["version": ["major": major, "minor": minor, "patch": patch]]
+    let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+    try data.write(
+        to: libraryFolder.appending(path: "WhiskyWineVersion").appendingPathExtension("plist")
+    )
+}
+
+/// Gzip-tars a minimal `Libraries` tree the way the runtime archive ships.
+func makeLibrariesTarball(in directory: URL) throws -> URL {
+    let source = directory.appending(path: "Libraries")
+    try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+    try Data("marker".utf8).write(to: source.appending(path: "marker.txt"))
+
+    let tarball = directory.appending(path: "archive.tar.gz")
+    let tar = Process()
+    tar.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+    tar.currentDirectoryURL = directory
+    tar.arguments = ["-czf", tarball.path(percentEncoded: false), "Libraries"]
+    try tar.run()
+    tar.waitUntilExit()
+    return tarball
+}
+
+/// A fresh scratch directory for one GPTK test case.
+func makeGPTKTempDir() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appending(path: "gptk_tests_\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+/// A store holding a freshly imported payload, under `tempDir`.
+func makeImportedStore(in tempDir: URL) throws -> URL {
+    let lib = tempDir.appending(path: "payload")
+    let store = tempDir.appending(path: "store")
+    try makePayload(at: lib)
+    try GPTKImporter.importPayload(GPTKImporter.validatePayload(at: lib), intoStore: store)
+    return store
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKFixtures.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKFixtures.swift
@@ -124,6 +124,34 @@ func makeGPTKTempDir() throws -> URL {
     return url
 }
 
+/// Hand-builds what an interrupted same-version deploy leaves behind, and
+/// returns the runtime's PE directory: `d3d10.dll` swapped with its original
+/// backed up, `d3d12.dll` backed up before its forwarder was copied in, and
+/// `d3d11.dll` never reached, so still Wine's own with no backup.
+@discardableResult
+func makePartialDeploy(store: URL, runtime: URL, runtimeVersion: String) throws -> URL {
+    let fileManager = FileManager.default
+    let peDir = runtime.appending(path: "Wine").appending(path: "lib")
+        .appending(path: "wine").appending(path: "x86_64-windows")
+    let storePE = store.appending(path: "lib")
+        .appending(path: "wine").appending(path: "x86_64-windows")
+    let originals = store.appending(path: "originals")
+    try fileManager.createDirectory(at: originals, withIntermediateDirectories: true)
+
+    let encoder = PropertyListEncoder()
+    encoder.outputFormat = .xml
+    try encoder.encode(GPTKOriginalsRecord(runtimeVersion: runtimeVersion))
+        .write(to: GPTKImporter.originalsRecordURL(inStore: store))
+
+    for name in ["d3d10.dll", "d3d12.dll"] {
+        try fileManager.moveItem(at: peDir.appending(path: name), to: originals.appending(path: name))
+    }
+    try fileManager.copyItem(
+        at: storePE.appending(path: "d3d10.dll"), to: peDir.appending(path: "d3d10.dll")
+    )
+    return peDir
+}
+
 /// A store holding a freshly imported payload, under `tempDir`.
 func makeImportedStore(in tempDir: URL) throws -> URL {
     let lib = tempDir.appending(path: "payload")

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKImporterTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKImporterTests.swift
@@ -20,86 +20,12 @@ import Foundation
 import Testing
 @testable import WhiskyKit
 
-/// Builds a fake PE: 0x40 bytes of stub, then either winebuild's marker
-/// (Apple's forwarders and Wine's builtins carry it) or filler (a native PE).
-private func fakePE(builtin: Bool) -> Data {
-    var data = Data(count: 0x40)
-    data.append(builtin ? Data("Wine builtin DLL".utf8) : Data(count: 16))
-    data.append(Data(count: 16))
-    return data
-}
-
-/// Assembles Apple's `redist/lib` payload layout under `libRoot`.
-private func makePayload(
-    at libRoot: URL,
-    version: String? = "4.0b2",
-    builtinForwarders: Bool = true,
-    omitting: Set<String> = [],
-    unixEntriesAsFiles: Bool = false
-) throws {
-    let fileManager = FileManager.default
-    let peDir = libRoot.appending(path: "wine").appending(path: "x86_64-windows")
-    let unixDir = libRoot.appending(path: "wine").appending(path: "x86_64-unix")
-    let external = libRoot.appending(path: "external")
-    try fileManager.createDirectory(at: peDir, withIntermediateDirectories: true)
-    try fileManager.createDirectory(at: unixDir, withIntermediateDirectories: true)
-    try fileManager.createDirectory(at: external, withIntermediateDirectories: true)
-
-    for name in GPTKImporter.forwarderDLLNames where !omitting.contains(name) {
-        try fakePE(builtin: builtinForwarders).write(to: peDir.appending(path: name))
-    }
-
-    if !omitting.contains("libd3dshared.dylib") {
-        try Data("fake dylib".utf8).write(to: external.appending(path: "libd3dshared.dylib"))
-    }
-
-    if !omitting.contains("D3DMetal.framework") {
-        let resources = external.appending(path: "D3DMetal.framework")
-            .appending(path: "Versions").appending(path: "A").appending(path: "Resources")
-        try fileManager.createDirectory(at: resources, withIntermediateDirectories: true)
-        if let version {
-            let plist: [String: Any] = ["CFBundleShortVersionString": version]
-            let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
-            try data.write(to: resources.appending(path: "Info.plist"))
-        }
-    }
-
-    for name in GPTKImporter.unixLibraryNames where !omitting.contains(name) {
-        let entry = unixDir.appending(path: name)
-        if unixEntriesAsFiles {
-            try Data("resolved copy".utf8).write(to: entry)
-        } else {
-            try fileManager.createSymbolicLink(
-                atPath: entry.path(percentEncoded: false),
-                withDestinationPath: GPTKImporter.unixLinkDestination
-            )
-        }
-    }
-}
-
-/// Assembles a minimal Wine runtime tree with builtin-marked d3d DLLs.
-private func makeRuntime(at libraryFolder: URL) throws {
-    let fileManager = FileManager.default
-    let wineLib = libraryFolder.appending(path: "Wine").appending(path: "lib")
-    let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
-    let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
-    try fileManager.createDirectory(at: peDir, withIntermediateDirectories: true)
-    try fileManager.createDirectory(at: unixDir, withIntermediateDirectories: true)
-    for name in ["d3d10.dll", "d3d11.dll", "d3d12.dll", "dxgi.dll"] {
-        var wineBuiltin = fakePE(builtin: true)
-        wineBuiltin.append(Data("wine original".utf8))
-        try wineBuiltin.write(to: peDir.appending(path: name))
-    }
-}
-
 @Suite("GPTKImporter Tests")
 struct GPTKImporterTests {
     private let tempDir: URL
 
     init() throws {
-        tempDir = FileManager.default.temporaryDirectory
-            .appending(path: "gptk_tests_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        tempDir = try makeGPTKTempDir()
     }
 
     // MARK: - Locating
@@ -149,6 +75,18 @@ struct GPTKImporterTests {
         try makePayload(at: lib, builtinForwarders: false)
 
         #expect(throws: GPTKImportError.forwarderNotBuiltin("d3d10.dll")) {
+            try GPTKImporter.validatePayload(at: lib)
+        }
+    }
+
+    @Test("A forwarder too short to hold the marker is rejected")
+    func validateTruncatedForwarder() throws {
+        let lib = tempDir.appending(path: "lib")
+        try makePayload(at: lib)
+        let peDir = lib.appending(path: "wine").appending(path: "x86_64-windows")
+        try Data([0x4D, 0x5A, 0x00]).write(to: peDir.appending(path: "d3d12.dll"))
+
+        #expect(throws: GPTKImportError.forwarderNotBuiltin("d3d12.dll")) {
             try GPTKImporter.validatePayload(at: lib)
         }
     }
@@ -226,108 +164,5 @@ struct GPTKImporterTests {
         )
 
         #expect(GPTKImporter.storedRecord(inStore: store) == nil)
-    }
-
-    // MARK: - Deployment
-
-    private func importedStore() throws -> URL {
-        let lib = tempDir.appending(path: "payload")
-        let store = tempDir.appending(path: "store")
-        try makePayload(at: lib)
-        let payload = try GPTKImporter.validatePayload(at: lib)
-        try GPTKImporter.importPayload(payload, intoStore: store)
-        return store
-    }
-
-    @Test("Deploy backs up Wine's originals and places the payload")
-    func deploy() throws {
-        let store = try importedStore()
-        let runtime = tempDir.appending(path: "Libraries")
-        try makeRuntime(at: runtime)
-
-        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
-
-        let backup = store.appending(path: "originals").appending(path: "d3d11.dll")
-        let backupData = try Data(contentsOf: backup)
-        #expect(backupData.suffix(13) == Data("wine original".utf8))
-
-        let wineLib = runtime.appending(path: "Wine").appending(path: "lib")
-        let deployed = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
-            .appending(path: "dxgi.dll")
-        #expect(FileManager.default.fileExists(atPath: deployed.path(percentEncoded: false)))
-        #expect(GPTKImporter.isDeployed(inLibraryFolder: runtime))
-
-        let link = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
-            .appending(path: "d3d12.so")
-        let destination = try FileManager.default.destinationOfSymbolicLink(
-            atPath: link.path(percentEncoded: false)
-        )
-        #expect(destination == GPTKImporter.unixLinkDestination)
-    }
-
-    @Test("Redeploying never overwrites the backed-up originals")
-    func redeployKeepsOriginals() throws {
-        let store = try importedStore()
-        let runtime = tempDir.appending(path: "Libraries")
-        try makeRuntime(at: runtime)
-
-        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
-        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
-
-        let backup = store.appending(path: "originals").appending(path: "d3d11.dll")
-        let backupData = try Data(contentsOf: backup)
-        #expect(backupData.suffix(13) == Data("wine original".utf8))
-    }
-
-    @Test("Deploying from an empty store fails")
-    func deployEmptyStore() throws {
-        let runtime = tempDir.appending(path: "Libraries")
-        try makeRuntime(at: runtime)
-
-        #expect(throws: GPTKImportError.storeEmpty) {
-            try GPTKImporter.deploy(
-                fromStore: tempDir.appending(path: "missing"), intoLibraryFolder: runtime
-            )
-        }
-    }
-
-    @Test("Remove restores the originals and clears the payload")
-    func removeRestores() throws {
-        let store = try importedStore()
-        let runtime = tempDir.appending(path: "Libraries")
-        try makeRuntime(at: runtime)
-        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
-
-        try GPTKImporter.remove(fromLibraryFolder: runtime, usingStore: store)
-
-        let wineLib = runtime.appending(path: "Wine").appending(path: "lib")
-        let restored = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
-            .appending(path: "d3d11.dll")
-        let restoredData = try Data(contentsOf: restored)
-        #expect(restoredData.suffix(13) == Data("wine original".utf8))
-        #expect(!GPTKImporter.isDeployed(inLibraryFolder: runtime))
-
-        let external = wineLib.appending(path: "external")
-        #expect(!FileManager.default.fileExists(atPath: external.path(percentEncoded: false)))
-    }
-
-    // MARK: - Runtime capability flag
-
-    @Test("gptkCapable decodes when present and stays nil when absent")
-    func gptkCapableDecoding() throws {
-        let capable = WhiskyWineVersion(
-            version: .init(4, 0, 0), gptkCapable: true
-        )
-        let encoder = PropertyListEncoder()
-        let decoded = try PropertyListDecoder().decode(
-            WhiskyWineVersion.self, from: encoder.encode(capable)
-        )
-        #expect(decoded.gptkCapable == true)
-
-        let legacy = WhiskyWineVersion(version: .init(3, 1, 1))
-        let decodedLegacy = try PropertyListDecoder().decode(
-            WhiskyWineVersion.self, from: encoder.encode(legacy)
-        )
-        #expect(decodedLegacy.gptkCapable == nil)
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKImporterTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKImporterTests.swift
@@ -1,0 +1,333 @@
+//
+//  GPTKImporterTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+/// Builds a fake PE: 0x40 bytes of stub, then either winebuild's marker
+/// (Apple's forwarders and Wine's builtins carry it) or filler (a native PE).
+private func fakePE(builtin: Bool) -> Data {
+    var data = Data(count: 0x40)
+    data.append(builtin ? Data("Wine builtin DLL".utf8) : Data(count: 16))
+    data.append(Data(count: 16))
+    return data
+}
+
+/// Assembles Apple's `redist/lib` payload layout under `libRoot`.
+private func makePayload(
+    at libRoot: URL,
+    version: String? = "4.0b2",
+    builtinForwarders: Bool = true,
+    omitting: Set<String> = [],
+    unixEntriesAsFiles: Bool = false
+) throws {
+    let fileManager = FileManager.default
+    let peDir = libRoot.appending(path: "wine").appending(path: "x86_64-windows")
+    let unixDir = libRoot.appending(path: "wine").appending(path: "x86_64-unix")
+    let external = libRoot.appending(path: "external")
+    try fileManager.createDirectory(at: peDir, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: unixDir, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: external, withIntermediateDirectories: true)
+
+    for name in GPTKImporter.forwarderDLLNames where !omitting.contains(name) {
+        try fakePE(builtin: builtinForwarders).write(to: peDir.appending(path: name))
+    }
+
+    if !omitting.contains("libd3dshared.dylib") {
+        try Data("fake dylib".utf8).write(to: external.appending(path: "libd3dshared.dylib"))
+    }
+
+    if !omitting.contains("D3DMetal.framework") {
+        let resources = external.appending(path: "D3DMetal.framework")
+            .appending(path: "Versions").appending(path: "A").appending(path: "Resources")
+        try fileManager.createDirectory(at: resources, withIntermediateDirectories: true)
+        if let version {
+            let plist: [String: Any] = ["CFBundleShortVersionString": version]
+            let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+            try data.write(to: resources.appending(path: "Info.plist"))
+        }
+    }
+
+    for name in GPTKImporter.unixLibraryNames where !omitting.contains(name) {
+        let entry = unixDir.appending(path: name)
+        if unixEntriesAsFiles {
+            try Data("resolved copy".utf8).write(to: entry)
+        } else {
+            try fileManager.createSymbolicLink(
+                atPath: entry.path(percentEncoded: false),
+                withDestinationPath: GPTKImporter.unixLinkDestination
+            )
+        }
+    }
+}
+
+/// Assembles a minimal Wine runtime tree with builtin-marked d3d DLLs.
+private func makeRuntime(at libraryFolder: URL) throws {
+    let fileManager = FileManager.default
+    let wineLib = libraryFolder.appending(path: "Wine").appending(path: "lib")
+    let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
+    let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
+    try fileManager.createDirectory(at: peDir, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: unixDir, withIntermediateDirectories: true)
+    for name in ["d3d10.dll", "d3d11.dll", "d3d12.dll", "dxgi.dll"] {
+        var wineBuiltin = fakePE(builtin: true)
+        wineBuiltin.append(Data("wine original".utf8))
+        try wineBuiltin.write(to: peDir.appending(path: name))
+    }
+}
+
+@Suite("GPTKImporter Tests")
+struct GPTKImporterTests {
+    private let tempDir: URL
+
+    init() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appending(path: "gptk_tests_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Locating
+
+    @Test("Locates the payload from volume root, redist folder, and lib folder")
+    func locateFromAllShapes() throws {
+        let volume = tempDir.appending(path: "volume")
+        let lib = volume.appending(path: "redist").appending(path: "lib")
+        try makePayload(at: lib)
+
+        #expect(GPTKImporter.locatePayload(under: volume) == lib)
+        #expect(GPTKImporter.locatePayload(under: volume.appending(path: "redist")) == lib)
+        #expect(GPTKImporter.locatePayload(under: lib) == lib)
+    }
+
+    @Test("Locate returns nil when nothing payload-shaped exists")
+    func locateNothing() throws {
+        #expect(GPTKImporter.locatePayload(under: tempDir) == nil)
+    }
+
+    // MARK: - Validation
+
+    @Test("Validates a complete payload and reads its version")
+    func validateComplete() throws {
+        let lib = tempDir.appending(path: "lib")
+        try makePayload(at: lib)
+
+        let payload = try GPTKImporter.validatePayload(at: lib)
+
+        #expect(payload.version == "4.0b2")
+        #expect(payload.libRoot == lib)
+    }
+
+    @Test("Missing forwarders are reported by name")
+    func validateMissingForwarder() throws {
+        let lib = tempDir.appending(path: "lib")
+        try makePayload(at: lib, omitting: ["d3d12.dll"])
+
+        #expect(throws: GPTKImportError.payloadIncomplete(missing: ["wine/x86_64-windows/d3d12.dll"])) {
+            try GPTKImporter.validatePayload(at: lib)
+        }
+    }
+
+    @Test("A native-marked forwarder is rejected")
+    func validateNativeForwarder() throws {
+        let lib = tempDir.appending(path: "lib")
+        try makePayload(at: lib, builtinForwarders: false)
+
+        #expect(throws: GPTKImportError.forwarderNotBuiltin("d3d10.dll")) {
+            try GPTKImporter.validatePayload(at: lib)
+        }
+    }
+
+    @Test("A missing framework is reported")
+    func validateMissingFramework() throws {
+        let lib = tempDir.appending(path: "lib")
+        try makePayload(at: lib, omitting: ["D3DMetal.framework"])
+
+        #expect(throws: GPTKImportError.payloadIncomplete(missing: ["external/D3DMetal.framework"])) {
+            try GPTKImporter.validatePayload(at: lib)
+        }
+    }
+
+    @Test("An unreadable framework version is rejected")
+    func validateUnreadableVersion() throws {
+        let lib = tempDir.appending(path: "lib")
+        try makePayload(at: lib, version: nil)
+
+        #expect(throws: GPTKImportError.versionUnreadable) {
+            try GPTKImporter.validatePayload(at: lib)
+        }
+    }
+
+    // MARK: - Import
+
+    @Test("Import copies the payload, normalizes symlinks, and records the version")
+    func importPayload() throws {
+        let lib = tempDir.appending(path: "lib")
+        let store = tempDir.appending(path: "store")
+        try makePayload(at: lib)
+        let payload = try GPTKImporter.validatePayload(at: lib)
+
+        let record = try GPTKImporter.importPayload(payload, intoStore: store)
+
+        #expect(record.gptkVersion == "4.0b2")
+        #expect(GPTKImporter.storedRecord(inStore: store)?.gptkVersion == "4.0b2")
+
+        let link = store.appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-unix").appending(path: "dxgi.so")
+        let destination = try FileManager.default.destinationOfSymbolicLink(
+            atPath: link.path(percentEncoded: false)
+        )
+        #expect(destination == GPTKImporter.unixLinkDestination)
+    }
+
+    @Test("Import rebuilds unix entries as symlinks even when the source resolved them into files")
+    func importNormalizesResolvedUnixEntries() throws {
+        let lib = tempDir.appending(path: "lib")
+        let store = tempDir.appending(path: "store")
+        try makePayload(at: lib, unixEntriesAsFiles: true)
+        let payload = try GPTKImporter.validatePayload(at: lib)
+
+        try GPTKImporter.importPayload(payload, intoStore: store)
+
+        let link = store.appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-unix").appending(path: "d3d11.so")
+        let destination = try FileManager.default.destinationOfSymbolicLink(
+            atPath: link.path(percentEncoded: false)
+        )
+        #expect(destination == GPTKImporter.unixLinkDestination)
+    }
+
+    @Test("Stored record is nil without a store or with a gutted payload")
+    func storedRecordAbsent() throws {
+        let store = tempDir.appending(path: "store")
+        #expect(GPTKImporter.storedRecord(inStore: store) == nil)
+
+        let lib = tempDir.appending(path: "lib")
+        try makePayload(at: lib)
+        let payload = try GPTKImporter.validatePayload(at: lib)
+        try GPTKImporter.importPayload(payload, intoStore: store)
+        try FileManager.default.removeItem(
+            at: store.appending(path: "lib").appending(path: "external")
+        )
+
+        #expect(GPTKImporter.storedRecord(inStore: store) == nil)
+    }
+
+    // MARK: - Deployment
+
+    private func importedStore() throws -> URL {
+        let lib = tempDir.appending(path: "payload")
+        let store = tempDir.appending(path: "store")
+        try makePayload(at: lib)
+        let payload = try GPTKImporter.validatePayload(at: lib)
+        try GPTKImporter.importPayload(payload, intoStore: store)
+        return store
+    }
+
+    @Test("Deploy backs up Wine's originals and places the payload")
+    func deploy() throws {
+        let store = try importedStore()
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        let backup = store.appending(path: "originals").appending(path: "d3d11.dll")
+        let backupData = try Data(contentsOf: backup)
+        #expect(backupData.suffix(13) == Data("wine original".utf8))
+
+        let wineLib = runtime.appending(path: "Wine").appending(path: "lib")
+        let deployed = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
+            .appending(path: "dxgi.dll")
+        #expect(FileManager.default.fileExists(atPath: deployed.path(percentEncoded: false)))
+        #expect(GPTKImporter.isDeployed(inLibraryFolder: runtime))
+
+        let link = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
+            .appending(path: "d3d12.so")
+        let destination = try FileManager.default.destinationOfSymbolicLink(
+            atPath: link.path(percentEncoded: false)
+        )
+        #expect(destination == GPTKImporter.unixLinkDestination)
+    }
+
+    @Test("Redeploying never overwrites the backed-up originals")
+    func redeployKeepsOriginals() throws {
+        let store = try importedStore()
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        let backup = store.appending(path: "originals").appending(path: "d3d11.dll")
+        let backupData = try Data(contentsOf: backup)
+        #expect(backupData.suffix(13) == Data("wine original".utf8))
+    }
+
+    @Test("Deploying from an empty store fails")
+    func deployEmptyStore() throws {
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+
+        #expect(throws: GPTKImportError.storeEmpty) {
+            try GPTKImporter.deploy(
+                fromStore: tempDir.appending(path: "missing"), intoLibraryFolder: runtime
+            )
+        }
+    }
+
+    @Test("Remove restores the originals and clears the payload")
+    func removeRestores() throws {
+        let store = try importedStore()
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        try GPTKImporter.remove(fromLibraryFolder: runtime, usingStore: store)
+
+        let wineLib = runtime.appending(path: "Wine").appending(path: "lib")
+        let restored = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
+            .appending(path: "d3d11.dll")
+        let restoredData = try Data(contentsOf: restored)
+        #expect(restoredData.suffix(13) == Data("wine original".utf8))
+        #expect(!GPTKImporter.isDeployed(inLibraryFolder: runtime))
+
+        let external = wineLib.appending(path: "external")
+        #expect(!FileManager.default.fileExists(atPath: external.path(percentEncoded: false)))
+    }
+
+    // MARK: - Runtime capability flag
+
+    @Test("gptkCapable decodes when present and stays nil when absent")
+    func gptkCapableDecoding() throws {
+        let capable = WhiskyWineVersion(
+            version: .init(4, 0, 0), gptkCapable: true
+        )
+        let encoder = PropertyListEncoder()
+        let decoded = try PropertyListDecoder().decode(
+            WhiskyWineVersion.self, from: encoder.encode(capable)
+        )
+        #expect(decoded.gptkCapable == true)
+
+        let legacy = WhiskyWineVersion(version: .init(3, 1, 1))
+        let decodedLegacy = try PropertyListDecoder().decode(
+            WhiskyWineVersion.self, from: encoder.encode(legacy)
+        )
+        #expect(decodedLegacy.gptkCapable == nil)
+    }
+}


### PR DESCRIPTION
pairs with #163, complements the #146 gating work.

#141/#143 made the resolver honest and #146 is making the picker honest, but there was still no way to actually get a d3dmetal payload into whisky. settings now has a game porting toolkit section: point it at apple's evaluation environment (the dmg, the outer gptk dmg with the nested image, a mounted volume, or a bare folder) and the payload is validated and imported. nothing of apple's is redistributed, the user supplies their own download.

the important part, per #163: today's runtime cannot execute the payload, so deployment into the wine tree is gated behind a `gptkCapable` key in the runtime version plist. imported payloads wait in `Libraries/D3DMetal` and deploy automatically once a capable engine is installed, no re-import needed. that flag is the handshake: whenever the engine build gains the unwind support, it just sets the key.

what's in it:

- **GPTKImporter** (kit): locate the `redist/lib` root, validate completeness, require the builtin-marked forwarder variant (the inverse of the dxmt native gate), read the D3DMetal version from the framework plist, import into the store with the unix symlinks normalized (a copy pipeline that resolved them into file duplicates would break the dylib's `@loader_path` framework lookup)
- **GPTKImporter+Deployment** (kit): the capability gate, deploy with wine's originals backed up into the store, remove restores them, redeploys never clobber the backups
- **WhiskyWineVersion**: optional `gptkCapable` key, absent on every existing plist
- **GPTKDiskImage** (app): hdiutil attach/detach incl. finding the eval dmg nested inside the outer gptk image
- **GPTKSettingsSection** (app): import/remove with a capability footnote that says honestly whether the engine can run what was imported

testing: 15 new kit tests against fixture payloads with forged builtin markers and a fake runtime tree (locate shapes, each validation failure, symlink normalization, deploy/backup/redeploy/remove, capability flag decode). full battery local: 38 swift-testing + 1167 xctest green, swiftlint --strict and swiftformat clean, app target builds.
