### PR TITLE
refactor: extract bottle operations into WhiskyKit for testability

### DIFF
--- a/Whisky/Extensions/Bottle+Extensions.swift
+++ b/Whisky/Extensions/Bottle+Extensions.swift
@@ -16,44 +16,10 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
-// swiftlint:disable file_length
 import AppKit
 import Foundation
 import os.log
 import WhiskyKit
-
-/// Phases reported during bottle duplication for progress feedback.
-enum DuplicationPhase: Equatable {
-    /// Calculating total size of the source bottle directory.
-    case calculatingSize
-    /// Copying files. `bytesCopied` and `totalBytes` track progress.
-    case copying(bytesCopied: Int64, totalBytes: Int64)
-    /// Rewriting metadata (pins, blocklist) for the new bottle.
-    case updatingMetadata
-    /// Registering the new bottle and reloading the bottle list.
-    case finalizing
-}
-
-/// Returns a duplicate name following the Finder convention.
-///
-/// - If no existing bottle is named "\(baseName) Copy", returns "\(baseName) Copy".
-/// - Otherwise tries "\(baseName) Copy 2", "Copy 3", etc.
-///
-/// - Parameters:
-///   - baseName: The original bottle's name.
-///   - existingNames: Names of all current bottles.
-/// - Returns: The next available duplicate name.
-func nextDuplicateName(baseName: String, existingNames: [String]) -> String {
-    let candidate = "\(baseName) Copy"
-    if !existingNames.contains(candidate) {
-        return candidate
-    }
-    var counter = 2
-    while existingNames.contains("\(baseName) Copy \(counter)") {
-        counter += 1
-    }
-    return "\(baseName) Copy \(counter)"
-}
 
 /// MainActor-isolated cache for Wine usernames to avoid repeated filesystem scans.
 @MainActor
@@ -259,95 +225,34 @@ extension Bottle {
         }
     }
 
+    /// Moves the bottle to a new location.
+    ///
+    /// Thin adapter over `BottleOperations.move`, which owns the
+    /// rewrite-before-move and rollback-on-failure semantics for pins and
+    /// blocklist URLs.
     @MainActor
     func move(destination: URL) {
-        let bottle = BottleVM.shared.bottles.first(where: { $0.url == url })
-        // The URL rewrite must happen before the move so the persisted settings
-        // travel with the bottle, so keep a snapshot to restore on failure.
-        let originalPins = bottle?.settings.pins
-        let originalBlocklist = bottle?.settings.blocklist
-
-        bottle?.inFlight = true
-        defer { bottle?.inFlight = false }
-
-        do {
-            if let bottle {
-                for index in 0 ..< bottle.settings.pins.count {
-                    let pin = bottle.settings.pins[index]
-                    if let pinURL = pin.url {
-                        bottle.settings.pins[index].url = pinURL.updateParentBottle(
-                            old: url,
-                            new: destination
-                        )
-                    }
-                }
-
-                for index in 0 ..< bottle.settings.blocklist.count {
-                    let blockedUrl = bottle.settings.blocklist[index]
-                    bottle.settings.blocklist[index] = blockedUrl.updateParentBottle(
-                        old: url,
-                        new: destination
-                    )
-                }
-            }
-            try FileManager.default.moveItem(at: url, to: destination)
-            if let path = BottleVM.shared.bottlesList.paths.firstIndex(of: url) {
-                BottleVM.shared.bottlesList.paths[path] = destination
-            }
-            BottleVM.shared.loadBottles()
-        } catch {
-            // A failed move must not leave settings pointing at a path that
-            // was never created.
-            if let bottle {
-                if let originalPins {
-                    bottle.settings.pins = originalPins
-                }
-                if let originalBlocklist {
-                    bottle.settings.blocklist = originalBlocklist
-                }
-            }
-            Logger.wineKit.error("Failed to move bottle: \(error.localizedDescription)")
-        }
+        BottleOperations.move(bottleAt: url, to: destination, registry: BottleVM.shared)
     }
 
     /// Exports the bottle as a gzip-compressed tar archive.
     ///
-    /// This operation runs on a background thread to avoid blocking the UI.
-    /// The bottle's `inFlight` property is set during the operation to show progress.
+    /// Thin adapter over `BottleOperations.export`.
     ///
     /// - Parameter destination: The URL where the archive should be saved.
     /// - Throws: `TarError` if the archive operation fails, or an error if the bottle is not found.
     @MainActor
     func exportAsArchive(destination: URL) async throws {
-        guard let bottle = BottleVM.shared.bottles.first(where: { $0.url == url }) else {
-            throw NSError(
-                domain: "com.franke.Whisky",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "Bottle not found"]
-            )
-        }
-        bottle.inFlight = true
-        defer { bottle.inFlight = false }
-
-        // Capture URL before entering detached task to satisfy actor isolation
-        let sourceURL = url
-        try await Task.detached(priority: .userInitiated) {
-            try Tar.tar(folder: sourceURL, toURL: destination)
-        }.value
+        try await BottleOperations.export(bottleAt: url, to: destination, registry: BottleVM.shared)
     }
 
     /// Duplicates the bottle to a new directory with the given name.
     ///
-    /// This operation runs on a background thread to avoid blocking the UI.
-    /// The bottle's `inFlight` property is set during the operation to show progress.
-    /// An optional progress callback reports duplication phases for UI feedback.
-    ///
-    /// On copy failure the partially created directory is removed before re-throwing.
-    /// Transient artifacts (old logs, diagnosis history) are excluded from the clone.
+    /// Thin adapter over `BottleOperations.duplicate`.
     ///
     /// - Parameters:
     ///   - newName: The name for the duplicated bottle.
