### PR TITLE
test: pin SteamLauncher.resolveBottle routing contract

### DIFF
--- a/WhiskyKit/Tests/WhiskyKitTests/SteamLauncherTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamLauncherTests.swift
@@ -30,35 +30,46 @@ struct SteamLauncherTests {
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
     }
 
-    /// A bottle holding a Steam install with each of `appIds` fully installed.
-    private func makeSteamBottle(_ label: String, appIds: [Int]) throws -> URL {
-        let fileManager = FileManager.default
+    /// A bottle holding a Steam install with each of `appIds` fully installed
+    /// and each of `updatingAppIds` present on disk but still downloading.
+    private func makeSteamBottle(
+        _ label: String, appIds: [Int], updatingAppIds: [Int] = []
+    ) throws -> URL {
         let bottle = tempRoot.appending(path: "\(label)-\(UUID().uuidString)")
         let steamRoot = bottle.appending(path: "drive_c")
             .appending(path: "Program Files (x86)").appending(path: "Steam")
         let steamApps = steamRoot.appending(path: "steamapps")
-        try fileManager.createDirectory(at: steamApps, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: steamApps, withIntermediateDirectories: true)
         try Data().write(to: steamRoot.appending(path: "steam.exe"))
 
         for appId in appIds {
-            let installDir = "Game\(appId)"
-            try fileManager.createDirectory(
-                at: steamApps.appending(path: "common").appending(path: installDir),
-                withIntermediateDirectories: true
-            )
-            let manifest = """
-            "AppState"
-            {
-                "appid"        "\(appId)"
-                "name"        "Game \(appId)"
-                "installdir"        "\(installDir)"
-                "StateFlags"        "4"
-            }
-            """
-            try Data(manifest.utf8)
-                .write(to: steamApps.appending(path: "appmanifest_\(appId).acf"))
+            try writeGame(appId: appId, stateFlags: 4, steamApps: steamApps)
+        }
+        for appId in updatingAppIds {
+            try writeGame(appId: appId, stateFlags: 2, steamApps: steamApps)
         }
         return bottle
+    }
+
+    /// Writes a manifest and install directory for `appId`. StateFlags 4 marks
+    /// the game fully installed; 2 marks an update still running.
+    private func writeGame(appId: Int, stateFlags: Int, steamApps: URL) throws {
+        let installDir = "Game\(appId)"
+        try FileManager.default.createDirectory(
+            at: steamApps.appending(path: "common").appending(path: installDir),
+            withIntermediateDirectories: true
+        )
+        let manifest = """
+        "AppState"
+        {
+            "appid"        "\(appId)"
+            "name"        "Game \(appId)"
+            "installdir"        "\(installDir)"
+            "StateFlags"        "\(stateFlags)"
+        }
+        """
+        try Data(manifest.utf8)
+            .write(to: steamApps.appending(path: "appmanifest_\(appId).acf"))
     }
 
     private func makeRouting() -> GameRouting {
@@ -128,5 +139,55 @@ struct SteamLauncherTests {
         #expect(throws: SteamLaunchError.gameNotFound(appId: 1_245_620)) {
             try SteamLauncher.resolveBottle(appId: 1_245_620, in: [bottle], routing: routing)
         }
+    }
+
+    @Test("With no route, bottle order decides between multiple holders")
+    @MainActor func ambiguityFollowsBottleOrder() throws {
+        let first = try Bottle(bottleUrl: makeSteamBottle("first", appIds: [1_245_620]))
+        let second = try Bottle(bottleUrl: makeSteamBottle("second", appIds: [1_245_620]))
+        let routing = makeRouting()
+
+        let forward = try SteamLauncher.resolveBottle(
+            appId: 1_245_620, in: [first, second], routing: routing
+        )
+        let reversed = try SteamLauncher.resolveBottle(
+            appId: 1_245_620, in: [second, first], routing: routing
+        )
+
+        #expect(forward.url == first.url)
+        #expect(reversed.url == second.url)
+    }
+
+    @Test("A bypassed stale route stays in the store untouched")
+    @MainActor func staleRouteIsBypassedNotPruned() throws {
+        let stale = try Bottle(bottleUrl: makeSteamBottle("stale", appIds: []))
+        let real = try Bottle(bottleUrl: makeSteamBottle("real", appIds: [1_245_620]))
+        let routing = makeRouting()
+        routing.record(appId: 1_245_620, bottleURL: stale.url)
+
+        let resolved = try SteamLauncher.resolveBottle(
+            appId: 1_245_620, in: [stale, real], routing: routing
+        )
+
+        #expect(resolved.url == real.url)
+        // Resolution never writes; pruning belongs to bottle deletion.
+        let stored = routing.bottleURL(forAppId: 1_245_620)
+        #expect(stored?.lastPathComponent == stale.url.lastPathComponent)
+    }
+
+    @Test("A route to a bottle still downloading the game is not trusted")
+    @MainActor func updatingInstallIsNotTrusted() throws {
+        let updating = try Bottle(
+            bottleUrl: makeSteamBottle("updating", appIds: [], updatingAppIds: [1_245_620])
+        )
+        let ready = try Bottle(bottleUrl: makeSteamBottle("ready", appIds: [1_245_620]))
+        let routing = makeRouting()
+        routing.record(appId: 1_245_620, bottleURL: updating.url)
+
+        let resolved = try SteamLauncher.resolveBottle(
+            appId: 1_245_620, in: [updating, ready], routing: routing
+        )
+
+        #expect(resolved.url == ready.url)
     }
 }


### PR DESCRIPTION
Part of #173 (first checklist item): dedicated coverage for `SteamLauncher.resolveBottle(appId:in:)`.

The no-wrong-bottle-launch property is load-bearing: a remembered app-to-bottle route must be re-validated against a fresh library enumerate before being trusted, so a stale route can never launch the wrong bottle. #169 landed with five tests pinning the main paths (route wins, stale route falls through, route to an unknown bottle falls through, first holder without a route, gameNotFound). This adds the parts of the contract still verified only by reading:

- **Ambiguity is deterministic, not silently lucky**: with no valid route and the game in multiple bottles, array order decides. Pinned in both orders so a future "prompt the user" change has to touch a test.
- **A bypassed stale route stays in the store untouched**: resolution never writes; pruning belongs to bottle deletion (the second checklist item of #173). This test documents that boundary so the wiring change lands against a pinned baseline.
- **Fresh enumerate means fully installed**: a route to a bottle where the manifest still exists but StateFlags lacks the installed bit (update in flight) is not trusted and falls through to a bottle that has the game ready. This is the sharpest form of re-validation: the routed bottle still "knows" the app, yet the route is refused.

Fixture change only in the test file: `makeSteamBottle` gains an `updatingAppIds` parameter and manifest writing moves into a shared `writeGame(appId:stateFlags:steamApps:)` helper. Same on-disk fixture pattern as `GameRoutingTests`. No source changes, no changelog entry (tests only).

Verified: `swift test --package-path WhiskyKit` passes (1206 XCTest and 112 Swift Testing tests, 0 failures); `swiftformat --lint` and `swiftlint lint --strict` are clean.
