### PR TITLE
fix: steam library follow-ups from review

### DIFF
--- a/Whisky/Utils/SteamClientOrchestrator.swift
+++ b/Whisky/Utils/SteamClientOrchestrator.swift
@@ -63,6 +63,12 @@ final class SteamClientOrchestrator: ObservableObject {
     /// The in-flight client startup, so concurrent launches await one attempt
     /// instead of each racing to start their own client.
     private var clientStartup: Task<Void, Error>?
+    private var launchTasks: [Int: Task<Void, Never>] = [:]
+    /// The launch watch polls every 2s and the status poller every 10s; sharing
+    /// one short-lived snapshot stops them each running their own tasklist.exe.
+    private var processSnapshot: (processes: [WineProcess], taken: Date)?
+    private var snapshotRead: Task<[WineProcess], Never>?
+    private let snapshotLifetime: TimeInterval = 1
 
     private lazy var watch = SteamProcessWatch(pollInterval: .seconds(2)) { [weak self] in
         await self?.runningImageNames() ?? []
@@ -83,10 +89,20 @@ final class SteamClientOrchestrator: ObservableObject {
     }
 
     /// Launches a game via `-applaunch`, bringing the client up first if needed.
-    func launch(_ game: SteamGame) async {
+    ///
+    /// Owns the task rather than the caller so ``stop()`` can cancel a launch
+    /// still inside its grace period.
+    func launch(_ game: SteamGame) {
         guard phases[game.appId] == nil else { return }
         phases[game.appId] = .startingClient
-        defer { phases[game.appId] = nil }
+        launchTasks[game.appId] = Task { await performLaunch(game) }
+    }
+
+    private func performLaunch(_ game: SteamGame) async {
+        defer {
+            phases[game.appId] = nil
+            launchTasks[game.appId] = nil
+        }
 
         guard let steamRoot = SteamLibrary.detectInstall(bottleURL: bottle.url) else {
             launchError = SteamOrchestratorError.steamNotInstalled.errorDescription
@@ -135,7 +151,6 @@ final class SteamClientOrchestrator: ObservableObject {
         trackingTask = Task { [weak self] in
             while !Task.isCancelled {
                 await self?.refreshRunningState()
-                guard !Task.isCancelled else { return }
                 try? await Task.sleep(for: .seconds(10))
             }
         }
@@ -145,14 +160,12 @@ final class SteamClientOrchestrator: ObservableObject {
     func stop(_ game: SteamGame) async {
         let names = executableNamesByAppId[game.appId]
             ?? SteamLibrary.executableNames(under: game.installURL)
-        guard let output = try? await Wine.runWine(["tasklist.exe", "/FO", "CSV"], bottle: bottle) else {
-            return
-        }
 
-        for process in Wine.parseTasklistOutput(output)
+        for process in await runningProcesses()
             where names.contains(process.imageName.lowercased()) {
             await Wine.gracefulKillProcess(winePID: process.winePID, bottle: bottle)
         }
+        processSnapshot = nil
         await refreshRunningState()
     }
 
@@ -165,6 +178,12 @@ final class SteamClientOrchestrator: ObservableObject {
     func stop() {
         trackingTask?.cancel()
         trackingTask = nil
+        for task in launchTasks.values {
+            task.cancel()
+        }
+        launchTasks.removeAll()
+        clientStartup?.cancel()
+        clientStartup = nil
         downloadMonitor.stopMonitoring()
     }
 
@@ -203,12 +222,7 @@ final class SteamClientOrchestrator: ObservableObject {
             return
         }
 
-        // The launcherManaged env recipe (UTF-8 locale, CEF sandbox flags) is
-        // what keeps steamwebhelper alive; make sure it applies to this launch.
-        if bottle.settings.detectedLauncher == nil {
-            bottle.settings.detectedLauncher = .steam
-        }
-        bottle.settings.launcherCompatibilityMode = true
+        applySteamLauncherFixes()
 
         let bottle = self.bottle
         // steam.exe -silent runs for the whole session -- never await it.
@@ -221,6 +235,20 @@ final class SteamClientOrchestrator: ObservableObject {
             return
         }
         throw SteamOrchestratorError.clientTimeout
+    }
+
+    /// Applies Steam's launcher fixes through the shared path, which carries the
+    /// locale, DXVK and GPU-spoofing settings steamwebhelper needs and not just
+    /// the compat flag.
+    ///
+    /// Skipped in manual mode: the user picked that launcher and that compat
+    /// setting, and Play must not quietly overrule either.
+    private func applySteamLauncherFixes() {
+        guard bottle.settings.launcherMode == .auto else { return }
+        guard !(bottle.settings.launcherCompatibilityMode
+            && bottle.settings.detectedLauncher == .steam)
+        else { return }
+        LauncherDetection.applyLauncherFixes(for: bottle, launcher: .steam)
     }
 
     private func isClientRunning() async -> Bool {
@@ -242,9 +270,29 @@ final class SteamClientOrchestrator: ObservableObject {
     }
 
     private func runningImageNames() async -> Set<String> {
+        await Set(runningProcesses().map { $0.imageName.lowercased() })
+    }
+
+    private func runningProcesses() async -> [WineProcess] {
+        if let processSnapshot, Date().timeIntervalSince(processSnapshot.taken) < snapshotLifetime {
+            return processSnapshot.processes
+        }
+        if let snapshotRead {
+            return await snapshotRead.value
+        }
+
+        let read = Task { await readProcessList() }
+        snapshotRead = read
+        let processes = await read.value
+        snapshotRead = nil
+        processSnapshot = (processes, Date())
+        return processes
+    }
+
+    private func readProcessList() async -> [WineProcess] {
         guard let output = try? await Wine.runWine(["tasklist.exe", "/FO", "CSV"], bottle: bottle) else {
             return []
         }
-        return Set(Wine.parseTasklistOutput(output).map { $0.imageName.lowercased() })
+        return Wine.parseTasklistOutput(output)
     }
 }

--- a/Whisky/Views/Bottle/SteamLibraryView.swift
+++ b/Whisky/Views/Bottle/SteamLibraryView.swift
@@ -86,7 +86,7 @@ struct SteamLibraryView: View {
                 .help("steam.button.stop")
             } else {
                 Button {
-                    Task { await orchestrator.launch(game) }
+                    orchestrator.launch(game)
                 } label: {
                     Image(systemName: "play.fill")
                 }

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamProcessWatch.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamProcessWatch.swift
@@ -43,7 +43,8 @@ public struct SteamProcessWatch: Sendable {
     ///
     /// Always checks at least once, so a zero timeout still observes the
     /// current state. An empty `names` set reports `true` immediately: there
-    /// is nothing to wait for.
+    /// is nothing to wait for. Returns `false` on cancellation rather than
+    /// running the timeout out, since `Task.sleep` throwing is swallowed here.
     public func waitForAny(of names: Set<String>, timeout: TimeInterval) async -> Bool {
         guard !names.isEmpty else { return true }
 
@@ -53,6 +54,7 @@ public struct SteamProcessWatch: Sendable {
                 return true
             }
             try? await Task.sleep(for: pollInterval)
+            guard !Task.isCancelled else { return false }
         } while Date() < deadline
         return false
     }

--- a/WhiskyKit/Tests/WhiskyKitTests/SteamProcessWatchTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamProcessWatchTests.swift
@@ -78,6 +78,19 @@ struct SteamProcessWatchTests {
         #expect(await watch.waitForAny(of: ["game.exe"], timeout: 0))
     }
 
+    @Test("Cancellation ends the wait instead of running the timeout out")
+    func cancellationEndsTheWait() async {
+        let watch = makeWatch(responses: [["svchost.exe"]], pollInterval: .milliseconds(20))
+
+        let started = Date()
+        let task = Task { await watch.waitForAny(of: ["game.exe"], timeout: 30) }
+        try? await Task.sleep(for: .milliseconds(50))
+        task.cancel()
+
+        #expect(await task.value == false)
+        #expect(Date().timeIntervalSince(started) < 5)
+    }
+
     @Test("Maps running processes back to their keys")
     func mapsRunningKeys() async {
         let watch = makeWatch(responses: [["casualtiesunknown.exe", "steam.exe"]])


### PR DESCRIPTION
the three deferred follow-ups from your #161 review.

**stacked on #161** and targets main because the base branch only exists on my fork, so the diff here carries #161's commits too. review/merge that one first and this collapses to the four files below.

the fourth one, "Starting Steam…" on every row, already went out with the #161 review fixes: per-app phases made it fall out.

**launcher fixes go through the shared path.** the hand-rolled `detectedLauncher = .steam` / `launcherCompatibilityMode = true` set two fields and skipped everything else `applyLauncherFixes` does for Steam, so the locale, dxvk and gpu spoofing that steamwebhelper needs never got applied by the Play button at all. it also only set the launcher when it was nil, so a different auto-detected one stayed active.

on the `launcherMode` gap, I read your note as: manual mode means the user is driving, so Play must not overrule their launcher choice or their compat toggle. that is what it does now, and in auto mode it applies Steam's set (replacing a different auto-detected launcher's). worth saying explicitly: it still *enables* compat mode in auto mode when it is off, because a fresh Steam bottle defaults to off and that is the case this code path exists for. if you meant the stricter reading, where compat is a user-owned master switch that Play never flips (matching `detectAndApplyLauncherFixes`, which only refines within an already-enabled mode), say so and I will drop the enable.

**cancellation.** launch tasks and the client startup are owned by the orchestrator rather than the view, so `stop()` cancels them on disappear, and `waitForAny` checks `Task.isCancelled` after its sleep since `try?` swallows the error. navigating away mid-launch no longer runs the 120s grace out. covered by a test that cancels a 30s wait and asserts it returns fast.

**shared snapshot.** one 1s process snapshot with the in-flight read shared between callers, so the 2s launch watch and the 10s status poller stop each spawning their own `tasklist.exe`. `stop(_:)` also routes through it and drops the snapshot after killing, so the refresh right after sees real state instead of the pre-kill cache.

1167 xctest + 67 swift-testing green, app target builds, swiftlint --strict and swiftformat clean.