-    ///   - progress: Optional callback reporting ``DuplicationPhase`` updates.
+    ///   - progress: Optional callback reporting `DuplicationPhase` updates.
     /// - Returns: The URL of the newly created bottle directory.
     /// - Throws: An error if the bottle is not found or the copy operation fails.
     @MainActor
@@ -355,130 +260,12 @@ extension Bottle {
         newName: String,
         progress: (@Sendable (DuplicationPhase) -> Void)? = nil
     ) async throws -> URL {
-        guard let bottle = BottleVM.shared.bottles.first(where: { $0.url == url }) else {
-            throw NSError(
-                domain: "com.franke.Whisky",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "Bottle not found"]
-            )
-        }
-        bottle.inFlight = true
-        defer { bottle.inFlight = false }
-
-        // Create new bottle directory in the same parent folder
-        let parentDir = url.deletingLastPathComponent()
-        let newBottleDir = parentDir.appendingPathComponent(UUID().uuidString)
-
-        // Capture URLs before entering detached task to satisfy actor isolation
-        let sourceURL = url
-        try await Task.detached(priority: .userInitiated) {
-            // Phase: calculate size
-            progress?(.calculatingSize)
-            let totalBytes = Self.calculateDirectorySize(at: sourceURL)
-
-            // Phase: copying
-            progress?(.copying(bytesCopied: 0, totalBytes: totalBytes))
-            do {
-                try FileManager.default.copyItem(at: sourceURL, to: newBottleDir)
-            } catch {
-                // Clean up partial clone on failure
-                try? FileManager.default.removeItem(at: newBottleDir)
-                throw error
-            }
-            progress?(.copying(bytesCopied: totalBytes, totalBytes: totalBytes))
-
-            // Remove transient artifacts from the clone
-            Self.removeTransientArtifacts(in: newBottleDir)
-        }.value
-
-        // Phase: updating metadata
-        progress?(.updatingMetadata)
-
-        // Update the new bottle's settings
-        let newBottle = Bottle(bottleUrl: newBottleDir)
-        newBottle.settings.name = newName
-
-        // Update pin URLs to point to the new bottle
-        for index in 0 ..< newBottle.settings.pins.count {
-            if let pinURL = newBottle.settings.pins[index].url {
-                newBottle.settings.pins[index].url = pinURL.updateParentBottle(
-                    old: sourceURL,
-                    new: newBottleDir
-                )
-            }
-        }
-
-        // Update blocklist URLs to point to the new bottle
-        for index in 0 ..< newBottle.settings.blocklist.count {
-            newBottle.settings.blocklist[index] = newBottle.settings.blocklist[index]
-                .updateParentBottle(old: sourceURL, new: newBottleDir)
-        }
-
-        // Explicitly save settings to ensure all modifications are persisted
-        // (modifying nested struct properties may not always trigger didSet)
-        newBottle.saveBottleSettings()
-
-        // Phase: finalizing
-        progress?(.finalizing)
-
-        // Register the new bottle
-        BottleVM.shared.bottlesList.paths.append(newBottleDir)
-        BottleVM.shared.loadBottles()
-
-        return newBottleDir
-    }
-
-    /// Calculates the total allocated size of a directory tree.
-    private nonisolated static func calculateDirectorySize(at url: URL) -> Int64 {
-        let fileManager = FileManager.default
-        guard let enumerator = fileManager.enumerator(
-            at: url,
-            includingPropertiesForKeys: [.totalFileAllocatedSizeKey],
-            options: [.skipsHiddenFiles]
+        try await BottleOperations.duplicate(
+            bottleAt: url,
+            newName: newName,
+            registry: BottleVM.shared,
+            progress: progress
         )
-        else {
-            return 0
-        }
-        var total: Int64 = 0
-        for case let fileURL as URL in enumerator {
-            if let values = try? fileURL.resourceValues(forKeys: [.totalFileAllocatedSizeKey]),
-               let size = values.totalFileAllocatedSize {
-                total += Int64(size)
-            }
-        }
-        return total
-    }
-
-    /// Removes transient artifacts from a cloned bottle directory.
-    ///
-    /// Deletes old log files, diagnosis history sidecars, and temp files so the
-    /// duplicate starts clean.
-    private nonisolated static func removeTransientArtifacts(in bottleDir: URL) {
-        let fileManager = FileManager.default
-
-        // Remove .log files from the logs directory
-        let logsDir = bottleDir.appending(path: "logs")
-        if let logEnumerator = fileManager.enumerator(
-            at: logsDir,
-            includingPropertiesForKeys: nil,
-            options: [.skipsSubdirectoryDescendants]
-        ) {
-            for case let fileURL as URL in logEnumerator where fileURL.pathExtension == "log" {
-                try? fileManager.removeItem(at: fileURL)
-            }
-        }
-
-        // Remove diagnosis history sidecar files
-        if let enumerator = fileManager.enumerator(
-            at: bottleDir,
-            includingPropertiesForKeys: nil,
-            options: []
-        ) {
-            for case let fileURL as URL in enumerator
-                where fileURL.lastPathComponent.hasSuffix(".diagnosis-history.plist") {
-                try? fileManager.removeItem(at: fileURL)
-            }
-        }
     }
 
     @MainActor
@@ -506,22 +293,7 @@ extension Bottle {
             ProcessRegistry.shared.clearRegistry(for: url)
         }
 
-        do {
-            if let bottle = BottleVM.shared.bottles.first(where: { $0.url == url }) {
-                bottle.inFlight = true
-            }
-
-            if delete {
-                try FileManager.default.removeItem(at: url)
-            }
-
-            if let path = BottleVM.shared.bottlesList.paths.firstIndex(of: url) {
-                BottleVM.shared.bottlesList.paths.remove(at: path)
-            }
-            BottleVM.shared.loadBottles()
-        } catch {
-            Logger.wineKit.error("Failed to remove bottle: \(error.localizedDescription)")
-        }
+        BottleOperations.remove(bottleAt: url, deleteFiles: delete, registry: BottleVM.shared)
     }
 
     @MainActor
