### PR TITLE
feat: whisky games and whisky launch, plus live shortcuts

### DIFF
--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -19851,6 +19851,28 @@
         }
       }
     },
+    "steam.launch.error.gameNotFound %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No bottle has App ID %lld installed."
+          }
+        }
+      }
+    },
+    "steam.launch.error.noClient" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This bottle doesn't have Steam installed."
+          }
+        }
+      }
+    },
     "steam.launch.failed" : {
       "localizations" : {
         "en" : {

--- a/Whisky/Utils/ProgramShortcut.swift
+++ b/Whisky/Utils/ProgramShortcut.swift
@@ -46,7 +46,8 @@ class ProgramShortcut {
     static func createShortcut(_ program: Program, app: URL, name: String) async {
         do {
             // Core bundle creation via shared WhiskyKit logic
-            let launchScript = program.generateTerminalCommand()
+            let target = ShortcutCreator.liveTarget(for: program.url, bottle: program.bottle)
+            let launchScript = ShortcutCreator.liveLaunchScript(for: target)
             try ShortcutCreator.createShortcutBundle(at: app, launchScript: launchScript, name: name)
 
             // App-specific: extract icon from PE file and set on the .app bundle

--- a/Whisky/Utils/SteamClientOrchestrator.swift
+++ b/Whisky/Utils/SteamClientOrchestrator.swift
@@ -118,21 +118,18 @@ final class SteamClientOrchestrator: ObservableObject {
         }
 
         phases[game.appId] = .launching
-        let plan = LaunchResolver.plan(
-            steamAppId: game.appId,
-            userOverrides: userOverrides(for: game)
-        )
-        let bottle = self.bottle
-        let appId = game.appId
-        // With the client already up this invocation just forwards and exits,
-        // but if the client died in between it becomes the client itself and
-        // runs for the whole session -- never await it.
-        Task {
-            _ = try? await Wine.runProgram(
-                at: steamExe, args: ["-applaunch", String(appId)], bottle: bottle,
-                programOverrides: plan.overrides,
-                gameProfileEnvironment: plan.gameProfileEnvironment
+        // Shared with `whisky launch`: resolves the GameDB profile and the
+        // user's overrides, records the bottle for this App ID, and hands
+        // -applaunch to the client. The returned task can outlive the game, so
+        // it is never awaited. installURL is already known here, which saves
+        // the launcher a library rescan.
+        do {
+            try SteamLauncher.launch(
+                appId: game.appId, bottle: bottle, installURL: game.installURL
             )
+        } catch {
+            launchError = error.localizedDescription
+            return
         }
 
         if await !waitForGameProcess(installURL: game.installURL) {
@@ -185,25 +182,6 @@ final class SteamClientOrchestrator: ObservableObject {
         clientStartup?.cancel()
         clientStartup = nil
         downloadMonitor.stopMonitoring()
-    }
-
-    /// The user's persisted overrides for this game's executables, so settings
-    /// tuned in the Programs tab survive a launch from the library.
-    private func userOverrides(for game: SteamGame) -> ProgramOverrides? {
-        let scanned = Dictionary(
-            bottle.programs.compactMap { program in
-                program.settings.overrides.map { (program.url.standardizedFileURL, $0) }
-            },
-            uniquingKeysWith: { first, _ in first }
-        )
-        let candidates = SteamLibrary.executableURLs(under: game.installURL).map { url in
-            // Falls back to a direct load for executables the bottle scan has
-            // not reached, so Play works before the Programs tab is opened.
-            let overrides = scanned[url.standardizedFileURL]
-                ?? Program(url: url, bottle: bottle, peFile: nil).settings.overrides
-            return ProgramOverrideCandidate(url: url, overrides: overrides ?? ProgramOverrides())
-        }
-        return SteamLibrary.preferredOverrides(among: candidates)
     }
 
     private func ensureClientRunning(steamExe: URL) async throws {

--- a/WhiskyCmd/Main.swift
+++ b/WhiskyCmd/Main.swift
@@ -417,7 +417,8 @@ extension Whisky {
             }
 
             // Generate launch script and create the bundle
-            let launchScript = program.generateTerminalCommand()
+            let target = ShortcutCreator.liveTarget(for: program.url, bottle: program.bottle)
+            let launchScript = ShortcutCreator.liveLaunchScript(for: target)
             try ShortcutCreator.createShortcutBundle(at: appURL, launchScript: launchScript, name: shortcutName)
 
             print("Created \(appURL.path(percentEncoded: false))")

--- a/WhiskyCmd/Main.swift
+++ b/WhiskyCmd/Main.swift
@@ -34,6 +34,8 @@ struct Whisky: AsyncParsableCommand {
             Delete.self,
             Remove.self,
             Run.self,
+            Games.self,
+            Launch.self,
             Shortcut.self,
             Shellenv.self
             /* Install.self,
@@ -453,5 +455,107 @@ extension Whisky {
         @Flag(name: [.long, .short], help: "Uninstall WhiskyWine") var whiskyWine = false
 
         mutating func run() throws {}
+    }
+}
+
+extension Whisky {
+    struct Games: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "List Steam games installed in a bottle."
+        )
+
+        @Argument(help: "Name of the bottle to inspect")
+        var bottleName: String
+
+        @Flag(name: .long, help: "Output as JSON")
+        var json: Bool = false
+
+        @MainActor
+        mutating func run() async throws {
+            var bottlesList = BottleData()
+            let bottles = bottlesList.loadBottles()
+
+            guard let bottle = bottles.first(where: { $0.settings.name == bottleName }) else {
+                throw ValidationError("A bottle with that name doesn't exist.")
+            }
+
+            let games = SteamLibrary.enumerate(bottleURL: bottle.url)
+
+            if json {
+                let payload = games.map { game in
+                    [
+                        "appId": String(game.appId),
+                        "name": game.name,
+                        "installPath": game.installURL.path(percentEncoded: false)
+                    ]
+                }
+                let data = try JSONSerialization.data(
+                    withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]
+                )
+                print(String(bytes: data, encoding: .utf8) ?? "")
+                return
+            }
+
+            var table = TextTable(headers: ["App ID", "Name", "Install Dir"])
+            for game in games {
+                table.addRow(values: [
+                    String(game.appId),
+                    game.name,
+                    game.installURL.lastPathComponent
+                ])
+            }
+            print(table.render())
+        }
+    }
+
+    struct Launch: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Launch a Steam game by App ID.",
+            discussion: """
+            Without --bottle, the bottle a game was last launched from is used, \
+            falling back to the first bottle that has it installed.
+            """
+        )
+
+        @Argument(help: "Steam App ID of the game")
+        var appId: Int
+
+        @Option(name: .long, help: "Name of the bottle to launch from")
+        var bottle: String?
+
+        @Flag(name: .long, help: "Output as JSON")
+        var json: Bool = false
+
+        @MainActor
+        mutating func run() async throws {
+            var bottlesList = BottleData()
+            let bottles = bottlesList.loadBottles()
+
+            let target: Bottle
+            if let bottleName = bottle {
+                guard let named = bottles.first(where: { $0.settings.name == bottleName }) else {
+                    throw ValidationError("A bottle with that name doesn't exist.")
+                }
+                target = named
+            } else {
+                target = try SteamLauncher.resolveBottle(appId: appId, in: bottles)
+            }
+
+            try SteamLauncher.launch(appId: appId, bottle: target)
+
+            if json {
+                let payload = [
+                    "appId": String(appId),
+                    "bottle": target.settings.name,
+                    "status": "launched"
+                ]
+                let data = try JSONSerialization.data(
+                    withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]
+                )
+                print(String(bytes: data, encoding: .utf8) ?? "")
+            } else {
+                print("Launched \(appId) in \(target.settings.name)")
+            }
+        }
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Steam/GameRouting.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/GameRouting.swift
@@ -1,0 +1,96 @@
+//
+//  GameRouting.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import os.log
+
+/// Remembers which bottle each Steam App ID was last launched from, so a game
+/// can be launched by App ID alone (from the CLI, or later from a URL) without
+/// asking which bottle every time.
+///
+/// Deliberately a plain dictionary on disk rather than a database: the file is
+/// hand-readable, a missing or corrupt entry only costs one prompt, and a wrong
+/// entry is corrected by the next launch.
+public struct GameRouting {
+    /// The default store, alongside the bottle registry.
+    public static var defaultURL: URL {
+        BottleData.containerDir.appending(path: "GameRouting").appendingPathExtension("plist")
+    }
+
+    private let url: URL
+
+    /// Creates a routing store.
+    ///
+    /// - Parameter url: The plist to read and write. Defaults to ``defaultURL``.
+    public init(url: URL = GameRouting.defaultURL) {
+        self.url = url
+    }
+
+    /// The bottle a game was last launched from.
+    public func bottleURL(forAppId appId: Int) -> URL? {
+        entries()[String(appId)].map { URL(fileURLWithPath: $0) }
+    }
+
+    /// All known routes, keyed by App ID.
+    public func routes() -> [Int: URL] {
+        var result: [Int: URL] = [:]
+        for (key, path) in entries() {
+            if let appId = Int(key) {
+                result[appId] = URL(fileURLWithPath: path)
+            }
+        }
+        return result
+    }
+
+    /// Records the bottle a game was launched from, replacing any previous
+    /// route for that App ID (last launch wins).
+    public func record(appId: Int, bottleURL: URL) {
+        var current = entries()
+        current[String(appId)] = bottleURL.path(percentEncoded: false)
+        write(current)
+    }
+
+    /// Forgets a route, e.g. when its bottle is deleted.
+    public func remove(appId: Int) {
+        var current = entries()
+        current.removeValue(forKey: String(appId))
+        write(current)
+    }
+
+    private func entries() -> [String: String] {
+        guard let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+              let dictionary = plist as? [String: String]
+        else { return [:] }
+        return dictionary
+    }
+
+    private func write(_ entries: [String: String]) {
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            let data = try PropertyListSerialization.data(
+                fromPropertyList: entries, format: .xml, options: 0
+            )
+            try data.write(to: url, options: .atomic)
+        } catch {
+            Logger.wineKit.error("Failed to write game routing: \(error.localizedDescription)")
+        }
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
@@ -1,0 +1,131 @@
+//
+//  SteamLauncher.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Errors thrown when launching a Steam game.
+public enum SteamLaunchError: LocalizedError, Equatable {
+    /// The bottle has no Steam installation.
+    case steamNotInstalled
+    /// No bottle known to Whisky has that App ID installed.
+    case gameNotFound(appId: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .steamNotInstalled:
+            "This bottle doesn't have Steam installed."
+        case let .gameNotFound(appId):
+            "No bottle has App ID \(appId) installed."
+        }
+    }
+}
+
+/// The single launch path for Steam games: resolve the game's GameDB profile,
+/// then hand `-applaunch` to the Windows client, which owns DRM and the game
+/// process itself.
+public enum SteamLauncher {
+    /// Launches a game through the bottle's Steam client.
+    ///
+    /// Starts the client too when it isn't running, since `-applaunch` on a
+    /// cold client brings it up first. The returned task is the client
+    /// invocation, which lives as long as the session, so callers should not
+    /// await it.
+    ///
+    /// - Parameters:
+    ///   - appId: The Steam App ID to launch.
+    ///   - bottle: The bottle whose Steam client to use.
+    ///   - installURL: The game's install folder, to save a library rescan when
+    ///     the caller already knows it.
+    ///   - record: Whether to remember this bottle for the App ID.
+    /// - Throws: ``SteamLaunchError/steamNotInstalled`` if the bottle has no client.
+    @MainActor
+    @discardableResult
+    public static func launch(
+        appId: Int, bottle: Bottle, installURL: URL? = nil, record: Bool = true
+    ) throws -> Task<Void, Never> {
+        guard let steamRoot = SteamLibrary.detectInstall(bottleURL: bottle.url) else {
+            throw SteamLaunchError.steamNotInstalled
+        }
+
+        if record {
+            GameRouting().record(appId: appId, bottleURL: bottle.url)
+        }
+
+        let installURL = installURL ?? SteamLibrary.enumerate(bottleURL: bottle.url)
+            .first { $0.appId == appId }?.installURL
+        let plan = LaunchResolver.plan(
+            steamAppId: appId,
+            userOverrides: installURL.flatMap { userOverrides(forInstallURL: $0, bottle: bottle) }
+        )
+        let steamExe = steamRoot.appending(path: "steam.exe")
+
+        return Task {
+            _ = try? await Wine.runProgram(
+                at: steamExe, args: ["-applaunch", String(appId)], bottle: bottle,
+                programOverrides: plan.overrides,
+                gameProfileEnvironment: plan.gameProfileEnvironment
+            )
+        }
+    }
+
+    /// The user's persisted overrides for a game's executables, so settings
+    /// tuned in the Programs tab survive a launch from the library or the cli.
+    @MainActor
+    static func userOverrides(forInstallURL installURL: URL, bottle: Bottle) -> ProgramOverrides? {
+        let scanned = Dictionary(
+            bottle.programs.compactMap { program in
+                program.settings.overrides.map { (program.url.standardizedFileURL, $0) }
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let candidates = SteamLibrary.executableURLs(under: installURL).map { url in
+            // Falls back to a direct load for executables the bottle scan has
+            // not reached, so Play works before the Programs tab is opened.
+            let overrides = scanned[url.standardizedFileURL]
+                ?? Program(url: url, bottle: bottle, peFile: nil).settings.overrides
+            return ProgramOverrideCandidate(url: url, overrides: overrides ?? ProgramOverrides())
+        }
+        return SteamLibrary.preferredOverrides(among: candidates)
+    }
+
+    /// Finds the bottle to launch an App ID from: the remembered route when it
+    /// still has the game installed, otherwise the first bottle that does.
+    ///
+    /// - Parameters:
+    ///   - appId: The Steam App ID to locate.
+    ///   - bottles: The bottles to search.
+    /// - Returns: The bottle holding the game.
+    /// - Throws: ``SteamLaunchError/gameNotFound(appId:)`` when no bottle has it.
+    @MainActor
+    public static func resolveBottle(appId: Int, in bottles: [Bottle]) throws -> Bottle {
+        let installs: (Bottle) -> Bool = { bottle in
+            SteamLibrary.enumerate(bottleURL: bottle.url).contains { $0.appId == appId }
+        }
+
+        if let routed = GameRouting().bottleURL(forAppId: appId),
+           let bottle = bottles.first(where: { $0.url.standardizedFileURL == routed.standardizedFileURL }),
+           installs(bottle) {
+            return bottle
+        }
+
+        guard let bottle = bottles.first(where: installs) else {
+            throw SteamLaunchError.gameNotFound(appId: appId)
+        }
+        return bottle
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
@@ -109,15 +109,18 @@ public enum SteamLauncher {
     /// - Parameters:
     ///   - appId: The Steam App ID to locate.
     ///   - bottles: The bottles to search.
+    ///   - routing: The route store to consult.
     /// - Returns: The bottle holding the game.
     /// - Throws: ``SteamLaunchError/gameNotFound(appId:)`` when no bottle has it.
     @MainActor
-    public static func resolveBottle(appId: Int, in bottles: [Bottle]) throws -> Bottle {
+    public static func resolveBottle(
+        appId: Int, in bottles: [Bottle], routing: GameRouting = GameRouting()
+    ) throws -> Bottle {
         let installs: (Bottle) -> Bool = { bottle in
             SteamLibrary.enumerate(bottleURL: bottle.url).contains { $0.appId == appId }
         }
 
-        if let routed = GameRouting().bottleURL(forAppId: appId),
+        if let routed = routing.bottleURL(forAppId: appId),
            let bottle = bottles.first(where: { $0.url.standardizedFileURL == routed.standardizedFileURL }),
            installs(bottle) {
             return bottle

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
@@ -28,9 +28,9 @@ public enum SteamLaunchError: LocalizedError, Equatable {
     public var errorDescription: String? {
         switch self {
         case .steamNotInstalled:
-            "This bottle doesn't have Steam installed."
+            String(localized: "steam.launch.error.noClient")
         case let .gameNotFound(appId):
-            "No bottle has App ID \(appId) installed."
+            String(localized: "steam.launch.error.gameNotFound \(appId)")
         }
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLibrary.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLibrary.swift
@@ -40,6 +40,15 @@ public enum SteamLibrary {
         "Program Files/Steam"
     ]
 
+    /// App IDs Steam installs as shared runtime payloads rather than games.
+    /// They appear as ordinary manifests but have nothing to launch.
+    static let nonGameAppIds: Set<Int> = [
+        228_980, // Steamworks Common Redistributables
+        1_070_560, // Steam Linux Runtime 1.0 (soldier)
+        1_391_110, // Steam Linux Runtime 2.0 (soldier)
+        1_628_350 // Steam Linux Runtime 3.0 (sniper)
+    ]
+
     /// Locates the Steam installation inside a bottle.
     ///
     /// - Parameter bottleURL: The root URL of the Wine bottle.
@@ -171,7 +180,8 @@ public enum SteamLibrary {
         for filename in contents where filename.hasPrefix("appmanifest_") && filename.hasSuffix(".acf") {
             guard let manifest = SteamAppManifest(contentsOf: steamApps.appending(path: filename)),
                   manifest.isFullyInstalled,
-                  isSafePathComponent(manifest.installDir)
+                  isSafePathComponent(manifest.installDir),
+                  !nonGameAppIds.contains(manifest.appId)
             else { continue }
 
             let installURL = steamApps.appending(path: "common").appending(path: manifest.installDir)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/ShortcutCreator.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/ShortcutCreator.swift
@@ -95,3 +95,81 @@ public enum ShortcutCreator {
         )
     }
 }
+
+public extension ShortcutCreator {
+    /// What a live shortcut launches.
+    enum LiveTarget: Equatable {
+        /// A Steam game, launched by App ID through the client so DRM and
+        /// GameDB profiles apply.
+        case steamGame(appId: Int)
+        /// A program addressed by bottle name and Windows path. The Windows
+        /// path is bottle-relative by construction, so the shortcut survives
+        /// the bottle moving.
+        case program(bottleName: String, windowsPath: String)
+    }
+
+    /// Picks the live target for a program: a Steam game when the executable
+    /// belongs to one of the bottle's Steam libraries (or ships a
+    /// steam_appid.txt), otherwise a bottle-name + Windows-path launch.
+    @MainActor
+    static func liveTarget(for url: URL, bottle: Bottle) -> LiveTarget {
+        if SteamLibrary.detectInstall(bottleURL: bottle.url) != nil {
+            let games = SteamLibrary.enumerate(bottleURL: bottle.url)
+            let path = url.standardizedFileURL.path
+            if let game = games.first(where: {
+                path.hasPrefix($0.installURL.standardizedFileURL.path + "/")
+            }) {
+                return .steamGame(appId: game.appId)
+            }
+            if let appId = SteamAppManifest.findAppIdForProgram(at: url) {
+                return .steamGame(appId: appId)
+            }
+        }
+
+        let windowsPath = windowsPath(for: url, bottleURL: bottle.url)
+            ?? url.path(percentEncoded: false)
+        return .program(bottleName: bottle.settings.name, windowsPath: windowsPath)
+    }
+
+    /// A launch script that goes through Whisky's live pipeline (WhiskyCmd)
+    /// instead of baking the environment at creation time: current settings,
+    /// GameDB profiles, backend deployment, and run logs all apply at launch,
+    /// and nothing breaks when the bottle moves or settings change.
+    static func liveLaunchScript(for target: LiveTarget) -> String {
+        let invocation = switch target {
+        case let .steamGame(appId):
+            "launch \(appId)"
+        case let .program(bottleName, windowsPath):
+            "run \(shellQuoted(bottleName)) \(shellQuoted(windowsPath))"
+        }
+
+        return """
+        WHISKY_CMD="/Applications/Whisky.app/Contents/Resources/WhiskyCmd"
+        if [ ! -x "$WHISKY_CMD" ]; then
+            WHISKY_APP="$(mdfind "kMDItemCFBundleIdentifier == '\(Bundle
+            .whiskyBundleIdentifier)'" 2>/dev/null | head -n 1)"
+            WHISKY_CMD="$WHISKY_APP/Contents/Resources/WhiskyCmd"
+        fi
+        if [ ! -x "$WHISKY_CMD" ]; then
+            osascript -e 'display alert "Whisky not found" message "Install Whisky to use this shortcut."'
+            exit 1
+        fi
+        exec "$WHISKY_CMD" \(invocation)
+        """
+    }
+
+    /// The Windows-style path (`C:\...`) of a file on the bottle's C drive,
+    /// or `nil` when the file lives elsewhere.
+    static func windowsPath(for url: URL, bottleURL: URL) -> String? {
+        let path = url.standardizedFileURL.path
+        let driveC = bottleURL.standardizedFileURL.appending(path: "drive_c").path
+        guard path.hasPrefix(driveC + "/") else { return nil }
+        let rest = String(path.dropFirst(driveC.count + 1))
+        return "C:\\" + rest.replacingOccurrences(of: "/", with: "\\")
+    }
+
+    /// Wraps a value in single quotes for safe shell interpolation.
+    static func shellQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/ShortcutCreator.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/ShortcutCreator.swift
@@ -31,7 +31,8 @@ import Foundation
 ///
 /// ```swift
 /// let appURL = URL(filePath: "~/Applications/MyGame.app")
-/// let script = program.generateTerminalCommand()
+/// let target = ShortcutCreator.liveTarget(for: program.url, bottle: program.bottle)
+/// let script = ShortcutCreator.liveLaunchScript(for: target)
 /// try ShortcutCreator.createShortcutBundle(at: appURL, launchScript: script, name: "MyGame")
 /// ```
 public enum ShortcutCreator {
@@ -101,6 +102,12 @@ public extension ShortcutCreator {
     enum LiveTarget: Equatable {
         /// A Steam game, launched by App ID through the client so DRM and
         /// GameDB profiles apply.
+        ///
+        /// Deliberately not pinned to a bottle: the App ID is Steam's own
+        /// identity for the game, and resolving it at launch means the
+        /// shortcut follows the copy that is actually installed rather than
+        /// breaking when its bottle moves or is deleted. A game installed in
+        /// two bottles launches from whichever was played most recently.
         case steamGame(appId: Int)
         /// A program addressed by bottle name and Windows path. The Windows
         /// path is bottle-relative by construction, so the shortcut survives

--- a/WhiskyKit/Tests/WhiskyKitTests/GameRoutingTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GameRoutingTests.swift
@@ -1,0 +1,104 @@
+//
+//  GameRoutingTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("GameRouting Tests")
+struct GameRoutingTests {
+    private func makeStore() -> (routing: GameRouting, cleanup: () -> Void) {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let url = tempDir.appending(path: "GameRouting.plist")
+        return (GameRouting(url: url), { try? FileManager.default.removeItem(at: tempDir) })
+    }
+
+    @Test("Records and reads a route")
+    func recordsRoute() {
+        let (routing, cleanup) = makeStore()
+        defer { cleanup() }
+
+        let bottle = URL(fileURLWithPath: "/tmp/bottles/one")
+        routing.record(appId: 4_576_510, bottleURL: bottle)
+
+        #expect(routing.bottleURL(forAppId: 4_576_510) == bottle)
+        #expect(routing.routes()[4_576_510] == bottle)
+    }
+
+    @Test("Last launch wins")
+    func lastLaunchWins() {
+        let (routing, cleanup) = makeStore()
+        defer { cleanup() }
+
+        routing.record(appId: 1, bottleURL: URL(fileURLWithPath: "/tmp/bottles/one"))
+        routing.record(appId: 1, bottleURL: URL(fileURLWithPath: "/tmp/bottles/two"))
+
+        #expect(routing.bottleURL(forAppId: 1)?.lastPathComponent == "two")
+        #expect(routing.routes().count == 1)
+    }
+
+    @Test("Unknown App IDs and a missing store read as empty")
+    func unknownReadsEmpty() {
+        let (routing, cleanup) = makeStore()
+        defer { cleanup() }
+
+        #expect(routing.bottleURL(forAppId: 99) == nil)
+        #expect(routing.routes().isEmpty)
+    }
+
+    @Test("Removes a route")
+    func removesRoute() {
+        let (routing, cleanup) = makeStore()
+        defer { cleanup() }
+
+        routing.record(appId: 7, bottleURL: URL(fileURLWithPath: "/tmp/bottles/seven"))
+        routing.remove(appId: 7)
+
+        #expect(routing.bottleURL(forAppId: 7) == nil)
+    }
+
+    @Test("Keeps other routes when one changes")
+    func keepsOtherRoutes() {
+        let (routing, cleanup) = makeStore()
+        defer { cleanup() }
+
+        routing.record(appId: 1, bottleURL: URL(fileURLWithPath: "/tmp/bottles/one"))
+        routing.record(appId: 2, bottleURL: URL(fileURLWithPath: "/tmp/bottles/two"))
+        routing.record(appId: 1, bottleURL: URL(fileURLWithPath: "/tmp/bottles/three"))
+
+        #expect(routing.routes().count == 2)
+        #expect(routing.bottleURL(forAppId: 2)?.lastPathComponent == "two")
+    }
+
+    @Test("A corrupt store is treated as empty, not fatal")
+    func corruptStoreIsEmpty() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let url = tempDir.appending(path: "GameRouting.plist")
+        try Data("this is not a plist".utf8).write(to: url)
+
+        let routing = GameRouting(url: url)
+        #expect(routing.routes().isEmpty)
+
+        // and writing over it still works
+        routing.record(appId: 5, bottleURL: URL(fileURLWithPath: "/tmp/bottles/five"))
+        #expect(routing.bottleURL(forAppId: 5) != nil)
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/ShortcutLiveScriptTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ShortcutLiveScriptTests.swift
@@ -1,0 +1,114 @@
+//
+//  ShortcutLiveScriptTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("Shortcut Live Script Tests")
+struct ShortcutLiveScriptTests {
+    @Test("Steam target launches by App ID")
+    func steamScript() {
+        let script = ShortcutCreator.liveLaunchScript(for: .steamGame(appId: 4_576_510))
+
+        #expect(script.contains(#"exec "$WHISKY_CMD" launch 4576510"#))
+        #expect(script.contains("mdfind"))
+    }
+
+    @Test("Program target quotes bottle name and Windows path")
+    func programScript() {
+        let script = ShortcutCreator.liveLaunchScript(
+            for: .program(bottleName: "Steam dx11", windowsPath: #"C:\Games\Some Game\game.exe"#)
+        )
+
+        #expect(script.contains(#"exec "$WHISKY_CMD" run 'Steam dx11' 'C:\Games\Some Game\game.exe'"#))
+    }
+
+    @Test("Hostile names survive shell quoting")
+    func hostileQuoting() {
+        let quoted = ShortcutCreator.shellQuoted("Bo'ttle; rm -rf $HOME")
+
+        #expect(quoted == #"'Bo'\''ttle; rm -rf $HOME'"#)
+    }
+
+    @Test("Windows paths map from drive_c and reject outsiders")
+    func windowsPathMapping() {
+        let bottle = URL(fileURLWithPath: "/tmp/bottles/b")
+
+        let inside = ShortcutCreator.windowsPath(
+            for: URL(fileURLWithPath: "/tmp/bottles/b/drive_c/Games/A Game/run.exe"),
+            bottleURL: bottle
+        )
+        #expect(inside == #"C:\Games\A Game\run.exe"#)
+
+        let outside = ShortcutCreator.windowsPath(
+            for: URL(fileURLWithPath: "/tmp/elsewhere/run.exe"),
+            bottleURL: bottle
+        )
+        #expect(outside == nil)
+    }
+
+    @Test("Live target picks Steam games by install directory")
+    @MainActor func liveTargetSteamGame() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let steamRoot = tempDir.appending(path: "drive_c")
+            .appending(path: "Program Files (x86)").appending(path: "Steam")
+        let steamApps = steamRoot.appending(path: "steamapps")
+        let installDir = steamApps.appending(path: "common").appending(path: "Casualties Unknown Demo")
+        try FileManager.default.createDirectory(at: installDir, withIntermediateDirectories: true)
+        try Data().write(to: steamRoot.appending(path: "steam.exe"))
+        let acf = """
+        "AppState"
+        {
+            "appid"        "4576510"
+            "name"        "Casualties: Unknown Demo"
+            "installdir"        "Casualties Unknown Demo"
+            "StateFlags"        "4"
+        }
+        """
+        try Data(acf.utf8).write(to: steamApps.appending(path: "appmanifest_4576510.acf"))
+        let exe = installDir.appending(path: "CasualtiesUnknown.exe")
+        try Data().write(to: exe)
+
+        let bottle = Bottle(bottleUrl: tempDir, inFlight: false, isAvailable: true)
+        let target = ShortcutCreator.liveTarget(for: exe, bottle: bottle)
+
+        #expect(target == .steamGame(appId: 4_576_510))
+    }
+
+    @Test("Live target falls back to bottle name and Windows path")
+    @MainActor func liveTargetPlainProgram() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let exe = tempDir.appending(path: "drive_c").appending(path: "Games").appending(path: "game.exe")
+        try FileManager.default.createDirectory(
+            at: exe.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try Data().write(to: exe)
+
+        let bottle = Bottle(bottleUrl: tempDir, inFlight: false, isAvailable: true)
+        let target = ShortcutCreator.liveTarget(for: exe, bottle: bottle)
+
+        #expect(target == .program(
+            bottleName: bottle.settings.name, windowsPath: #"C:\Games\game.exe"#
+        ))
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/SteamLauncherTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamLauncherTests.swift
@@ -1,0 +1,132 @@
+//
+//  SteamLauncherTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("SteamLauncher Routing Tests")
+struct SteamLauncherTests {
+    private let tempRoot: URL
+
+    init() throws {
+        tempRoot = FileManager.default.temporaryDirectory
+            .appending(path: "steamlaunch_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    /// A bottle holding a Steam install with each of `appIds` fully installed.
+    private func makeSteamBottle(_ label: String, appIds: [Int]) throws -> URL {
+        let fileManager = FileManager.default
+        let bottle = tempRoot.appending(path: "\(label)-\(UUID().uuidString)")
+        let steamRoot = bottle.appending(path: "drive_c")
+            .appending(path: "Program Files (x86)").appending(path: "Steam")
+        let steamApps = steamRoot.appending(path: "steamapps")
+        try fileManager.createDirectory(at: steamApps, withIntermediateDirectories: true)
+        try Data().write(to: steamRoot.appending(path: "steam.exe"))
+
+        for appId in appIds {
+            let installDir = "Game\(appId)"
+            try fileManager.createDirectory(
+                at: steamApps.appending(path: "common").appending(path: installDir),
+                withIntermediateDirectories: true
+            )
+            let manifest = """
+            "AppState"
+            {
+                "appid"        "\(appId)"
+                "name"        "Game \(appId)"
+                "installdir"        "\(installDir)"
+                "StateFlags"        "4"
+            }
+            """
+            try Data(manifest.utf8)
+                .write(to: steamApps.appending(path: "appmanifest_\(appId).acf"))
+        }
+        return bottle
+    }
+
+    private func makeRouting() -> GameRouting {
+        GameRouting(url: tempRoot.appending(path: "GameRouting-\(UUID().uuidString).plist"))
+    }
+
+    @Test("The remembered bottle wins over another that also has the game")
+    @MainActor func routeWins() throws {
+        let first = try Bottle(bottleUrl: makeSteamBottle("first", appIds: [1_245_620]))
+        let second = try Bottle(bottleUrl: makeSteamBottle("second", appIds: [1_245_620]))
+        let routing = makeRouting()
+        routing.record(appId: 1_245_620, bottleURL: second.url)
+
+        let resolved = try SteamLauncher.resolveBottle(
+            appId: 1_245_620, in: [first, second], routing: routing
+        )
+
+        #expect(resolved.url == second.url)
+    }
+
+    @Test("A route to a bottle that lost the game falls through to one that has it")
+    @MainActor func staleRouteFallsThrough() throws {
+        let stale = try Bottle(bottleUrl: makeSteamBottle("stale", appIds: [4_576_510]))
+        let real = try Bottle(bottleUrl: makeSteamBottle("real", appIds: [1_245_620]))
+        let routing = makeRouting()
+        routing.record(appId: 1_245_620, bottleURL: stale.url)
+
+        let resolved = try SteamLauncher.resolveBottle(
+            appId: 1_245_620, in: [stale, real], routing: routing
+        )
+
+        #expect(resolved.url == real.url)
+    }
+
+    @Test("A route to a bottle Whisky no longer knows falls through")
+    @MainActor func routeToUnknownBottleFallsThrough() throws {
+        let deleted = try makeSteamBottle("deleted", appIds: [1_245_620])
+        let real = try Bottle(bottleUrl: makeSteamBottle("real", appIds: [1_245_620]))
+        let routing = makeRouting()
+        routing.record(appId: 1_245_620, bottleURL: deleted)
+
+        let resolved = try SteamLauncher.resolveBottle(
+            appId: 1_245_620, in: [real], routing: routing
+        )
+
+        #expect(resolved.url == real.url)
+    }
+
+    @Test("Without a route the first bottle holding the game wins")
+    @MainActor func firstInstallWinsWithoutRoute() throws {
+        let empty = try Bottle(bottleUrl: makeSteamBottle("empty", appIds: []))
+        let holder = try Bottle(bottleUrl: makeSteamBottle("holder", appIds: [1_245_620]))
+
+        let resolved = try SteamLauncher.resolveBottle(
+            appId: 1_245_620, in: [empty, holder], routing: makeRouting()
+        )
+
+        #expect(resolved.url == holder.url)
+    }
+
+    @Test("No bottle with the game throws gameNotFound")
+    @MainActor func noBottleThrows() throws {
+        let bottle = try Bottle(bottleUrl: makeSteamBottle("other", appIds: [4_576_510]))
+        let routing = makeRouting()
+        routing.record(appId: 1_245_620, bottleURL: bottle.url)
+
+        #expect(throws: SteamLaunchError.gameNotFound(appId: 1_245_620)) {
+            try SteamLauncher.resolveBottle(appId: 1_245_620, in: [bottle], routing: routing)
+        }
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/SteamLibraryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamLibraryTests.swift
@@ -228,6 +228,28 @@ struct SteamLibraryTests {
         #expect(!games.contains { $0.appId == 999 || $0.appId == 777 })
     }
 
+    @Test("Runtime payloads are not listed as games")
+    func filtersRuntimePayloads() throws {
+        let (bottle, tempRoot) = try makeFixtureBottle()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let steamApps = bottle.appending(path: "drive_c")
+            .appending(path: "Program Files (x86)").appending(path: "Steam")
+            .appending(path: "steamapps")
+        try FileManager.default.createDirectory(
+            at: steamApps.appending(path: "common").appending(path: "Steamworks Shared"),
+            withIntermediateDirectories: true
+        )
+        try Data(acf(
+            appId: 228_980, name: "Steamworks Common Redistributables",
+            installDir: "Steamworks Shared", stateFlags: 4
+        ).utf8).write(to: steamApps.appending(path: "appmanifest_228980.acf"))
+
+        let games = SteamLibrary.enumerate(bottleURL: bottle)
+
+        #expect(!games.contains { $0.appId == 228_980 })
+    }
+
     @Test("Collects executable names at root and one level deep")
     func collectsExecutableNames() throws {
         let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)


### PR DESCRIPTION
phase 2 of #158. two commits, 10 files.

**`whisky games` / `whisky launch <appid>`**

- `SteamLauncher` is now the single launch path for steam games. resolves the gamedb profile and the user's program overrides, records the bottle for the app id, hands `-applaunch` to the windows client.
- `GameRouting` remembers which bottle an app id last launched from, so `whisky launch 1245620` needs no `--bottle`. falls back to the first bottle that actually has the game installed.
- both subcommands take `--json`.
- `SteamLibrary` gained a non-game app id filter, so steamworks redistributables stop showing up as games.

**shortcuts launch through the live pipeline**

`ShortcutCreator` writes a script that shells out to WhiskyCmd instead of baking the environment in at creation time. a shortcut made today picks up tomorrow's dxvk setting, gamedb profile and override changes.

**note on the merge with #161**

the branch predated #161, so rebasing it onto main meant reconciling two refactors of the same seam. #161 added the programs-tab override carry-through in the orchestrator, this branch extracted launching into `SteamLauncher`. taking either side alone would have dropped one of them, so `userOverrides` moved into `SteamLauncher` and both the play button and `whisky launch` now go through it. the orchestrator's private copy is gone.

`launch` takes an optional `installURL` so the orchestrator, which already has the `SteamGame`, skips a library rescan; the cli lets it resolve.

local: 83/83 kit tests green, all four schemes build.