### PR TITLE
fix: prune Steam game routes when their bottle is deleted

### DIFF
--- a/WhiskyCmd/Main.swift
+++ b/WhiskyCmd/Main.swift
@@ -143,6 +143,7 @@ extension Whisky {
                 bottlesList.paths.removeAll(where: { $0 == bottleToRemove.url })
                 do {
                     try FileManager.default.removeItem(at: bottleToRemove.url)
+                    GameRouting().removeRoutes(toBottle: bottleToRemove.url)
                     print("Deleted \"\(name)\".")
                 } catch {
                     print(error)

--- a/WhiskyKit/Sources/WhiskyKit/Steam/GameRouting.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/GameRouting.swift
@@ -65,11 +65,19 @@ public struct GameRouting {
         write(current)
     }
 
-    /// Forgets a route, e.g. when its bottle is deleted.
-    public func remove(appId: Int) {
-        var current = entries()
-        current.removeValue(forKey: String(appId))
-        write(current)
+    /// Forgets every route pointing at a bottle, e.g. when the bottle is
+    /// deleted.
+    ///
+    /// Paths are compared through `standardizedFileURL`, the same way
+    /// resolution matches a route against the bottle list, so exactly the
+    /// routes that would have named this bottle are the ones removed. When
+    /// nothing matches the store is left untouched (and never created).
+    public func removeRoutes(toBottle bottleURL: URL) {
+        let target = bottleURL.standardizedFileURL
+        let current = entries()
+        let remaining = current.filter { URL(fileURLWithPath: $0.value).standardizedFileURL != target }
+        guard remaining.count != current.count else { return }
+        write(remaining)
     }
 
     private func entries() -> [String: String] {

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleOperations.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleOperations.swift
@@ -275,12 +275,25 @@ public enum BottleOperations {
     /// Callers are responsible for stopping any running processes first; this
     /// is only the delete-and-deregister step.
     ///
+    /// Deleting the files also forgets any Steam game routes pointing at the
+    /// bottle, since they can never resolve again. Removing the bottle from
+    /// the list while keeping its files leaves routes in place: the bottle can
+    /// come back through re-import, and resolution ignores routes to bottles
+    /// it doesn't know. A failed deletion keeps the routes, matching the kept
+    /// registry entry.
+    ///
     /// - Parameters:
     ///   - url: The bottle's directory.
     ///   - deleteFiles: Whether to delete the bottle directory from disk.
     ///   - registry: The registry that owns the bottle list.
+    ///   - routing: The Steam route store to prune. Defaults to the real one.
     @MainActor
-    public static func remove(bottleAt url: URL, deleteFiles: Bool, registry: BottleRegistry) {
+    public static func remove(
+        bottleAt url: URL,
+        deleteFiles: Bool,
+        registry: BottleRegistry,
+        routing: GameRouting = GameRouting()
+    ) {
         do {
             if let bottle = registry.bottle(for: url) {
                 bottle.inFlight = true
@@ -288,6 +301,7 @@ public enum BottleOperations {
 
             if deleteFiles {
                 try FileManager.default.removeItem(at: url)
+                routing.removeRoutes(toBottle: url)
             }
 
             if let path = registry.bottlePaths.firstIndex(of: url) {

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleOperationsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleOperationsTests.swift
@@ -16,6 +16,7 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
+// swiftlint:disable file_length
 import Foundation
 @testable import WhiskyKit
 import XCTest
@@ -356,6 +357,55 @@ final class NextDuplicateNameTests: XCTestCase {
 // MARK: - Remove
 
 final class BottleOperationsRemoveTests: BottleOperationsTestCase {
+    /// A route store in the test's temp dir, pre-loaded with one route to the
+    /// fixture bottle and one to an unrelated bottle.
+    private func makeRouting() -> (routing: GameRouting, otherBottle: URL) {
+        let routing = GameRouting(url: tempDir.appending(path: "GameRouting.plist"))
+        let otherBottle = tempDir.appending(path: "Other")
+        routing.record(appId: 1_245_620, bottleURL: bottleURL)
+        routing.record(appId: 4_576_510, bottleURL: otherBottle)
+        return (routing, otherBottle)
+    }
+
+    @MainActor
+    func testRemoveDeletingFilesPrunesRoutesToTheBottle() {
+        let registry = RegistryFixture()
+        _ = makeRegisteredBottle(in: registry)
+        let (routing, otherBottle) = makeRouting()
+
+        BottleOperations.remove(bottleAt: bottleURL, deleteFiles: true, registry: registry, routing: routing)
+
+        XCTAssertNil(routing.bottleURL(forAppId: 1_245_620))
+        XCTAssertEqual(routing.bottleURL(forAppId: 4_576_510)?.lastPathComponent, otherBottle.lastPathComponent)
+    }
+
+    @MainActor
+    func testRemoveKeepingFilesKeepsRoutes() {
+        let registry = RegistryFixture()
+        _ = makeRegisteredBottle(in: registry)
+        let (routing, _) = makeRouting()
+
+        BottleOperations.remove(bottleAt: bottleURL, deleteFiles: false, registry: registry, routing: routing)
+
+        // The bottle is still on disk and can be re-imported; its routes wait
+        // for it, inert until then because resolution ignores routes to
+        // bottles it doesn't know.
+        XCTAssertEqual(routing.bottleURL(forAppId: 1_245_620)?.lastPathComponent, bottleURL.lastPathComponent)
+    }
+
+    @MainActor
+    func testRemoveFailureKeepsRoutes() throws {
+        let registry = RegistryFixture()
+        _ = makeRegisteredBottle(in: registry)
+        let (routing, _) = makeRouting()
+        // Deleting the directory up front makes the file removal throw.
+        try FileManager.default.removeItem(at: bottleURL)
+
+        BottleOperations.remove(bottleAt: bottleURL, deleteFiles: true, registry: registry, routing: routing)
+
+        XCTAssertEqual(routing.bottleURL(forAppId: 1_245_620)?.lastPathComponent, bottleURL.lastPathComponent)
+    }
+
     @MainActor
     func testRemoveDeletingFilesRemovesDirectoryAndRegistryEntry() {
         let registry = RegistryFixture()

--- a/WhiskyKit/Tests/WhiskyKitTests/GameRoutingTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GameRoutingTests.swift
@@ -61,15 +61,45 @@ struct GameRoutingTests {
         #expect(routing.routes().isEmpty)
     }
 
-    @Test("Removes a route")
-    func removesRoute() {
+    @Test("Removes every route pointing at a bottle, keeping the rest")
+    func removesRoutesToBottle() {
         let (routing, cleanup) = makeStore()
         defer { cleanup() }
 
-        routing.record(appId: 7, bottleURL: URL(fileURLWithPath: "/tmp/bottles/seven"))
-        routing.remove(appId: 7)
+        let doomed = URL(fileURLWithPath: "/tmp/bottles/doomed")
+        routing.record(appId: 1, bottleURL: doomed)
+        routing.record(appId: 2, bottleURL: URL(fileURLWithPath: "/tmp/bottles/kept"))
+        routing.record(appId: 3, bottleURL: doomed)
 
-        #expect(routing.bottleURL(forAppId: 7) == nil)
+        routing.removeRoutes(toBottle: doomed)
+
+        #expect(routing.bottleURL(forAppId: 1) == nil)
+        #expect(routing.bottleURL(forAppId: 3) == nil)
+        #expect(routing.bottleURL(forAppId: 2)?.lastPathComponent == "kept")
+        #expect(routing.routes().count == 1)
+    }
+
+    @Test("Bottle paths match the way resolution compares them")
+    func removesRoutesByStandardizedPath() {
+        let (routing, cleanup) = makeStore()
+        defer { cleanup() }
+
+        routing.record(appId: 1, bottleURL: URL(fileURLWithPath: "/tmp/bottles/one"))
+        routing.removeRoutes(toBottle: URL(fileURLWithPath: "/tmp/bottles/./one"))
+
+        #expect(routing.bottleURL(forAppId: 1) == nil)
+    }
+
+    @Test("Pruning without a match never creates the store")
+    func pruneWithoutMatchWritesNothing() {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let url = tempDir.appending(path: "GameRouting.plist")
+
+        let routing = GameRouting(url: url)
+        routing.removeRoutes(toBottle: URL(fileURLWithPath: "/tmp/bottles/none"))
+
+        #expect(!FileManager.default.fileExists(atPath: url.path(percentEncoded: false)))
     }
 
     @Test("Keeps other routes when one changes")


### PR DESCRIPTION
Part of #173 (checklist item 2).

## What

Routes in `GameRouting` pointing at a deleted bottle were never cleaned up: `remove(appId:)` existed but had zero call sites, so stale entries accumulated in the plist forever. They were bypassed safely at resolve time (pinned by `staleRouteIsBypassedNotPruned`, #179) but never pruned.

## Pruning semantics

- **Delete files**: `BottleOperations.remove(deleteFiles: true)` and the `whisky delete` command now call `GameRouting.removeRoutes(toBottle:)` after the directory is actually gone. Every route pointing at the bottle is forgotten; routes to other bottles survive.
- **Remove from list, keep files** (app checkbox off, `whisky remove`): routes are deliberately kept. The bottle survives on disk and can come back through orphan re-import (#145) or `whisky add`; until then the route is inert, because resolution ignores routes to bottles it doesn't know (pinned by `routeToUnknownBottleFallsThrough`). Pruning here would throw away a still-useful memory.
- **Failed deletion**: routes are kept, matching the kept registry entry.
- **Resolution stays read-only**: `resolveBottle` is untouched, and `staleRouteIsBypassedNotPruned` still pins that pruning happens at deletion time only.

## Why `remove(appId:)` is folded in rather than wired

Bottle deletion needs "remove every route pointing at this bottle", not "remove this App ID": a deleted bottle can hold routes for any number of games, and the deletion path knows the bottle URL, not the App IDs. The new `removeRoutes(toBottle:)` uses the same `standardizedFileURL` comparison `resolveBottle` uses, so exactly the routes that would have matched this bottle are the ones removed; a no-match prune leaves the store untouched and never creates the file. After that, `remove(appId:)` would still have zero production call sites, plus a doc comment claiming the deletion use case it doesn't actually serve, so it is removed instead of kept.

## Tests

- `GameRoutingTests`: `removesRoutesToBottle` (matching routes go, others survive), `removesRoutesByStandardizedPath` (path comparison matches resolution's), `pruneWithoutMatchWritesNothing` (no store file materializes). The old `removesRoute` test goes with the API it covered.
- `BottleOperationsRemoveTests`: `testRemoveDeletingFilesPrunesRoutesToTheBottle`, `testRemoveKeepingFilesKeepsRoutes`, `testRemoveFailureKeepsRoutes`, all against on-disk fixture stores injected through the new `routing` parameter (which defaults to the real store, so app call sites are unchanged).

`swift test --package-path WhiskyKit` green (1209 XCTest + 114 Swift Testing tests); `swiftformat --lint` and `swiftlint lint --strict` clean on the touched files; Whisky and WhiskyCmd schemes both build.