@@ -538,5 +310,20 @@ extension Bottle {
         alert.alertStyle = .critical
         alert.addButton(withTitle: String(localized: "button.ok"))
         alert.runModal()
+    }
+}
+
+// MARK: - BottleRegistry Conformance
+
+/// Bridges `BottleOperations` to the app's bottle list. The `loadBottles()`
+/// requirement is satisfied by the existing method on `BottleVM`.
+extension BottleVM: BottleRegistry {
+    var bottlePaths: [URL] {
+        get { bottlesList.paths }
+        set { bottlesList.paths = newValue }
+    }
+
+    func bottle(for url: URL) -> Bottle? {
+        bottles.first(where: { $0.url == url })
     }
 }

--- a/Whisky/Views/Bottle/BottleListEntry.swift
+++ b/Whisky/Views/Bottle/BottleListEntry.swift
@@ -85,7 +85,7 @@ struct BottleListEntry: View {
         .sheet(isPresented: $showBottleDuplicate) {
             RenameView(
                 "duplicate.bottle.title",
-                name: nextDuplicateName(
+                name: BottleOperations.nextDuplicateName(
                     baseName: name,
                     existingNames: BottleVM.shared.bottles.map(\.settings.name)
                 )

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -217,7 +217,7 @@ struct BottleView: View {
             .sheet(isPresented: $showDuplicate) {
                 RenameView(
                     "duplicate.bottle.title",
-                    name: nextDuplicateName(
+                    name: BottleOperations.nextDuplicateName(
                         baseName: bottle.settings.name,
                         existingNames: BottleVM.shared.bottles.map(\.settings.name)
                     )

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleOperations.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleOperations.swift
@@ -1,0 +1,366 @@
+//
+//  BottleOperations.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import os.log
+
+/// Phases reported during bottle duplication for progress feedback.
+public enum DuplicationPhase: Equatable, Sendable {
+    /// Calculating total size of the source bottle directory.
+    case calculatingSize
+    /// Copying files. `bytesCopied` and `totalBytes` track progress.
+    case copying(bytesCopied: Int64, totalBytes: Int64)
+    /// Rewriting metadata (pins, blocklist) for the new bottle.
+    case updatingMetadata
+    /// Registering the new bottle and reloading the bottle list.
+    case finalizing
+}
+
+/// The registry seam ``BottleOperations`` uses to reach the bottle list.
+///
+/// Operations look up live ``Bottle`` instances, mutate the persisted path
+/// registry, and trigger a reload through this protocol instead of touching
+/// the app's view model directly, so the operation state machines can be
+/// exercised in tests against an in-memory registry.
+@MainActor
+public protocol BottleRegistry: AnyObject {
+    /// The registered bottle paths. Mutations must persist to the backing store.
+    var bottlePaths: [URL] { get set }
+
+    /// Returns the live bottle instance for `url`, if one is loaded.
+    func bottle(for url: URL) -> Bottle?
+
+    /// Rebuilds the bottle list from ``bottlePaths``.
+    func loadBottles()
+}
+
+/// Bottle lifecycle operations (move, export, duplicate, remove) shared by the
+/// app target so their state machines are testable from the package.
+///
+/// Each operation resolves the live bottle through a ``BottleRegistry`` and
+/// manages the bottle's `inFlight` guard for the duration, preserving the
+/// snapshot-and-rollback semantics of the pin/blocklist rewrite during a move
+/// (issue #154).
+public enum BottleOperations {
+    // MARK: - Move
+
+    /// Moves the bottle directory at `url` to `destination`.
+    ///
+    /// Pin and blocklist URLs are rewritten to `destination` *before* the file
+    /// move so the persisted settings travel with the bottle; a snapshot of
+    /// both is restored if the move throws, so a failed move never leaves
+    /// settings pointing at a path that was never created (issue #154). If no
+    /// live bottle exists for `url` the file move is still attempted.
+    ///
+    /// - Parameters:
+    ///   - url: The bottle's current directory.
+    ///   - destination: The directory the bottle should move to.
+    ///   - registry: The registry that owns the bottle list.
+    @MainActor
+    public static func move(bottleAt url: URL, to destination: URL, registry: BottleRegistry) {
+        let bottle = registry.bottle(for: url)
+        // The URL rewrite must happen before the move so the persisted settings
+        // travel with the bottle, so keep a snapshot to restore on failure.
+        let originalPins = bottle?.settings.pins
+        let originalBlocklist = bottle?.settings.blocklist
+
+        bottle?.inFlight = true
+        defer { bottle?.inFlight = false }
+
+        do {
+            if let bottle {
+                for index in 0 ..< bottle.settings.pins.count {
+                    let pin = bottle.settings.pins[index]
+                    if let pinURL = pin.url {
+                        bottle.settings.pins[index].url = pinURL.updateParentBottle(
+                            old: url,
+                            new: destination
+                        )
+                    }
+                }
+
+                for index in 0 ..< bottle.settings.blocklist.count {
+                    let blockedUrl = bottle.settings.blocklist[index]
+                    bottle.settings.blocklist[index] = blockedUrl.updateParentBottle(
+                        old: url,
+                        new: destination
+                    )
+                }
+            }
+            try FileManager.default.moveItem(at: url, to: destination)
+            if let path = registry.bottlePaths.firstIndex(of: url) {
+                registry.bottlePaths[path] = destination
+            }
+            registry.loadBottles()
+        } catch {
+            // A failed move must not leave settings pointing at a path that
+            // was never created.
+            if let bottle {
+                if let originalPins {
+                    bottle.settings.pins = originalPins
+                }
+                if let originalBlocklist {
+                    bottle.settings.blocklist = originalBlocklist
+                }
+            }
+            Logger.wineKit.error("Failed to move bottle: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Export
+
+    /// Exports the bottle at `url` as a gzip-compressed tar archive.
+    ///
+    /// The archive work runs on a background task to avoid blocking the main
+    /// actor. The bottle's `inFlight` property is set for the duration so the
+    /// UI can show progress and block conflicting actions.
+    ///
+    /// - Parameters:
+    ///   - url: The bottle's directory.
+    ///   - destination: The URL where the archive should be saved.
+    ///   - registry: The registry that owns the bottle list.
+    /// - Throws: `TarError` if the archive operation fails, or an error if the
+    ///   bottle is not found.
+    @MainActor
+    public static func export(bottleAt url: URL, to destination: URL, registry: BottleRegistry) async throws {
+        guard let bottle = registry.bottle(for: url) else {
+            throw bottleNotFoundError()
+        }
+        bottle.inFlight = true
+        defer { bottle.inFlight = false }
+
+        // Capture URL before entering detached task to satisfy actor isolation
+        let sourceURL = url
+        try await Task.detached(priority: .userInitiated) {
+            try Tar.tar(folder: sourceURL, toURL: destination)
+        }.value
+    }
+
+    // MARK: - Duplicate
+
+    /// Duplicates the bottle at `url` to a new directory with the given name.
+    ///
+    /// The copy runs on a background task to avoid blocking the main actor.
+    /// The bottle's `inFlight` property is set during the operation, and an
+    /// optional progress callback reports duplication phases for UI feedback.
+    ///
+    /// On copy failure the partially created directory is removed before
+    /// re-throwing. Transient artifacts (old logs, diagnosis history) are
+    /// excluded from the clone.
+    ///
+    /// - Parameters:
+    ///   - url: The source bottle's directory.
+    ///   - newName: The name for the duplicated bottle.
+    ///   - registry: The registry that owns the bottle list.
+    ///   - progress: Optional callback reporting ``DuplicationPhase`` updates.
+    /// - Returns: The URL of the newly created bottle directory.
+    /// - Throws: An error if the bottle is not found or the copy operation fails.
+    @MainActor
+    public static func duplicate(
+        bottleAt url: URL,
+        newName: String,
+        registry: BottleRegistry,
+        progress: (@Sendable (DuplicationPhase) -> Void)? = nil
+    ) async throws -> URL {
+        guard let bottle = registry.bottle(for: url) else {
+            throw bottleNotFoundError()
+        }
+        bottle.inFlight = true
+        defer { bottle.inFlight = false }
+
+        // Create new bottle directory in the same parent folder
+        let parentDir = url.deletingLastPathComponent()
+        let newBottleDir = parentDir.appendingPathComponent(UUID().uuidString)
+
+        // Capture URLs before entering detached task to satisfy actor isolation
+        let sourceURL = url
+        try await Task.detached(priority: .userInitiated) {
+            // Phase: calculate size
+            progress?(.calculatingSize)
+            let totalBytes = Self.calculateDirectorySize(at: sourceURL)
+
+            // Phase: copying
+            progress?(.copying(bytesCopied: 0, totalBytes: totalBytes))
+            do {
+                try FileManager.default.copyItem(at: sourceURL, to: newBottleDir)
+            } catch {
+                // Clean up partial clone on failure
+                try? FileManager.default.removeItem(at: newBottleDir)
+                throw error
+            }
+            progress?(.copying(bytesCopied: totalBytes, totalBytes: totalBytes))
+
+            // Remove transient artifacts from the clone
+            Self.removeTransientArtifacts(in: newBottleDir)
+        }.value
+
+        // Phase: updating metadata
+        progress?(.updatingMetadata)
+
+        // Update the new bottle's settings
+        let newBottle = Bottle(bottleUrl: newBottleDir)
+        newBottle.settings.name = newName
+
+        // Update pin URLs to point to the new bottle
+        for index in 0 ..< newBottle.settings.pins.count {
+            if let pinURL = newBottle.settings.pins[index].url {
+                newBottle.settings.pins[index].url = pinURL.updateParentBottle(
+                    old: sourceURL,
+                    new: newBottleDir
+                )
+            }
+        }
+
+        // Update blocklist URLs to point to the new bottle
+        for index in 0 ..< newBottle.settings.blocklist.count {
+            newBottle.settings.blocklist[index] = newBottle.settings.blocklist[index]
+                .updateParentBottle(old: sourceURL, new: newBottleDir)
+        }
+
+        // Explicitly save settings to ensure all modifications are persisted
+        // (modifying nested struct properties may not always trigger didSet)
+        newBottle.saveBottleSettings()
+
+        // Phase: finalizing
+        progress?(.finalizing)
+
+        // Register the new bottle
+        registry.bottlePaths.append(newBottleDir)
+        registry.loadBottles()
+
+        return newBottleDir
+    }
+
+    /// Returns a duplicate name following the Finder convention.
+    ///
+    /// - If no existing bottle is named "\(baseName) Copy", returns "\(baseName) Copy".
+    /// - Otherwise tries "\(baseName) Copy 2", "Copy 3", etc.
+    ///
+    /// - Parameters:
+    ///   - baseName: The original bottle's name.
+    ///   - existingNames: Names of all current bottles.
+    /// - Returns: The next available duplicate name.
+    public static func nextDuplicateName(baseName: String, existingNames: [String]) -> String {
+        let candidate = "\(baseName) Copy"
+        if !existingNames.contains(candidate) {
+            return candidate
+        }
+        var counter = 2
+        while existingNames.contains("\(baseName) Copy \(counter)") {
+            counter += 1
+        }
+        return "\(baseName) Copy \(counter)"
+    }
+
+    // MARK: - Remove
+
+    /// Removes the bottle at `url` from the registry, optionally deleting its
+    /// files from disk.
+    ///
+    /// Callers are responsible for stopping any running processes first; this
+    /// is only the delete-and-deregister step.
+    ///
+    /// - Parameters:
+    ///   - url: The bottle's directory.
+    ///   - deleteFiles: Whether to delete the bottle directory from disk.
+    ///   - registry: The registry that owns the bottle list.
+    @MainActor
+    public static func remove(bottleAt url: URL, deleteFiles: Bool, registry: BottleRegistry) {
+        do {
+            if let bottle = registry.bottle(for: url) {
+                bottle.inFlight = true
+            }
+
+            if deleteFiles {
+                try FileManager.default.removeItem(at: url)
+            }
+
+            if let path = registry.bottlePaths.firstIndex(of: url) {
+                registry.bottlePaths.remove(at: path)
+            }
+            registry.loadBottles()
+        } catch {
+            Logger.wineKit.error("Failed to remove bottle: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// The error thrown when an operation's bottle has no live instance in the
+    /// registry.
+    private static func bottleNotFoundError() -> NSError {
+        NSError(
+            domain: "com.franke.Whisky",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Bottle not found"]
+        )
+    }
+
+    /// Calculates the total allocated size of a directory tree.
+    private static func calculateDirectorySize(at url: URL) -> Int64 {
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.totalFileAllocatedSizeKey],
+            options: [.skipsHiddenFiles]
+        )
+        else {
+            return 0
+        }
+        var total: Int64 = 0
+        for case let fileURL as URL in enumerator {
+            if let values = try? fileURL.resourceValues(forKeys: [.totalFileAllocatedSizeKey]),
+               let size = values.totalFileAllocatedSize {
+                total += Int64(size)
+            }
+        }
+        return total
+    }
+
+    /// Removes transient artifacts from a cloned bottle directory.
+    ///
+    /// Deletes old log files, diagnosis history sidecars, and temp files so the
+    /// duplicate starts clean.
+    private static func removeTransientArtifacts(in bottleDir: URL) {
+        let fileManager = FileManager.default
+
+        // Remove .log files from the logs directory
+        let logsDir = bottleDir.appending(path: "logs")
+        if let logEnumerator = fileManager.enumerator(
+            at: logsDir,
+            includingPropertiesForKeys: nil,
+            options: [.skipsSubdirectoryDescendants]
+        ) {
+            for case let fileURL as URL in logEnumerator where fileURL.pathExtension == "log" {
+                try? fileManager.removeItem(at: fileURL)
+            }
+        }
+
+        // Remove diagnosis history sidecar files
+        if let enumerator = fileManager.enumerator(
+            at: bottleDir,
+            includingPropertiesForKeys: nil,
+            options: []
+        ) {
+            for case let fileURL as URL in enumerator
+                where fileURL.lastPathComponent.hasSuffix(".diagnosis-history.plist") {
+                try? fileManager.removeItem(at: fileURL)
+            }
+        }
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleOperationsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleOperationsTests.swift
@@ -1,0 +1,395 @@
+//
+//  BottleOperationsTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WhiskyKit
+import XCTest
+
+// MARK: - Fixtures
+
+/// In-memory ``BottleRegistry`` so operation tests can observe path mutations
+/// and reload requests without the app's view model.
+@MainActor
+final class RegistryFixture: BottleRegistry {
+    var bottles: [Bottle] = []
+    var bottlePaths: [URL] = []
+    private(set) var loadCount = 0
+
+    func bottle(for url: URL) -> Bottle? {
+        bottles.first(where: { $0.url == url })
+    }
+
+    func loadBottles() {
+        loadCount += 1
+    }
+}
+
+/// Thread-safe collector for duplication progress phases; the early phases are
+/// reported from a background task, the later ones from the main actor.
+private final class PhaseRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [DuplicationPhase] = []
+
+    func record(_ phase: DuplicationPhase) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage.append(phase)
+    }
+
+    var phases: [DuplicationPhase] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}
+
+/// Shared temp-dir bottle fixture: a bottle directory with one installed
+/// program, one pin, and one blocklist entry, all backed by a real
+/// `Metadata.plist`.
+class BottleOperationsTestCase: XCTestCase {
+    var tempDir: URL!
+    var bottleURL: URL!
+    var exeURL: URL!
+    var blockedURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory.appending(path: "bottle_ops_\(UUID().uuidString)")
+        bottleURL = tempDir.appending(path: "Original")
+        let gameDir = bottleURL.appending(path: "drive_c/Program Files/Game")
+        try? FileManager.default.createDirectory(at: gameDir, withIntermediateDirectories: true)
+        exeURL = gameDir.appending(path: "game.exe")
+        blockedURL = gameDir.appending(path: "helper.exe")
+        try? Data("game".utf8).write(to: exeURL)
+        try? Data("helper".utf8).write(to: blockedURL)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    /// Creates the live bottle with a pin and a blocklist entry and registers
+    /// both the instance and its path in `registry`.
+    @MainActor
+    func makeRegisteredBottle(in registry: RegistryFixture) -> Bottle {
+        let bottle = Bottle(bottleUrl: bottleURL)
+        bottle.settings.pins = [PinnedProgram(name: "Game", url: exeURL)]
+        bottle.settings.blocklist = [blockedURL]
+        registry.bottles = [bottle]
+        registry.bottlePaths = [bottleURL]
+        return bottle
+    }
+
+    /// Decodes the persisted settings for the bottle directory at `url`.
+    func persistedSettings(at url: URL) throws -> BottleSettings {
+        try BottleSettings.decode(from: url.appending(path: "Metadata.plist"))
+    }
+}
+
+// MARK: - Move
+
+final class BottleOperationsMoveTests: BottleOperationsTestCase {
+    @MainActor
+    func testMoveRewritesSettingsBeforeMoveAndUpdatesRegistry() throws {
+        let registry = RegistryFixture()
+        let bottle = makeRegisteredBottle(in: registry)
+        let destination = tempDir.appending(path: "Moved")
+
+        BottleOperations.move(bottleAt: bottleURL, to: destination, registry: registry)
+
+        let fileManager = FileManager.default
+        XCTAssertFalse(fileManager.fileExists(atPath: bottleURL.path(percentEncoded: false)))
+        XCTAssertTrue(fileManager.fileExists(atPath: destination.path(percentEncoded: false)))
+        XCTAssertEqual(registry.bottlePaths, [destination])
+        XCTAssertEqual(registry.loadCount, 1)
+        XCTAssertFalse(bottle.inFlight)
+
+        // The rewrite ran before the file move, so the persisted settings
+        // traveled with the bottle and now point inside the destination.
+        let moved = try persistedSettings(at: destination)
+        XCTAssertEqual(
+            moved.pins.compactMap { $0.url?.path(percentEncoded: false) },
+            [destination.appending(path: "drive_c/Program Files/Game/game.exe").path(percentEncoded: false)]
+        )
+        XCTAssertEqual(
+            moved.blocklist.map { $0.path(percentEncoded: false) },
+            [destination.appending(path: "drive_c/Program Files/Game/helper.exe").path(percentEncoded: false)]
+        )
+    }
+
+    @MainActor
+    func testFailedMoveRestoresPinsAndBlocklistAndClearsInFlight() throws {
+        let registry = RegistryFixture()
+        let bottle = makeRegisteredBottle(in: registry)
+        let originalPins = bottle.settings.pins
+        let originalBlocklist = bottle.settings.blocklist
+        // The destination's parent doesn't exist, so the file move throws
+        // after the settings were already rewritten (the issue #154 scenario).
+        let destination = tempDir.appending(path: "missing/Moved")
+
+        BottleOperations.move(bottleAt: bottleURL, to: destination, registry: registry)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: bottleURL.path(percentEncoded: false)))
+        XCTAssertEqual(bottle.settings.pins, originalPins)
+        XCTAssertEqual(bottle.settings.blocklist, originalBlocklist)
+
+        // The rollback must reach the persisted plist, not just memory.
+        let persisted = try persistedSettings(at: bottleURL)
+        XCTAssertEqual(
+            persisted.pins.compactMap { $0.url?.path(percentEncoded: false) },
+            [exeURL.path(percentEncoded: false)]
+        )
+        XCTAssertEqual(
+            persisted.blocklist.map { $0.path(percentEncoded: false) },
+            [blockedURL.path(percentEncoded: false)]
+        )
+
+        XCTAssertEqual(registry.bottlePaths, [bottleURL])
+        XCTAssertEqual(registry.loadCount, 0)
+        XCTAssertFalse(bottle.inFlight)
+    }
+
+    @MainActor
+    func testMoveWithNoRegisteredBottleStillMovesDirectory() {
+        let registry = RegistryFixture()
+        registry.bottlePaths = [bottleURL]
+        let destination = tempDir.appending(path: "Moved")
+
+        BottleOperations.move(bottleAt: bottleURL, to: destination, registry: registry)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: bottleURL.path(percentEncoded: false)))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
+        XCTAssertEqual(registry.bottlePaths, [destination])
+        XCTAssertEqual(registry.loadCount, 1)
+    }
+}
+
+// MARK: - Export
+
+final class BottleOperationsExportTests: BottleOperationsTestCase {
+    @MainActor
+    func testExportWritesArchiveAndClearsInFlight() async throws {
+        let registry = RegistryFixture()
+        let bottle = makeRegisteredBottle(in: registry)
+        let destination = tempDir.appending(path: "export.tar.gz")
+
+        try await BottleOperations.export(bottleAt: bottleURL, to: destination, registry: registry)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
+        XCTAssertFalse(bottle.inFlight)
+    }
+
+    @MainActor
+    func testExportThrowsWhenBottleIsNotRegistered() async {
+        let registry = RegistryFixture()
+        let destination = tempDir.appending(path: "export.tar.gz")
+
+        do {
+            try await BottleOperations.export(bottleAt: bottleURL, to: destination, registry: registry)
+            XCTFail("expected export to throw for an unregistered bottle")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, "com.franke.Whisky")
+            XCTAssertEqual(nsError.code, 1)
+        }
+    }
+}
+
+// MARK: - Duplicate
+
+final class BottleOperationsDuplicateTests: BottleOperationsTestCase {
+    @MainActor
+    func testDuplicateCopiesRewritesMetadataAndRegisters() async throws {
+        let registry = RegistryFixture()
+        let bottle = makeRegisteredBottle(in: registry)
+
+        let newURL = try await BottleOperations.duplicate(
+            bottleAt: bottleURL,
+            newName: "Original Copy",
+            registry: registry
+        )
+
+        // The clone lives beside the source and contains the copied program.
+        let clonedExe = newURL.appending(path: "drive_c/Program Files/Game/game.exe")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: clonedExe.path(percentEncoded: false)))
+
+        // The clone's metadata was renamed and rewritten to its own paths.
+        let cloned = try persistedSettings(at: newURL)
+        XCTAssertEqual(cloned.name, "Original Copy")
+        XCTAssertEqual(
+            cloned.pins.compactMap { $0.url?.path(percentEncoded: false) },
+            [clonedExe.path(percentEncoded: false)]
+        )
+        XCTAssertEqual(
+            cloned.blocklist.map { $0.path(percentEncoded: false) },
+            [newURL.appending(path: "drive_c/Program Files/Game/helper.exe").path(percentEncoded: false)]
+        )
+
+        // The source bottle's settings are untouched.
+        let source = try persistedSettings(at: bottleURL)
+        XCTAssertEqual(
+            source.pins.compactMap { $0.url?.path(percentEncoded: false) },
+            [exeURL.path(percentEncoded: false)]
+        )
+
+        // Registered, reloaded, and the guard released.
+        XCTAssertEqual(registry.bottlePaths, [bottleURL, newURL])
+        XCTAssertEqual(registry.loadCount, 1)
+        XCTAssertFalse(bottle.inFlight)
+    }
+
+    @MainActor
+    func testDuplicateReportsPhasesInOrder() async throws {
+        let registry = RegistryFixture()
+        _ = makeRegisteredBottle(in: registry)
+        let recorder = PhaseRecorder()
+
+        _ = try await BottleOperations.duplicate(
+            bottleAt: bottleURL,
+            newName: "Original Copy",
+            registry: registry
+        ) { recorder.record($0) }
+
+        let phases = recorder.phases
+        XCTAssertEqual(phases.count, 5)
+        guard phases.count == 5 else { return }
+        XCTAssertEqual(phases[0], .calculatingSize)
+        guard case let .copying(bytesCopied: startBytes, totalBytes: total) = phases[1] else {
+            return XCTFail("expected a copying start phase, got \(phases[1])")
+        }
+        XCTAssertEqual(startBytes, 0)
+        XCTAssertEqual(phases[2], .copying(bytesCopied: total, totalBytes: total))
+        XCTAssertEqual(phases[3], .updatingMetadata)
+        XCTAssertEqual(phases[4], .finalizing)
+    }
+
+    @MainActor
+    func testDuplicateStripsTransientArtifactsFromClone() async throws {
+        let registry = RegistryFixture()
+        _ = makeRegisteredBottle(in: registry)
+        let logFile = bottleURL.appending(path: "logs/old-run.log")
+        try FileManager.default.createDirectory(
+            at: bottleURL.appending(path: "logs"),
+            withIntermediateDirectories: true
+        )
+        try Data("log".utf8).write(to: logFile)
+        let historyFile = bottleURL.appending(path: "drive_c/game.exe.diagnosis-history.plist")
+        try Data("history".utf8).write(to: historyFile)
+
+        let newURL = try await BottleOperations.duplicate(
+            bottleAt: bottleURL,
+            newName: "Original Copy",
+            registry: registry
+        )
+
+        let fileManager = FileManager.default
+        XCTAssertFalse(
+            fileManager.fileExists(atPath: newURL.appending(path: "logs/old-run.log").path(percentEncoded: false))
+        )
+        let clonedHistory = newURL.appending(path: "drive_c/game.exe.diagnosis-history.plist")
+        XCTAssertFalse(fileManager.fileExists(atPath: clonedHistory.path(percentEncoded: false)))
+        // The source keeps its artifacts.
+        XCTAssertTrue(fileManager.fileExists(atPath: logFile.path(percentEncoded: false)))
+        XCTAssertTrue(fileManager.fileExists(atPath: historyFile.path(percentEncoded: false)))
+    }
+
+    @MainActor
+    func testDuplicateThrowsWhenBottleIsNotRegistered() async {
+        let registry = RegistryFixture()
+
+        do {
+            _ = try await BottleOperations.duplicate(
+                bottleAt: bottleURL,
+                newName: "Original Copy",
+                registry: registry
+            )
+            XCTFail("expected duplicate to throw for an unregistered bottle")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, "com.franke.Whisky")
+            XCTAssertEqual(nsError.code, 1)
+        }
+    }
+}
+
+// MARK: - Duplicate Naming
+
+final class NextDuplicateNameTests: XCTestCase {
+    func testFirstDuplicateAppendsCopy() {
+        XCTAssertEqual(
+            BottleOperations.nextDuplicateName(baseName: "Games", existingNames: ["Games"]),
+            "Games Copy"
+        )
+    }
+
+    func testSubsequentDuplicatesCountUp() {
+        XCTAssertEqual(
+            BottleOperations.nextDuplicateName(baseName: "Games", existingNames: ["Games", "Games Copy"]),
+            "Games Copy 2"
+        )
+        XCTAssertEqual(
+            BottleOperations.nextDuplicateName(
+                baseName: "Games",
+                existingNames: ["Games", "Games Copy", "Games Copy 2"]
+            ),
+            "Games Copy 3"
+        )
+    }
+}
+
+// MARK: - Remove
+
+final class BottleOperationsRemoveTests: BottleOperationsTestCase {
+    @MainActor
+    func testRemoveDeletingFilesRemovesDirectoryAndRegistryEntry() {
+        let registry = RegistryFixture()
+        _ = makeRegisteredBottle(in: registry)
+
+        BottleOperations.remove(bottleAt: bottleURL, deleteFiles: true, registry: registry)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: bottleURL.path(percentEncoded: false)))
+        XCTAssertTrue(registry.bottlePaths.isEmpty)
+        XCTAssertEqual(registry.loadCount, 1)
+    }
+
+    @MainActor
+    func testRemoveKeepingFilesOnlyDeregisters() {
+        let registry = RegistryFixture()
+        _ = makeRegisteredBottle(in: registry)
+
+        BottleOperations.remove(bottleAt: bottleURL, deleteFiles: false, registry: registry)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: bottleURL.path(percentEncoded: false)))
+        XCTAssertTrue(registry.bottlePaths.isEmpty)
+        XCTAssertEqual(registry.loadCount, 1)
+    }
+
+    @MainActor
+    func testRemoveFailureKeepsRegistryEntry() throws {
+        let registry = RegistryFixture()
+        _ = makeRegisteredBottle(in: registry)
+        // Deleting the directory up front makes the file removal throw.
+        try FileManager.default.removeItem(at: bottleURL)
+
+        BottleOperations.remove(bottleAt: bottleURL, deleteFiles: true, registry: registry)
+
+        XCTAssertEqual(registry.bottlePaths, [bottleURL])
+        XCTAssertEqual(registry.loadCount, 0)
+    }
+}


