### PR TITLE
feat: resumable runtime download with retry

### DIFF
--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -75016,6 +75016,17 @@
         }
       }
     },
+    "setup.whiskywine.error.interrupted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The connection was interrupted and the download could not be completed. Please try again."
+          }
+        }
+      }
+    },
     "setup.whiskywine.error.invalidDownloadURL" : {
       "localizations" : {
         "ar" : {

--- a/Whisky/Views/Setup/WhiskyWineDownloadView.swift
+++ b/Whisky/Views/Setup/WhiskyWineDownloadView.swift
@@ -17,12 +17,9 @@
 //
 
 import AppKit
-import os
 import SemanticVersion
 import SwiftUI
 import WhiskyKit
-
-private let logger = Logger(subsystem: Bundle.whiskyBundleIdentifier, category: "WhiskyWineDownloadView")
 
 struct WhiskyWineDownloadView: View {
     @State private var fractionProgress: Double = 0
@@ -30,14 +27,15 @@ struct WhiskyWineDownloadView: View {
     @State private var totalBytes: Int64 = 0
     // Internal so the formatting helpers in WhiskyWineDownloadFormatting.swift can read it.
     @State var downloadSpeed: Double = 0
-    @State private var downloadTask: URLSessionDownloadTask?
-    @State private var observation: NSKeyValueObservation?
+    @State private var downloadTask: Task<Void, Never>?
     @State private var startTime: Date?
+    /// Bytes already on disk when this UI session's download began (non-zero
+    /// when resuming a partial), so speed and ETA only count fresh bytes.
+    @State private var sessionBaselineBytes: Int64?
     /// The current failure, if any. Carries the user-facing message and the
     /// telemetry reason together so the two can never drift apart.
     /// Internal so the failure helper in WhiskyWineDownloadFormatting.swift can set it.
     @State var downloadFailure: DownloadFailure?
-    @State private var currentDownloadTaskID: UUID?
     /// Expected SHA-256 of the runtime archive, from the version plist. `nil`
     /// when no hash is advertised, in which case verification is skipped.
     @State private var expectedSHA256: String?
@@ -49,15 +47,26 @@ struct WhiskyWineDownloadView: View {
     @Binding var showSetup: Bool
     @Binding var diagnostics: WhiskyWineSetupDiagnostics
 
-    /// URLSession that survives transient connectivity loss (Wi-Fi/Ethernet
-    /// switches, VPN reconnects) and applies bounded request/resource timeouts
-    /// so a stalled download surfaces an error instead of hanging forever.
-    private static let resilientSession: URLSession = {
+    /// Stable on-disk home for the runtime archive. Living in Caches rather
+    /// than the ephemeral temp directory means a partially downloaded archive
+    /// survives an app relaunch, and the next attempt resumes it instead of
+    /// starting the full download over.
+    static let archiveDestination: URL = .cachesDirectory
+        .appending(path: Bundle.whiskyBundleIdentifier)
+        .appending(path: "RuntimeDownload")
+        .appending(path: "Libraries.tar.gz")
+
+    /// Downloader that resumes interrupted transfers and retries transient
+    /// failures with backoff. The session survives transient connectivity loss
+    /// (Wi-Fi/Ethernet switches, VPN reconnects) and applies bounded
+    /// request/resource timeouts so a stalled download surfaces an error
+    /// instead of hanging forever.
+    private static let downloader: ResumableDownloader = {
         let config = URLSessionConfiguration.ephemeral
         config.waitsForConnectivity = true
         config.timeoutIntervalForRequest = 60
         config.timeoutIntervalForResource = 600
-        return URLSession(configuration: config)
+        return ResumableDownloader(sessionConfiguration: config)
     }()
 
     var body: some View {
@@ -173,6 +182,8 @@ extension WhiskyWineDownloadView {
         .padding(.horizontal)
     }
 
+    /// Resets the UI and starts over. Partial download data stays on disk, so
+    /// the new attempt resumes from wherever the failed one stopped.
     private func retryDownload() {
         downloadFailure = nil
         fractionProgress = 0
@@ -180,11 +191,9 @@ extension WhiskyWineDownloadView {
         totalBytes = 0
         downloadSpeed = 0
         startTime = nil
+        sessionBaselineBytes = nil
         downloadTask?.cancel()
-        observation?.invalidate()
-        observation = nil
         downloadTask = nil
-        currentDownloadTaskID = nil
         diagnostics.resetDownloadState(reason: "Retry requested")
         Task {
             await fetchVersionAndDownload()
@@ -235,6 +244,9 @@ extension WhiskyWineDownloadView {
             }
 
             diagnostics.downloadURL = downloadURL.absoluteString
+            if await reuseExistingArchiveIfValid() {
+                return
+            }
             startDownload(from: downloadURL)
         } catch {
             let errorMessage = error.localizedDescription
@@ -246,97 +258,77 @@ extension WhiskyWineDownloadView {
         }
     }
 
+    /// A finished archive can be left behind when the app quits between the
+    /// download and install stages. If it matches the advertised hash, skip
+    /// straight to install; if not, discard it so the download starts clean.
+    /// - Returns: `true` when the setup flow already moved on to install.
     @MainActor
-    private func startDownload(from url: URL) {
-        let taskID = UUID()
-        currentDownloadTaskID = taskID
-
-        diagnostics.downloadStartedAt = Date()
-        diagnostics.record("Starting download")
-        downloadTask = Self.resilientSession.downloadTask(with: url) { fileURL, response, error in
-            // URLSession deletes the temporary file immediately after completion handler returns.
-            // We must move it to a safe location synchronously before the async Task executes.
-            var permanentURL: URL?
-            var moveError: Error?
-            if let tempURL = fileURL {
-                let destinationURL = FileManager.default.temporaryDirectory
-                    .appendingPathComponent(UUID().uuidString)
-                    .appendingPathExtension("tar.gz")
-                do {
-                    try FileManager.default.moveItem(at: tempURL, to: destinationURL)
-                    permanentURL = destinationURL
-                } catch {
-                    // Log and capture move error to provide better error messaging
-                    let errorDesc = error.localizedDescription
-                    logger.error("Failed to move file: \(errorDesc)")
-                    moveError = error
-                    permanentURL = nil
-                }
-            }
-
-            // Prioritize network error, then move error
-            let effectiveError = error ?? moveError
-            Task { @MainActor in
-                handleDownloadCompletion(
-                    taskID: taskID,
-                    fileURL: permanentURL,
-                    response: response,
-                    error: effectiveError
-                )
-            }
+    private func reuseExistingArchiveIfValid() async -> Bool {
+        let destination = Self.archiveDestination
+        guard let expected = expectedSHA256,
+              FileManager.default.fileExists(atPath: destination.path(percentEncoded: false))
+        else { return false }
+        diagnostics.record("Found previously downloaded archive; verifying")
+        let result = await Task.detached {
+            WhiskyWineInstaller.integrityResult(forFileAt: destination, expectedSHA256: expected)
+        }.value
+        guard result == .match else {
+            diagnostics.record("Previous archive failed verification; discarding")
+            ResumableDownloader.discardArtifacts(at: destination)
+            return false
         }
-
-        observation = downloadTask?.observe(\.countOfBytesReceived) { [taskID] task, _ in
-            Task { @MainActor in
-                handleProgressUpdate(taskID: taskID, task: task)
-            }
-        }
-
-        startTime = Date()
-        downloadTask?.resume()
+        diagnostics.record("Previous archive verified; skipping download")
+        tarLocation = destination
+        proceed()
+        return true
     }
 
     @MainActor
-    private func handleDownloadCompletion(
-        taskID: UUID,
-        fileURL: URL?,
-        response: URLResponse?,
-        error: Error?
-    ) {
-        guard currentDownloadTaskID == taskID else { return }
-
-        if let error {
-            // Don't show error when download was explicitly cancelled (e.g., during retry)
-            if (error as NSError).code == NSURLErrorCancelled {
-                return
+    private func startDownload(from url: URL) {
+        diagnostics.downloadStartedAt = Date()
+        diagnostics.record("Starting download")
+        startTime = Date()
+        sessionBaselineBytes = nil
+        let destination = Self.archiveDestination
+        downloadTask = Task { @MainActor in
+            do {
+                try await Self.downloader.download(
+                    from: url,
+                    to: destination,
+                    onEvent: { message in
+                        Task { @MainActor in diagnostics.record(message) }
+                    },
+                    progress: { progress in
+                        Task { @MainActor in handleProgressUpdate(progress) }
+                    }
+                )
+                diagnostics.downloadFinishedAt = Date()
+                diagnostics.record("Download completed")
+                await verifyThenProceed(fileURL: destination)
+            } catch is CancellationError {
+                // Cancelled by retry or quit; partial data stays for resume.
+            } catch let urlError as URLError where urlError.code == .cancelled {
+                // Same as above, surfaced through URLSession.
+            } catch {
+                handleDownloadError(error)
             }
-            setDownloadFailure(String(
-                format: String(localized: "setup.whiskywine.error.downloadFailed"),
-                error.localizedDescription
-            ))
-            diagnostics.downloadFinishedAt = Date()
-            diagnostics.record("Download failed: \(error.localizedDescription)")
+        }
+    }
+
+    @MainActor
+    private func handleDownloadError(_ error: Error) {
+        diagnostics.downloadFinishedAt = Date()
+        if case let ResumableDownloadError.httpStatus(statusCode) = error {
+            diagnostics.downloadHTTPStatus = statusCode
+            diagnostics.record("Download HTTP \(statusCode)")
+            setDownloadFailure(formatHTTPError(statusCode: statusCode))
             return
         }
-
-        if let httpResponse = response as? HTTPURLResponse,
-           !(200 ... 299).contains(httpResponse.statusCode) {
-            diagnostics.downloadHTTPStatus = httpResponse.statusCode
-            diagnostics.downloadFinishedAt = Date()
-            diagnostics.record("Download HTTP \(httpResponse.statusCode)")
-            setDownloadFailure(formatHTTPError(statusCode: httpResponse.statusCode))
-            return
-        }
-
-        if let url = fileURL {
-            diagnostics.downloadFinishedAt = Date()
-            diagnostics.record("Download completed: moved to temp")
-            Task { await verifyThenProceed(fileURL: url) }
-        } else {
-            diagnostics.downloadFinishedAt = Date()
-            diagnostics.record("Download completed but no file URL received")
-            setDownloadFailure(String(localized: "setup.whiskywine.error.noFileReceived"))
-        }
+        diagnostics.record("Download failed: \(error.localizedDescription)")
+        setDownloadFailure(String(
+            format: String(localized: "setup.whiskywine.error.downloadFailed"),
+            error.localizedDescription
+        ))
     }
 
     /// Verifies the downloaded archive against the advertised SHA-256, then
@@ -359,7 +351,9 @@ extension WhiskyWineDownloadView {
             }
             if let failure {
                 diagnostics.record("Integrity check FAILED — \(failure)")
-                WhiskyWineInstaller.cleanupTarball(at: fileURL)
+                // Discard the archive plus any resume artifacts so the next
+                // attempt restarts from a clean slate, never from bad bytes.
+                ResumableDownloader.discardArtifacts(at: fileURL)
                 setDownloadFailure(
                     String(
                         localized: "setup.whiskywine.error.checksumMismatch",
@@ -380,17 +374,22 @@ extension WhiskyWineDownloadView {
     }
 
     @MainActor
-    private func handleProgressUpdate(taskID: UUID, task: URLSessionDownloadTask) {
-        guard currentDownloadTaskID == taskID else { return }
-
+    private func handleProgressUpdate(_ progress: ResumableDownloadProgress) {
+        if sessionBaselineBytes == nil {
+            // First report of this session. When resuming, it already includes
+            // the carried-over prefix; baseline it so speed and ETA reflect
+            // only bytes actually transferred now.
+            sessionBaselineBytes = progress.bytesOnDisk
+            startTime = Date()
+        }
+        completedBytes = progress.bytesOnDisk
+        totalBytes = progress.expectedBytes ?? 0
         let currentTime = Date()
         let elapsedTime = currentTime.timeIntervalSince(startTime ?? currentTime)
-        let currentBytes = task.countOfBytesReceived
-        if currentBytes > 0 {
-            downloadSpeed = Double(currentBytes) / elapsedTime
+        let sessionBytes = completedBytes - (sessionBaselineBytes ?? 0)
+        if sessionBytes > 0, elapsedTime > 0 {
+            downloadSpeed = Double(sessionBytes) / elapsedTime
         }
-        totalBytes = task.countOfBytesExpectedToReceive
-        completedBytes = currentBytes
         if totalBytes > 0 {
             fractionProgress = Double(completedBytes) / Double(totalBytes)
         }

--- a/WhiskyKit/Sources/WhiskyKit/Utils/ResumableDownloadSupport.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Utils/ResumableDownloadSupport.swift
@@ -1,0 +1,188 @@
+//
+//  ResumableDownloadSupport.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Retry policy for ``ResumableDownloader``: how many attempts to make and how
+/// long to back off between them.
+public struct ResumableDownloadRetryPolicy: Sendable {
+    /// Total attempt budget, counting the first try. `1` disables retries.
+    public var maxAttempts: Int
+
+    /// Delay before the first retry. Each subsequent retry doubles it.
+    public var initialRetryDelay: TimeInterval
+
+    /// Upper bound on the backoff delay, so a long outage polls at a steady
+    /// cadence instead of growing without bound.
+    public var maxRetryDelay: TimeInterval
+
+    public init(maxAttempts: Int = 4, initialRetryDelay: TimeInterval = 1, maxRetryDelay: TimeInterval = 15) {
+        self.maxAttempts = max(1, maxAttempts)
+        self.initialRetryDelay = max(0, initialRetryDelay)
+        self.maxRetryDelay = max(self.initialRetryDelay, maxRetryDelay)
+    }
+
+    /// The backoff before retry number `retry` (1-based): the initial delay
+    /// doubled per retry, capped at ``maxRetryDelay``.
+    func delay(beforeRetry retry: Int) -> TimeInterval {
+        // Cap the exponent so the shift can't overflow for absurd retry counts.
+        let exponent = min(max(retry - 1, 0), 32)
+        return min(initialRetryDelay * pow(2, Double(exponent)), maxRetryDelay)
+    }
+}
+
+/// A snapshot of download progress reported by ``ResumableDownloader``.
+public struct ResumableDownloadProgress: Sendable, Equatable {
+    /// Bytes persisted to disk so far, including any prefix carried over from
+    /// an earlier interrupted attempt.
+    public let bytesOnDisk: Int64
+
+    /// Total size of the file when the server advertised one, or `nil`.
+    public let expectedBytes: Int64?
+
+    public init(bytesOnDisk: Int64, expectedBytes: Int64?) {
+        self.bytesOnDisk = bytesOnDisk
+        self.expectedBytes = expectedBytes
+    }
+}
+
+/// Errors thrown by ``ResumableDownloader/download(from:to:onEvent:progress:)``.
+public enum ResumableDownloadError: LocalizedError, Equatable {
+    /// The server answered with a status code outside the download protocol
+    /// (not 200/206/416). Retried automatically only for transient codes.
+    case httpStatus(Int)
+
+    /// The response was not an HTTP response, or the connection closed before
+    /// headers arrived.
+    case invalidResponse
+
+    /// The connection closed cleanly before all advertised bytes arrived. The
+    /// partial file is kept so the next attempt resumes where this one stopped.
+    case truncatedTransfer(received: Int64, expected: Int64)
+
+    /// The on-disk partial no longer matches what the server offers (HTTP 416,
+    /// or a 206 at an unexpected offset). The partial has been discarded, so
+    /// the next attempt starts from a clean slate.
+    case staleResume
+
+    public var errorDescription: String? {
+        switch self {
+        case let .httpStatus(code):
+            String(format: String(localized: "setup.whiskywine.error.httpError"), code)
+        case .invalidResponse, .truncatedTransfer, .staleResume:
+            String(localized: "setup.whiskywine.error.interrupted")
+        }
+    }
+}
+
+/// Sidecar record persisted next to a partial download so a later attempt, or
+/// a fresh app launch, can resume it safely.
+struct ResumeState: Codable, Equatable {
+    /// The absolute source URL. A partial is only ever resumed for the same
+    /// URL; a different runtime release downloads to a clean slate.
+    var urlString: String
+
+    /// The server's validator for the entity the partial belongs to (a strong
+    /// ETag when available, else Last-Modified). Replayed via `If-Range` so a
+    /// republished asset produces a full 200 response instead of splicing
+    /// bytes from two different files.
+    var validator: String?
+
+    /// Total size when the server advertised one.
+    var expectedBytes: Int64?
+
+    static func load(from url: URL) -> ResumeState? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? PropertyListDecoder().decode(ResumeState.self, from: data)
+    }
+
+    func save(to url: URL) {
+        guard let data = try? PropertyListEncoder().encode(self) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+}
+
+/// Header parsing for the byte-range resume protocol.
+enum HTTPRangeSupport {
+    /// Parses a `Content-Range` header of the form `bytes <start>-<end>/<total>`.
+    /// Returns the start offset and the total size (`nil` when the server sent
+    /// `*` for an unknown total).
+    static func parseContentRange(_ value: String?) -> (start: Int64, total: Int64?)? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        guard trimmed.lowercased().hasPrefix("bytes") else { return nil }
+        let spec = trimmed.dropFirst("bytes".count).trimmingCharacters(in: .whitespaces)
+        let parts = spec.split(separator: "/", maxSplits: 1)
+        guard let rangePart = parts.first,
+              let dash = rangePart.firstIndex(of: "-"),
+              let start = Int64(rangePart[..<dash])
+        else { return nil }
+        let total = parts.count == 2 ? Int64(parts[1]) : nil
+        return (start, total)
+    }
+
+    /// Picks the validator to record for a response: a strong ETag when the
+    /// server sent one, else Last-Modified. Weak ETags (`W/...`) are unusable
+    /// for `If-Range` per RFC 9110, so they are skipped.
+    static func validator(from response: HTTPURLResponse) -> String? {
+        if let etag = response.value(forHTTPHeaderField: "ETag"), !etag.hasPrefix("W/") {
+            return etag
+        }
+        return response.value(forHTTPHeaderField: "Last-Modified")
+    }
+}
+
+/// Bridges `URLSession`'s data-task delegate callbacks into an async stream so
+/// the downloader can inspect response headers and append body chunks to disk
+/// as they arrive. A download task only hands over its file at the very end
+/// (and deletes it on failure), which is exactly what resumability cannot
+/// afford; a data task streamed to an app-owned file keeps every byte.
+final class HTTPStreamDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    enum Event {
+        case response(URLResponse)
+        case chunk(Data)
+    }
+
+    /// Response headers first, then body chunks; finishes when the transfer
+    /// completes or fails.
+    let events: AsyncThrowingStream<Event, Error>
+    private let continuation: AsyncThrowingStream<Event, Error>.Continuation
+
+    override init() {
+        (events, continuation) = AsyncThrowingStream<Event, Error>.makeStream()
+        super.init()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void
+    ) {
+        continuation.yield(.response(response))
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        continuation.yield(.chunk(data))
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        continuation.finish(throwing: error)
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Utils/ResumableDownloader.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Utils/ResumableDownloader.swift
@@ -1,0 +1,337 @@
+//
+//  ResumableDownloader.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import os
+
+private let logger = Logger(subsystem: Bundle.whiskyBundleIdentifier, category: "ResumableDownloader")
+
+/// Downloads a file over HTTP with resume support and bounded automatic retry.
+///
+/// Interrupted transfers keep their partial bytes on disk (next to the final
+/// destination, with a sidecar resume record), so the next attempt, whether an
+/// automatic retry, a user-initiated one, or a fresh app launch, continues from
+/// where the last one stopped instead of restarting from byte zero. Resumes use
+/// HTTP `Range` requests guarded by `If-Range`, so a republished asset falls
+/// back to a clean full download rather than splicing bytes from two different
+/// files.
+///
+/// This is transport-level recovery only: callers remain responsible for
+/// content integrity (the runtime install path verifies the advertised SHA-256
+/// before extracting, and discards the file via ``discardArtifacts(at:)`` on a
+/// mismatch).
+public final class ResumableDownloader: @unchecked Sendable {
+    // Both stored properties are set at init and never mutated afterwards
+    // (the session configuration is treated as frozen), hence @unchecked.
+    private let sessionConfiguration: URLSessionConfiguration
+    private let retryPolicy: ResumableDownloadRetryPolicy
+
+    /// - Parameters:
+    ///   - sessionConfiguration: Configuration for the URLSession each attempt
+    ///     runs on. Must not be mutated after being handed over.
+    ///   - retryPolicy: Attempt budget and backoff for transient failures.
+    public init(
+        sessionConfiguration: URLSessionConfiguration = .ephemeral,
+        retryPolicy: ResumableDownloadRetryPolicy = ResumableDownloadRetryPolicy()
+    ) {
+        self.sessionConfiguration = sessionConfiguration
+        self.retryPolicy = retryPolicy
+    }
+
+    // MARK: - On-disk layout
+
+    /// Where in-flight bytes accumulate for `destination`.
+    static func partialURL(for destination: URL) -> URL {
+        destination.appendingPathExtension("partial")
+    }
+
+    /// Where the resume record for `destination` lives.
+    static func resumeStateURL(for destination: URL) -> URL {
+        destination.appendingPathExtension("resume")
+    }
+
+    /// Removes the downloaded file plus any partial data and resume state for
+    /// `destination`. Call after a failed integrity check so the next download
+    /// starts from a clean slate.
+    public static func discardArtifacts(at destination: URL) {
+        for url in [destination, partialURL(for: destination), resumeStateURL(for: destination)] {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    /// Removes only the in-flight artifacts (partial bytes and resume record).
+    private static func discardPartial(for destination: URL) {
+        try? FileManager.default.removeItem(at: partialURL(for: destination))
+        try? FileManager.default.removeItem(at: resumeStateURL(for: destination))
+    }
+
+    // MARK: - Download
+
+    /// Downloads `url` to `destination`, resuming any compatible partial left
+    /// by an earlier attempt and retrying transient failures with exponential
+    /// backoff. On success the completed file sits at `destination` and all
+    /// in-flight artifacts are gone. On failure the partial bytes stay behind
+    /// for the next call to resume. Throws `CancellationError` when the
+    /// surrounding task is cancelled.
+    ///
+    /// - Parameters:
+    ///   - url: The source URL.
+    ///   - destination: The final location for the completed file.
+    ///   - onEvent: Diagnostic callback for notable transport events (resume
+    ///     offsets, retries). Messages are developer-facing, not localized.
+    ///   - progress: Called as bytes reach disk.
+    public func download(
+        from url: URL,
+        to destination: URL,
+        onEvent: @escaping @Sendable (String) -> Void = { _ in },
+        progress: @escaping @Sendable (ResumableDownloadProgress) -> Void = { _ in }
+    ) async throws {
+        var attempt = 1
+        while true {
+            do {
+                try await performAttempt(url: url, destination: destination, onEvent: onEvent, progress: progress)
+                return
+            } catch {
+                // A cancelled URLSession task surfaces as URLError.cancelled;
+                // report it as task cancellation, never as a download failure.
+                try Task.checkCancellation()
+                guard Self.isTransient(error), attempt < retryPolicy.maxAttempts else {
+                    throw error
+                }
+                let delay = retryPolicy.delay(beforeRetry: attempt)
+                let message = "Attempt \(attempt) of \(retryPolicy.maxAttempts) failed"
+                    + " (\(error.localizedDescription)); retrying in \(String(format: "%.1f", delay))s"
+                logger.warning("\(message)")
+                onEvent(message)
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                attempt += 1
+            }
+        }
+    }
+
+    /// Whether `error` is worth retrying without user involvement: dropped or
+    /// unreachable connections, stalls, transient HTTP statuses, and resume
+    /// state the server rejected (the retry then starts clean).
+    static func isTransient(_ error: Error) -> Bool {
+        switch error {
+        case let downloadError as ResumableDownloadError:
+            switch downloadError {
+            case let .httpStatus(code):
+                code == 408 || code == 429 || (500 ... 599).contains(code)
+            case .truncatedTransfer, .staleResume:
+                true
+            case .invalidResponse:
+                false
+            }
+        case let urlError as URLError:
+            Self.transientURLErrorCodes.contains(urlError.code)
+        default:
+            false
+        }
+    }
+
+    private static let transientURLErrorCodes: Set<URLError.Code> = [
+        .timedOut, .cannotFindHost, .cannotConnectToHost, .networkConnectionLost,
+        .dnsLookupFailed, .notConnectedToInternet, .resourceUnavailable,
+        .secureConnectionFailed, .dataNotAllowed
+    ]
+
+    // MARK: - Single attempt
+
+    /// Inputs threaded through one attempt.
+    private struct AttemptContext {
+        let url: URL
+        let destination: URL
+        let partialURL: URL
+        let stateURL: URL
+        let resumeOffset: Int64
+        let onEvent: @Sendable (String) -> Void
+        let progress: @Sendable (ResumableDownloadProgress) -> Void
+    }
+
+    private func performAttempt(
+        url: URL,
+        destination: URL,
+        onEvent: @escaping @Sendable (String) -> Void,
+        progress: @escaping @Sendable (ResumableDownloadProgress) -> Void
+    ) async throws {
+        let fileManager = FileManager.default
+        let partialURL = Self.partialURL(for: destination)
+        let stateURL = Self.resumeStateURL(for: destination)
+        try fileManager.createDirectory(
+            at: destination.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+
+        // Resume only when the recorded state matches this URL and partial
+        // bytes actually exist; otherwise clear leftovers and start clean.
+        var resumeOffset: Int64 = 0
+        var validator: String?
+        if let state = ResumeState.load(from: stateURL),
+           state.urlString == url.absoluteString,
+           let partialSize = Self.fileSize(at: partialURL),
+           partialSize > 0 {
+            resumeOffset = partialSize
+            validator = state.validator
+        } else {
+            Self.discardPartial(for: destination)
+        }
+
+        var request = URLRequest(url: url)
+        if resumeOffset > 0 {
+            request.setValue("bytes=\(resumeOffset)-", forHTTPHeaderField: "Range")
+            if let validator {
+                request.setValue(validator, forHTTPHeaderField: "If-Range")
+            }
+            onEvent("Resuming download from byte \(resumeOffset)")
+        }
+
+        let context = AttemptContext(
+            url: url,
+            destination: destination,
+            partialURL: partialURL,
+            stateURL: stateURL,
+            resumeOffset: resumeOffset,
+            onEvent: onEvent,
+            progress: progress
+        )
+
+        let delegate = HTTPStreamDelegate()
+        let session = URLSession(configuration: sessionConfiguration, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        let task = session.dataTask(with: request)
+
+        try await withTaskCancellationHandler {
+            try await consume(events: delegate.events, task: task, context: context)
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
+    private func consume(
+        events: AsyncThrowingStream<HTTPStreamDelegate.Event, Error>,
+        task: URLSessionDataTask,
+        context: AttemptContext
+    ) async throws {
+        task.resume()
+        let fileManager = FileManager.default
+        var handle: FileHandle?
+        var bytesOnDisk = context.resumeOffset
+        var expectedTotal: Int64?
+        var sawResponse = false
+        defer { try? handle?.close() }
+
+        for try await event in events {
+            switch event {
+            case let .response(response):
+                sawResponse = true
+                guard let http = response as? HTTPURLResponse else {
+                    task.cancel()
+                    throw ResumableDownloadError.invalidResponse
+                }
+                switch Self.disposition(for: http, resumeOffset: context.resumeOffset) {
+                case let .append(total):
+                    expectedTotal = total
+                    let fileHandle = try FileHandle(forWritingTo: context.partialURL)
+                    try fileHandle.seekToEnd()
+                    handle = fileHandle
+                case let .restart(total):
+                    expectedTotal = total
+                    bytesOnDisk = 0
+                    fileManager.createFile(atPath: context.partialURL.path(percentEncoded: false), contents: nil)
+                    handle = try FileHandle(forWritingTo: context.partialURL)
+                    if context.resumeOffset > 0 {
+                        context.onEvent("Server restarted the download from the beginning")
+                    }
+                case .stale:
+                    task.cancel()
+                    Self.discardPartial(for: context.destination)
+                    throw ResumableDownloadError.staleResume
+                case let .failure(code):
+                    task.cancel()
+                    throw ResumableDownloadError.httpStatus(code)
+                }
+                // Record resume state as soon as headers arrive, so a partial
+                // left by a crash or quit is resumable on the next launch.
+                ResumeState(
+                    urlString: context.url.absoluteString,
+                    validator: HTTPRangeSupport.validator(from: http),
+                    expectedBytes: expectedTotal
+                ).save(to: context.stateURL)
+            case let .chunk(data):
+                guard let handle else { continue }
+                try handle.write(contentsOf: data)
+                bytesOnDisk += Int64(data.count)
+                context.progress(ResumableDownloadProgress(bytesOnDisk: bytesOnDisk, expectedBytes: expectedTotal))
+            }
+        }
+
+        guard sawResponse else { throw ResumableDownloadError.invalidResponse }
+        try handle?.close()
+        handle = nil
+        if let expectedTotal, bytesOnDisk < expectedTotal {
+            // The connection closed cleanly before all advertised bytes came
+            // through. Keep the partial; the next attempt resumes from here.
+            throw ResumableDownloadError.truncatedTransfer(received: bytesOnDisk, expected: expectedTotal)
+        }
+
+        // Promote the finished partial and drop the resume record.
+        try? fileManager.removeItem(at: context.destination)
+        try fileManager.moveItem(at: context.partialURL, to: context.destination)
+        try? fileManager.removeItem(at: context.stateURL)
+    }
+
+    /// What to do with a response, given the offset the attempt asked to
+    /// resume from.
+    private enum Disposition {
+        case append(expectedTotal: Int64?)
+        case restart(expectedTotal: Int64?)
+        case stale
+        case failure(Int)
+    }
+
+    private static func disposition(for response: HTTPURLResponse, resumeOffset: Int64) -> Disposition {
+        switch response.statusCode {
+        case 206:
+            // Only honor a partial response that starts exactly where our
+            // bytes end; anything else would corrupt the file.
+            guard resumeOffset > 0,
+                  let range = HTTPRangeSupport.parseContentRange(
+                      response.value(forHTTPHeaderField: "Content-Range")
+                  ),
+                  range.start == resumeOffset
+            else { return .stale }
+            return .append(expectedTotal: range.total)
+        case 200:
+            // Full response: either a clean start, or the server declined the
+            // range (e.g. the If-Range validator no longer matches).
+            let length = response.expectedContentLength
+            return .restart(expectedTotal: length >= 0 ? length : nil)
+        case 416:
+            // Requested range not satisfiable: our partial is useless.
+            return .stale
+        default:
+            return .failure(response.statusCode)
+        }
+    }
+
+    private static func fileSize(at url: URL) -> Int64? {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path(percentEncoded: false))
+        return (attributes?[.size] as? NSNumber)?.int64Value
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/HTTPStubProtocol.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/HTTPStubProtocol.swift
@@ -1,0 +1,140 @@
+//
+//  HTTPStubProtocol.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// A `URLProtocol` stub that answers every request from a test-provided
+/// handler, recording each request it sees. Install it via
+/// `URLSessionConfiguration.protocolClasses` so downloader tests run fully
+/// offline and deterministically.
+final class HTTPStubProtocol: URLProtocol {
+    /// One scripted response.
+    struct StubResponse {
+        var statusCode: Int
+        var headers: [String: String] = [:]
+        var body = Data()
+        /// When set, deliver only this many body bytes and then interrupt.
+        var deliverOnly: Int?
+        /// How to interrupt after `deliverOnly` bytes: finish the response
+        /// cleanly (a truncated close) when `true`, else fail with
+        /// `URLError.networkConnectionLost`.
+        var finishEarlyAfterPartialBody = false
+    }
+
+    typealias Handler = @Sendable (URLRequest) -> StubResponse
+
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var storedHandler: Handler?
+    private nonisolated(unsafe) static var storedRequests: [URLRequest] = []
+
+    static var handler: Handler? {
+        get { lock.withLock { storedHandler } }
+        set { lock.withLock { storedHandler = newValue } }
+    }
+
+    /// Every request seen since the last `reset()`, in arrival order.
+    static var requests: [URLRequest] {
+        lock.withLock { storedRequests }
+    }
+
+    static func reset() {
+        lock.withLock {
+            storedHandler = nil
+            storedRequests = []
+        }
+    }
+
+    private static func record(_ request: URLRequest) {
+        lock.withLock { storedRequests.append(request) }
+    }
+
+    private let stateLock = NSLock()
+    private var isStopped = false
+
+    // URLProtocol declares these as class funcs, so `static` is not an option.
+    // swiftlint:disable:next static_over_final_class
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    // swiftlint:disable:next static_over_final_class
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+            return
+        }
+        Self.record(request)
+        let stub = handler(request)
+
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: stub.statusCode,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: stub.headers
+              )
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+
+        if let limit = stub.deliverOnly {
+            let partial = stub.body.prefix(limit)
+            if !partial.isEmpty {
+                client?.urlProtocol(self, didLoad: Data(partial))
+            }
+            if stub.finishEarlyAfterPartialBody {
+                client?.urlProtocolDidFinishLoading(self)
+            } else {
+                // Fail on a delay: an error reported in the same turn as the
+                // final data chunk makes URLSession drop the not-yet-delivered
+                // bytes, which would make the interruption tests start the
+                // resume from byte zero.
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                    guard let self, !self.stateLock.withLock({ self.isStopped }) else { return }
+                    client?.urlProtocol(self, didFailWithError: URLError(.networkConnectionLost))
+                }
+            }
+        } else {
+            if !stub.body.isEmpty {
+                client?.urlProtocol(self, didLoad: stub.body)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    override func stopLoading() {
+        stateLock.withLock { isStopped = true }
+    }
+}
+
+/// A tiny thread-safe attempt counter for scripting per-request behavior.
+final class RequestCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    /// Returns the 1-based number of this call.
+    func next() -> Int {
+        lock.withLock {
+            count += 1
+            return count
+        }
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/ResumableDownloaderTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ResumableDownloaderTests.swift
@@ -1,0 +1,446 @@
+//
+//  ResumableDownloaderTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+// swiftlint:disable file_length
+
+import CryptoKit
+@testable import WhiskyKit
+import XCTest
+
+/// Collects progress values across concurrency domains.
+private final class ProgressLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Int64] = []
+
+    func append(_ value: Int64) {
+        lock.withLock { values.append(value) }
+    }
+
+    var all: [Int64] {
+        lock.withLock { values }
+    }
+}
+
+// swiftlint:disable:next type_body_length
+final class ResumableDownloaderTests: XCTestCase {
+    private var tempDir: URL!
+    private var destination: URL!
+    private let sourceURL = URL(string: "https://example.test/Libraries.tar.gz") ?? URL(fileURLWithPath: "/")
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appending(path: "ResumableDownloaderTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        destination = tempDir.appending(path: "Libraries.tar.gz")
+        HTTPStubProtocol.reset()
+    }
+
+    override func tearDownWithError() throws {
+        HTTPStubProtocol.reset()
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    private var partialURL: URL { ResumableDownloader.partialURL(for: destination) }
+    private var stateURL: URL { ResumableDownloader.resumeStateURL(for: destination) }
+
+    private func makeDownloader(
+        maxAttempts: Int = 4,
+        initialRetryDelay: TimeInterval = 0.02
+    ) -> ResumableDownloader {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [HTTPStubProtocol.self]
+        return ResumableDownloader(
+            sessionConfiguration: config,
+            retryPolicy: ResumableDownloadRetryPolicy(
+                maxAttempts: maxAttempts,
+                initialRetryDelay: initialRetryDelay,
+                maxRetryDelay: 0.1
+            )
+        )
+    }
+
+    /// Deterministic pseudo-random payload so byte-identity failures are real.
+    private static func makePayload(length: Int, seed: UInt64 = 42) -> Data {
+        var state = seed
+        var data = Data(capacity: length)
+        for _ in 0 ..< length {
+            state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            data.append(UInt8(truncatingIfNeeded: state >> 33))
+        }
+        return data
+    }
+
+    private static func sha256Hex(of data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Serves `payload` like a static file server with byte-range support.
+    /// `script` can override individual requests (1-based) to fault-inject.
+    private static func installRangeServer(
+        payload: Data,
+        etag: String = "\"etag-1\"",
+        script: @escaping @Sendable (Int, URLRequest) -> HTTPStubProtocol.StubResponse? = { _, _ in nil }
+    ) {
+        let counter = RequestCounter()
+        HTTPStubProtocol.handler = { request in
+            if let scripted = script(counter.next(), request) {
+                return scripted
+            }
+            return serve(payload: payload, etag: etag, request: request)
+        }
+    }
+
+    private static func serve(payload: Data, etag: String, request: URLRequest) -> HTTPStubProtocol.StubResponse {
+        let ifRange = request.value(forHTTPHeaderField: "If-Range")
+        if let rangeHeader = request.value(forHTTPHeaderField: "Range"),
+           let offsetPart = rangeHeader.split(separator: "=").last?.split(separator: "-").first,
+           let offset = Int(offsetPart),
+           ifRange == nil || ifRange == etag {
+            guard offset < payload.count else {
+                return HTTPStubProtocol.StubResponse(
+                    statusCode: 416,
+                    headers: ["Content-Range": "bytes */\(payload.count)", "ETag": etag]
+                )
+            }
+            let body = payload.subdata(in: offset ..< payload.count)
+            return HTTPStubProtocol.StubResponse(
+                statusCode: 206,
+                headers: [
+                    "Content-Range": "bytes \(offset)-\(payload.count - 1)/\(payload.count)",
+                    "Content-Length": "\(body.count)",
+                    "ETag": etag
+                ],
+                body: body
+            )
+        }
+        return HTTPStubProtocol.StubResponse(
+            statusCode: 200,
+            headers: ["Content-Length": "\(payload.count)", "ETag": etag],
+            body: payload
+        )
+    }
+
+    private func rangeHeader(ofRequest index: Int) -> String? {
+        let requests = HTTPStubProtocol.requests
+        guard index < requests.count else { return nil }
+        return requests[index].value(forHTTPHeaderField: "Range")
+    }
+
+    private func assertNoInFlightArtifacts(file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: partialURL.path), "partial should be gone", file: file, line: line
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: stateURL.path), "resume state should be gone", file: file, line: line
+        )
+    }
+
+    // MARK: - Clean download
+
+    func testCleanDownloadWritesExactBytes() async throws {
+        let payload = Self.makePayload(length: 256 * 1_024)
+        Self.installRangeServer(payload: payload)
+
+        try await makeDownloader().download(from: sourceURL, to: destination)
+
+        XCTAssertEqual(try Data(contentsOf: destination), payload)
+        XCTAssertEqual(HTTPStubProtocol.requests.count, 1)
+        XCTAssertNil(rangeHeader(ofRequest: 0), "clean download must not send a Range header")
+        assertNoInFlightArtifacts()
+    }
+
+    // MARK: - Interrupt and resume
+
+    func testInterruptedDownloadResumesAndMatchesByteIdentical() async throws {
+        let payload = Self.makePayload(length: 256 * 1_024)
+        Self.installRangeServer(payload: payload) { requestNumber, request in
+            guard requestNumber == 1 else { return nil }
+            var stub = Self.serve(payload: payload, etag: "\"etag-1\"", request: request)
+            stub.deliverOnly = 96 * 1_024
+            return stub
+        }
+        let progressLog = ProgressLog()
+
+        try await makeDownloader().download(from: sourceURL, to: destination, progress: { progress in
+            progressLog.append(progress.bytesOnDisk)
+        })
+
+        XCTAssertEqual(try Data(contentsOf: destination), payload, "resumed file must be byte-identical")
+        XCTAssertEqual(HTTPStubProtocol.requests.count, 2)
+        let resumeRange = try XCTUnwrap(rangeHeader(ofRequest: 1), "second request should resume with a Range header")
+        XCTAssertTrue(resumeRange.hasPrefix("bytes="))
+        let resumeOffset = try XCTUnwrap(Int64(resumeRange.dropFirst("bytes=".count).dropLast()))
+        XCTAssertGreaterThan(resumeOffset, 0)
+        let observed = progressLog.all
+        XCTAssertEqual(observed, observed.sorted(), "progress must never go backwards")
+        XCTAssertEqual(observed.last, Int64(payload.count))
+        assertNoInFlightArtifacts()
+    }
+
+    func testResumeSurvivesDownloaderRelaunch() async throws {
+        let payload = Self.makePayload(length: 256 * 1_024)
+        Self.installRangeServer(payload: payload) { requestNumber, request in
+            guard requestNumber == 1 else { return nil }
+            var stub = Self.serve(payload: payload, etag: "\"etag-1\"", request: request)
+            stub.deliverOnly = 128 * 1_024
+            return stub
+        }
+
+        // First "launch": no retry budget, so the interruption surfaces.
+        do {
+            try await makeDownloader(maxAttempts: 1).download(from: sourceURL, to: destination)
+            XCTFail("interrupted download should throw")
+        } catch {
+            XCTAssertTrue(ResumableDownloader.isTransient(error), "interruption should be a transient error")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: partialURL.path), "partial must survive for resume")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stateURL.path), "resume state must survive")
+
+        // Second "launch": a fresh instance picks up the on-disk state.
+        try await makeDownloader().download(from: sourceURL, to: destination)
+
+        XCTAssertEqual(try Data(contentsOf: destination), payload)
+        XCTAssertNotNil(rangeHeader(ofRequest: 1), "relaunched download should resume, not restart")
+        assertNoInFlightArtifacts()
+    }
+
+    // MARK: - Resume invalidation
+
+    func testStaleValidatorFallsBackToFreshStart() async throws {
+        let payload = Self.makePayload(length: 128 * 1_024)
+        // Seed a partial from an older release of the asset.
+        try Data(repeating: 0xAB, count: 100).write(to: partialURL)
+        ResumeState(urlString: sourceURL.absoluteString, validator: "\"old\"", expectedBytes: nil).save(to: stateURL)
+        Self.installRangeServer(payload: payload, etag: "\"new\"")
+
+        try await makeDownloader().download(from: sourceURL, to: destination)
+
+        XCTAssertEqual(try Data(contentsOf: destination), payload, "stale partial must not leak into the result")
+        XCTAssertEqual(HTTPStubProtocol.requests.count, 1)
+        XCTAssertNotNil(rangeHeader(ofRequest: 0), "resume should have been attempted")
+        assertNoInFlightArtifacts()
+    }
+
+    func testRangeNotSatisfiableDiscardsPartialAndRestartsClean() async throws {
+        let payload = Self.makePayload(length: 128 * 1_024)
+        try Data(repeating: 0xCD, count: 100).write(to: partialURL)
+        ResumeState(urlString: sourceURL.absoluteString, validator: nil, expectedBytes: nil).save(to: stateURL)
+        Self.installRangeServer(payload: payload) { requestNumber, _ in
+            guard requestNumber == 1 else { return nil }
+            return HTTPStubProtocol.StubResponse(
+                statusCode: 416,
+                headers: ["Content-Range": "bytes */\(payload.count)"]
+            )
+        }
+
+        try await makeDownloader().download(from: sourceURL, to: destination)
+
+        XCTAssertEqual(try Data(contentsOf: destination), payload)
+        XCTAssertEqual(HTTPStubProtocol.requests.count, 2)
+        XCTAssertNotNil(rangeHeader(ofRequest: 0))
+        XCTAssertNil(rangeHeader(ofRequest: 1), "after 416 the retry must start clean")
+        assertNoInFlightArtifacts()
+    }
+
+    func testPartialForDifferentURLIsDiscarded() async throws {
+        let payload = Self.makePayload(length: 64 * 1_024)
+        try Data(repeating: 0xEF, count: 100).write(to: partialURL)
+        ResumeState(
+            urlString: "https://example.test/v-old/Libraries.tar.gz", validator: "\"e\"", expectedBytes: nil
+        ).save(to: stateURL)
+        Self.installRangeServer(payload: payload)
+
+        try await makeDownloader().download(from: sourceURL, to: destination)
+
+        XCTAssertEqual(try Data(contentsOf: destination), payload)
+        XCTAssertNil(rangeHeader(ofRequest: 0), "a partial for another URL must not be resumed")
+        assertNoInFlightArtifacts()
+    }
+
+    // MARK: - Truncated close
+
+    func testTruncatedCleanCloseResumesOnRetry() async throws {
+        let payload = Self.makePayload(length: 128 * 1_024)
+        Self.installRangeServer(payload: payload) { requestNumber, request in
+            guard requestNumber == 1 else { return nil }
+            var stub = Self.serve(payload: payload, etag: "\"etag-1\"", request: request)
+            stub.deliverOnly = 64 * 1_024
+            stub.finishEarlyAfterPartialBody = true
+            return stub
+        }
+
+        try await makeDownloader().download(from: sourceURL, to: destination)
+
+        XCTAssertEqual(try Data(contentsOf: destination), payload)
+        XCTAssertEqual(HTTPStubProtocol.requests.count, 2)
+        XCTAssertEqual(rangeHeader(ofRequest: 1), "bytes=\(64 * 1_024)-")
+        assertNoInFlightArtifacts()
+    }
+
+    // MARK: - Retry and backoff
+
+    func testTransientServerErrorRetriesUntilSuccess() async throws {
+        let payload = Self.makePayload(length: 64 * 1_024)
+        Self.installRangeServer(payload: payload) { requestNumber, _ in
+            guard requestNumber <= 2 else { return nil }
+            return HTTPStubProtocol.StubResponse(statusCode: 503)
+        }
+
+        try await makeDownloader(maxAttempts: 4).download(from: sourceURL, to: destination)
+
+        XCTAssertEqual(try Data(contentsOf: destination), payload)
+        XCTAssertEqual(HTTPStubProtocol.requests.count, 3)
+    }
+
+    func testRetriesExhaustedThrowsLastError() async {
+        Self.installRangeServer(payload: Data()) { _, _ in
+            HTTPStubProtocol.StubResponse(statusCode: 503)
+        }
+
+        do {
+            try await makeDownloader(maxAttempts: 2).download(from: sourceURL, to: destination)
+            XCTFail("download should fail once the attempt budget is spent")
+        } catch {
+            XCTAssertEqual(error as? ResumableDownloadError, .httpStatus(503))
+        }
+        XCTAssertEqual(HTTPStubProtocol.requests.count, 2, "budget of 2 attempts means exactly 2 requests")
+    }
+
+    func testPermanentHTTPErrorFailsWithoutRetry() async {
+        Self.installRangeServer(payload: Data()) { _, _ in
+            HTTPStubProtocol.StubResponse(statusCode: 404)
+        }
+
+        do {
+            try await makeDownloader(maxAttempts: 4).download(from: sourceURL, to: destination)
+            XCTFail("404 should fail immediately")
+        } catch {
+            XCTAssertEqual(error as? ResumableDownloadError, .httpStatus(404))
+        }
+        XCTAssertEqual(HTTPStubProtocol.requests.count, 1, "permanent errors must not be retried")
+    }
+
+    func testCancellationDuringBackoffPreservesPartialAndThrowsCancellation() async throws {
+        let payload = Self.makePayload(length: 128 * 1_024)
+        Self.installRangeServer(payload: payload) { requestNumber, request in
+            guard requestNumber == 1 else { return nil }
+            var stub = Self.serve(payload: payload, etag: "\"etag-1\"", request: request)
+            stub.deliverOnly = 64 * 1_024
+            return stub
+        }
+
+        // Long backoff so cancellation lands during the sleep.
+        let downloader = makeDownloader(maxAttempts: 3, initialRetryDelay: 30)
+        let sourceURL = sourceURL
+        let destination = try XCTUnwrap(destination)
+        let task = Task {
+            try await downloader.download(from: sourceURL, to: destination)
+        }
+        while HTTPStubProtocol.requests.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+
+        do {
+            try await task.value
+            XCTFail("cancelled download should throw")
+        } catch {
+            XCTAssertTrue(error is CancellationError, "expected CancellationError, got \(error)")
+        }
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: partialURL.path),
+            "cancellation must keep the partial for a later resume"
+        )
+    }
+
+    // MARK: - Integrity gate interplay
+
+    func testHashMismatchDiscardThenCleanRedownload() async throws {
+        let goodPayload = Self.makePayload(length: 64 * 1_024)
+        var corrupted = goodPayload
+        corrupted[1_000] ^= 0xFF
+        let expectedHash = Self.sha256Hex(of: goodPayload)
+        let corruptedBody = corrupted
+
+        // First download: server hands out corrupted bytes.
+        Self.installRangeServer(payload: corruptedBody)
+        try await makeDownloader().download(from: sourceURL, to: destination)
+        XCTAssertEqual(
+            WhiskyWineInstaller.integrityResult(forFileAt: destination, expectedSHA256: expectedHash),
+            .mismatch(actual: Self.sha256Hex(of: corruptedBody))
+        )
+
+        // The caller-side gate discards everything on a mismatch.
+        ResumableDownloader.discardArtifacts(at: destination)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+        assertNoInFlightArtifacts()
+
+        // The re-download starts clean and verifies.
+        HTTPStubProtocol.reset()
+        Self.installRangeServer(payload: goodPayload)
+        try await makeDownloader().download(from: sourceURL, to: destination)
+        XCTAssertNil(rangeHeader(ofRequest: 0), "post-discard download must not resume")
+        XCTAssertEqual(
+            WhiskyWineInstaller.integrityResult(forFileAt: destination, expectedSHA256: expectedHash),
+            .match
+        )
+    }
+
+    // MARK: - Pure helpers
+
+    func testParseContentRange() {
+        XCTAssertNil(HTTPRangeSupport.parseContentRange(nil))
+        XCTAssertNil(HTTPRangeSupport.parseContentRange("chunks 0-1/2"))
+        let parsed = HTTPRangeSupport.parseContentRange("bytes 100-999/1000")
+        XCTAssertEqual(parsed?.start, 100)
+        XCTAssertEqual(parsed?.total, 1_000)
+        let unknownTotal = HTTPRangeSupport.parseContentRange("bytes 5-9/*")
+        XCTAssertEqual(unknownTotal?.start, 5)
+        XCTAssertNil(unknownTotal?.total)
+    }
+
+    func testValidatorPrefersStrongETagAndSkipsWeak() throws {
+        let strong = try XCTUnwrap(HTTPURLResponse(
+            url: sourceURL, statusCode: 200, httpVersion: nil,
+            headerFields: ["ETag": "\"abc\"", "Last-Modified": "yesterday"]
+        ))
+        XCTAssertEqual(HTTPRangeSupport.validator(from: strong), "\"abc\"")
+
+        let weak = try XCTUnwrap(HTTPURLResponse(
+            url: sourceURL, statusCode: 200, httpVersion: nil,
+            headerFields: ["ETag": "W/\"abc\"", "Last-Modified": "yesterday"]
+        ))
+        XCTAssertEqual(HTTPRangeSupport.validator(from: weak), "yesterday")
+    }
+
+    func testRetryPolicyBackoffDoublesAndCaps() {
+        let policy = ResumableDownloadRetryPolicy(maxAttempts: 6, initialRetryDelay: 1, maxRetryDelay: 5)
+        XCTAssertEqual(policy.delay(beforeRetry: 1), 1)
+        XCTAssertEqual(policy.delay(beforeRetry: 2), 2)
+        XCTAssertEqual(policy.delay(beforeRetry: 3), 4)
+        XCTAssertEqual(policy.delay(beforeRetry: 4), 5, "backoff must cap at maxRetryDelay")
+        XCTAssertEqual(policy.delay(beforeRetry: 100), 5)
+    }
+}
+
+// swiftlint:enable file_length


### PR DESCRIPTION
Telemetry shows download-stage failures are the top first-run friction (~1,430 `download_failed` events in the June-August window), and every retry today restarts the full ~313 MB archive from byte zero. This makes the runtime download resumable and self-retrying.

## What changed

- New `ResumableDownloader` in WhiskyKit: streams the archive to an app-owned partial file, resumes interrupted transfers with HTTP `Range` requests, and retries transient failures (dropped connections, timeouts, 408/429/5xx) with bounded exponential backoff (4 attempts, 1s doubling to a 15s cap).
- `WhiskyWineDownloadView` now downloads through it, to a stable path in `~/Library/Caches` instead of a random temp file, so a partial download survives an app relaunch and resumes on the next attempt. The user-visible Retry button is preserved and also resumes rather than restarting.
- If a fully downloaded archive is already present (app quit between download and install), it is hash-verified and reused, skipping the download entirely.
- One new user-facing string (`setup.whiskywine.error.interrupted`, manual extraction) for the case where every retry is exhausted.

## How resume works

Partial bytes accumulate in `Libraries.tar.gz.partial` next to a small `Libraries.tar.gz.resume` sidecar recording the source URL, the server's validator (strong ETag, else Last-Modified), and the expected size. A later attempt sends `Range: bytes=N-` plus `If-Range` with the recorded validator; GitHub release assets serve `Accept-Ranges: bytes` after redirect. A 206 at the right offset appends; a 200 (validator changed, or server declined the range) restarts clean; a 416 or a 206 at the wrong offset discards the partial and restarts clean. The existing SHA-256 check against `WhiskyWineVersion.sha256` remains the final gate before install, unchanged in semantics: a resumed file that fails the hash is discarded (including resume artifacts) and the next attempt starts from a clean slate.

## Tests

15 new tests in `ResumableDownloaderTests` run against a `URLProtocol` stub acting as a range-aware file server, fully offline:

- clean download writes exact bytes with no leftover artifacts
- interrupt mid-body, then resume produces byte-identical output (Range header verified)
- resume survives a downloader relaunch (fresh instance picks up on-disk state)
- stale validator falls back to a fresh start; 416 discards the partial; a partial recorded for a different URL is never resumed
- clean connection close before the advertised size resumes on retry
- transient 503s retry until success; retry budget exhaustion throws the last error; 404 fails without retry
- cancellation during backoff preserves the partial and throws `CancellationError`
- hash mismatch discard then clean re-download verifies against the good hash
- unit coverage for Content-Range parsing, validator selection (weak ETag skipped), and backoff doubling with cap

`swift test` (1206 tests), `xcodebuild -scheme Whisky` and `swiftlint lint --strict` all pass.

Not included here: the issue's third proposal (separating the abandonment signal in telemetry) touches the documented event surface and is better done as its own change.

Closes #174