### PR DESCRIPTION
## Summary

Step 1 of the #171 extraction plan: the bottle move/export/duplicate/remove state machines move from the app target (`Whisky/Extensions/Bottle+Extensions.swift`) into WhiskyKit as `BottleOperations`, so `swift test` can finally reach them.

- New `BottleOperations` (WhiskyKit/Whisky) owns the operation logic verbatim: the move's pin/blocklist URL rewrite with snapshot and rollback on failure (#154 semantics preserved exactly: rewrite before the file move so settings travel with the bottle, restore both on throw, defer-clear the inFlight guard), export via Tar, duplicate (size/copy/metadata/finalize phases, transient artifact stripping, clone metadata rewrite), and the delete-and-deregister step of remove. `DuplicationPhase` and `nextDuplicateName` move with it.
- The BottleVM interactions sit behind a small `BottleRegistry` protocol (live bottle lookup by URL, path list access, reload). `BottleVM` conforms via a tiny bridge, and the app-side `Bottle` extension methods are now thin adapters, so all existing call sites keep working unchanged. WhiskyCmd-visible APIs are untouched.
- No behavior change intended anywhere; code was moved, not rewritten.

### Stayed in the app target (with reasons)

- `remove(delete:)` keeps its running-process check and NSAlert confirmation (AppKit modal flow), then delegates the delete-and-deregister step to the kit.
- `openCDrive`, `openTerminal`, `getStartMenuPrograms`, `updateInstalledPrograms`, `rename`, and the Wine username cache: NSWorkspace/AppleScript/UI entanglement, out of scope for step 1.

## Tests

New `BottleOperationsTests` (real temp-dir bottles with real `Metadata.plist` writes, in-memory registry fixture):

- move: failed move restores pins and blocklist in memory and in the persisted plist and clears inFlight (the #154 regression); successful move rewrites both before the file move and updates the registry path; move with no registered bottle still attempts the file move (preserved edge)
- export: archive written and inFlight cleared; unregistered bottle throws the existing not-found error
- duplicate: copy plus metadata rewrite plus registration; phases reported in order; transient artifacts stripped from the clone only; unregistered bottle throws
- remove: delete and deregister; deregister-only; failed delete keeps the registry entry
- naming: Finder-style Copy / Copy N sequence

## Verification

- `swift test --package-path WhiskyKit`: 1183 XCTest + 91 Swift Testing tests, 0 failures
- `xcodebuild -scheme Whisky -configuration Debug build`: succeeds
- `swiftlint lint --strict`: clean
- SwiftFormat 0.58.7 `--lint`: 0 files require formatting

Part of #171