### PR TITLE
perf: lazy override loading on Play

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
@@ -85,6 +85,11 @@ public enum SteamLauncher {
 
     /// The user's persisted overrides for a game's executables, so settings
     /// tuned in the Programs tab survive a launch from the library or the cli.
+    ///
+    /// Resolution is read-only: no ``Program`` is materialized, so Play never
+    /// writes settings plists for the executables that don't win. Only an
+    /// executable with persisted overrides can win, so skipping the default
+    /// plists changes nothing for the winner.
     @MainActor
     static func userOverrides(forInstallURL installURL: URL, bottle: Bottle) -> ProgramOverrides? {
         let scanned = Dictionary(
@@ -94,10 +99,10 @@ public enum SteamLauncher {
             uniquingKeysWith: { first, _ in first }
         )
         let candidates = SteamLibrary.executableURLs(under: installURL).map { url in
-            // Falls back to a direct load for executables the bottle scan has
+            // Falls back to a plist read for executables the bottle scan has
             // not reached, so Play works before the Programs tab is opened.
             let overrides = scanned[url.standardizedFileURL]
-                ?? Program(url: url, bottle: bottle, peFile: nil).settings.overrides
+                ?? Program.persistedOverrides(for: url, bottleURL: bottle.url)
             return ProgramOverrideCandidate(url: url, overrides: overrides ?? ProgramOverrides())
         }
         return SteamLibrary.preferredOverrides(among: candidates)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/Program.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/Program.swift
@@ -165,25 +165,63 @@ public final class Program: ObservableObject, Equatable, Hashable, Identifiable 
     /// the old plist to the identity-keyed name on first load, so downgrading
     /// loses nothing.
     static func settingsURL(for url: URL, in bottle: Bottle, legacyName: String) -> URL {
-        let settingsFolder = bottle.url.appending(path: "Program Settings")
-        try? FileManager.default.createDirectory(at: settingsFolder, withIntermediateDirectories: true)
-        let identityURL = settingsFolder
-            .appending(path: settingsIdentity(for: url, bottleURL: bottle.url))
-            .appendingPathExtension("plist")
-        let legacyURL = settingsFolder.appending(path: legacyName).appendingPathExtension("plist")
-
+        let locations = settingsLocations(for: url, bottleURL: bottle.url, legacyName: legacyName)
         let fileManager = FileManager.default
-        if !fileManager.fileExists(atPath: identityURL.path(percentEncoded: false)),
-           fileManager.fileExists(atPath: legacyURL.path(percentEncoded: false)) {
+        try? fileManager.createDirectory(
+            at: locations.identity.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+
+        if !fileManager.fileExists(atPath: locations.identity.path(percentEncoded: false)),
+           fileManager.fileExists(atPath: locations.legacy.path(percentEncoded: false)) {
             do {
-                try fileManager.copyItem(at: legacyURL, to: identityURL)
+                try fileManager.copyItem(at: locations.legacy, to: locations.identity)
             } catch {
                 Logger.wineKit.error(
                     "Failed to migrate settings for `\(legacyName)`: \(error.localizedDescription)"
                 )
             }
         }
-        return identityURL
+        return locations.identity
+    }
+
+    /// Where a program's settings live: the identity-keyed plist and the
+    /// legacy filename-keyed one it may have to be migrated from. Pure path
+    /// computation; nothing is created or copied.
+    nonisolated static func settingsLocations(
+        for url: URL, bottleURL: URL, legacyName: String
+    ) -> (identity: URL, legacy: URL) {
+        let settingsFolder = bottleURL.appending(path: "Program Settings")
+        let identityURL = settingsFolder
+            .appending(path: settingsIdentity(for: url, bottleURL: bottleURL))
+            .appendingPathExtension("plist")
+        let legacyURL = settingsFolder.appending(path: legacyName).appendingPathExtension("plist")
+        return (identityURL, legacyURL)
+    }
+
+    /// The overrides an executable's persisted settings carry, read without
+    /// materializing a ``Program``: a missing settings plist yields `nil`
+    /// where the initializer would write a default plist to disk.
+    ///
+    /// A legacy filename-keyed plist is read in place; migrating it to the
+    /// identity-keyed name stays with the initializer, as does quarantining
+    /// an unreadable plist (an unreadable plist reads as no overrides here).
+    nonisolated static func persistedOverrides(for url: URL, bottleURL: URL) -> ProgramOverrides? {
+        let locations = settingsLocations(for: url, bottleURL: bottleURL, legacyName: url.lastPathComponent)
+        let settingsURL = FileManager.default.fileExists(atPath: locations.identity.path(percentEncoded: false))
+            ? locations.identity
+            : locations.legacy
+
+        do {
+            return try ProgramSettings.decodeIfPresent(from: settingsURL)?.overrides
+        } catch {
+            Logger.wineKit.error(
+                """
+                Failed to read settings for `\(url.lastPathComponent, privacy: .public)`: \
+                \(String(describing: error), privacy: .public)
+                """
+            )
+            return nil
+        }
     }
 
     /// A stable identity for a program: the executable's stem plus a short

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramSettings.swift
@@ -205,10 +205,27 @@ public struct ProgramSettings: Codable {
     /// - Returns: The decoded settings or new default settings.
     /// - Throws: An error if the file exists but cannot be decoded.
     static func decode(from settingsURL: URL) throws -> ProgramSettings {
-        guard FileManager.default.fileExists(atPath: settingsURL.path(percentEncoded: false)) else {
+        guard let settings = try decodeIfPresent(from: settingsURL) else {
             let settings = ProgramSettings()
             try settings.encode(to: settingsURL)
             return settings
+        }
+        return settings
+    }
+
+    /// Loads program settings from a plist file without touching the disk
+    /// beyond the read.
+    ///
+    /// Unlike ``decode(from:)``, a missing file yields `nil` instead of a
+    /// default plist written to disk, so callers can inspect a program's
+    /// persisted settings without materializing them.
+    ///
+    /// - Parameter settingsURL: The URL to the settings plist file.
+    /// - Returns: The decoded settings, or `nil` if the file doesn't exist.
+    /// - Throws: An error if the file exists but cannot be decoded.
+    static func decodeIfPresent(from settingsURL: URL) throws -> ProgramSettings? {
+        guard FileManager.default.fileExists(atPath: settingsURL.path(percentEncoded: false)) else {
+            return nil
         }
 
         let data = try Data(contentsOf: settingsURL)

--- a/WhiskyKit/Tests/WhiskyKitTests/SteamOverrideResolutionTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamOverrideResolutionTests.swift
@@ -1,0 +1,203 @@
+//
+//  SteamOverrideResolutionTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+/// Pins the read-only contract of Play's override resolution: only persisted
+/// settings decide the launch, and resolving them never writes settings
+/// plists for executables that don't win.
+@Suite("Steam Override Resolution Tests")
+struct SteamOverrideResolutionTests {
+    private let tempRoot: URL
+
+    init() throws {
+        tempRoot = FileManager.default.temporaryDirectory
+            .appending(path: "steamoverrides_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    /// A bottle holding a Steam install with `appId` fully installed and the
+    /// given executables (install-relative paths) inside its install folder.
+    private func makeGameBottle(
+        appId: Int, executables: [String]
+    ) throws -> (bottleURL: URL, installURL: URL) {
+        let bottle = tempRoot.appending(path: "bottle-\(UUID().uuidString)")
+        let steamRoot = bottle.appending(path: "drive_c")
+            .appending(path: "Program Files (x86)").appending(path: "Steam")
+        let steamApps = steamRoot.appending(path: "steamapps")
+        try FileManager.default.createDirectory(at: steamApps, withIntermediateDirectories: true)
+        try Data().write(to: steamRoot.appending(path: "steam.exe"))
+
+        let installDir = "Game\(appId)"
+        let installURL = steamApps.appending(path: "common").appending(path: installDir)
+        try FileManager.default.createDirectory(at: installURL, withIntermediateDirectories: true)
+        for relative in executables {
+            let url = installURL.appending(path: relative)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try Data().write(to: url)
+        }
+
+        let manifest = """
+        "AppState"
+        {
+            "appid"        "\(appId)"
+            "name"        "Game \(appId)"
+            "installdir"        "\(installDir)"
+            "StateFlags"        "4"
+        }
+        """
+        try Data(manifest.utf8).write(to: steamApps.appending(path: "appmanifest_\(appId).acf"))
+        return (bottle, installURL)
+    }
+
+    /// The plist filenames currently in the bottle's Program Settings folder.
+    private func settingsPlists(inBottle bottleURL: URL) -> Set<String> {
+        let folder = bottleURL.appending(path: "Program Settings")
+        let contents = (try? FileManager.default
+            .contentsOfDirectory(atPath: folder.path(percentEncoded: false))) ?? []
+        return Set(contents.filter { $0.hasSuffix(".plist") })
+    }
+
+    @Test("Resolution writes no settings plists for the losing executables")
+    @MainActor func losersGetNoSettingsPlists() throws {
+        let fixture = try makeGameBottle(appId: 1_245_620, executables: [
+            "Game.exe", "bin/Helper.exe", "bin/UnityCrashHandler64.exe"
+        ])
+        let bottle = Bottle(bottleUrl: fixture.bottleURL)
+        let winner = fixture.installURL.appending(path: "Game.exe")
+
+        var tuned = ProgramOverrides()
+        tuned.forceD3D11 = true
+        let program = Program(url: winner, bottle: bottle, peFile: nil)
+        program.settings.overrides = tuned
+
+        let installURL = try #require(
+            SteamLibrary.enumerate(bottleURL: bottle.url).first { $0.appId == 1_245_620 }?.installURL
+        )
+        let resolved = SteamLauncher.userOverrides(forInstallURL: installURL, bottle: bottle)
+
+        #expect(resolved == tuned)
+        // Only the winner's plist exists; the helpers never got defaults written.
+        let winnerPlist = Program.settingsLocations(
+            for: winner, bottleURL: bottle.url, legacyName: winner.lastPathComponent
+        ).identity.lastPathComponent
+        #expect(settingsPlists(inBottle: bottle.url) == [winnerPlist])
+        // A real Program still reads the winner back byte-identical.
+        #expect(Program(url: winner, bottle: bottle, peFile: nil).settings.overrides == tuned)
+    }
+
+    @Test("A game with nothing tuned resolves nil and writes nothing")
+    @MainActor func untouchedGameResolvesNilAndWritesNothing() throws {
+        let fixture = try makeGameBottle(appId: 4_576_510, executables: [
+            "Game.exe", "bin/Helper.exe"
+        ])
+        let bottle = Bottle(bottleUrl: fixture.bottleURL)
+
+        let resolved = SteamLauncher.userOverrides(forInstallURL: fixture.installURL, bottle: bottle)
+
+        #expect(resolved == nil)
+        #expect(settingsPlists(inBottle: bottle.url).isEmpty)
+    }
+
+    @Test("A legacy filename-keyed plist is honored in place, not migrated")
+    @MainActor func legacyPlistHonoredWithoutMigration() throws {
+        let fixture = try makeGameBottle(appId: 2_357_570, executables: ["bin/Helper.exe"])
+        let bottle = Bottle(bottleUrl: fixture.bottleURL)
+        let helper = fixture.installURL.appending(path: "bin").appending(path: "Helper.exe")
+
+        var tuned = ProgramOverrides()
+        tuned.dxvk = true
+        var settings = ProgramSettings()
+        settings.overrides = tuned
+        let locations = Program.settingsLocations(
+            for: helper, bottleURL: bottle.url, legacyName: helper.lastPathComponent
+        )
+        try FileManager.default.createDirectory(
+            at: locations.legacy.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try settings.encode(to: locations.legacy)
+
+        let resolved = SteamLauncher.userOverrides(forInstallURL: fixture.installURL, bottle: bottle)
+
+        #expect(resolved == tuned)
+        // Migration to the identity-keyed name stays with Program init.
+        #expect(settingsPlists(inBottle: bottle.url) == [locations.legacy.lastPathComponent])
+    }
+
+    @Test("The shallowest tuned executable's overrides win")
+    @MainActor func shallowestTunedExecutableWins() throws {
+        let fixture = try makeGameBottle(appId: 1_086_940, executables: [
+            "Game.exe", "bin/Helper.exe"
+        ])
+        let bottle = Bottle(bottleUrl: fixture.bottleURL)
+
+        var deep = ProgramOverrides()
+        deep.dxvk = true
+        var shallow = ProgramOverrides()
+        shallow.forceD3D11 = true
+        let helper = Program(
+            url: fixture.installURL.appending(path: "bin").appending(path: "Helper.exe"),
+            bottle: bottle, peFile: nil
+        )
+        helper.settings.overrides = deep
+        let game = Program(
+            url: fixture.installURL.appending(path: "Game.exe"), bottle: bottle, peFile: nil
+        )
+        game.settings.overrides = shallow
+
+        let resolved = SteamLauncher.userOverrides(forInstallURL: fixture.installURL, bottle: bottle)
+
+        #expect(resolved == shallow)
+    }
+
+    @Test("An unreadable plist reads as no overrides and is left untouched")
+    @MainActor func unreadablePlistSkippedAndLeftAlone() throws {
+        let fixture = try makeGameBottle(appId: 632_360, executables: [
+            "Game.exe", "bin/Helper.exe"
+        ])
+        let bottle = Bottle(bottleUrl: fixture.bottleURL)
+        let game = fixture.installURL.appending(path: "Game.exe")
+
+        let corruptURL = Program.settingsLocations(
+            for: game, bottleURL: bottle.url, legacyName: game.lastPathComponent
+        ).identity
+        try FileManager.default.createDirectory(
+            at: corruptURL.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let garbage = Data("not a plist".utf8)
+        try garbage.write(to: corruptURL)
+
+        var tuned = ProgramOverrides()
+        tuned.dxvkAsync = true
+        let helper = Program(
+            url: fixture.installURL.appending(path: "bin").appending(path: "Helper.exe"),
+            bottle: bottle, peFile: nil
+        )
+        helper.settings.overrides = tuned
+
+        let resolved = SteamLauncher.userOverrides(forInstallURL: fixture.installURL, bottle: bottle)
+
+        #expect(resolved == tuned)
+        // Read-only resolution neither quarantines nor rewrites the file.
+        #expect(try Data(contentsOf: corruptURL) == garbage)
+    }
+}


### PR DESCRIPTION
## What was redundant

`SteamLauncher.userOverrides(forInstallURL:bottle:)` built its candidate list by instantiating a `Program` for every executable at the game's install root and one level deep, on the main actor. `Program.init` runs `ProgramSettings.decode`, which writes a default settings plist whenever none exists, so a single Play click could write a plist for every helper, crash handler, and redistributable next to the game, even though only one candidate's overrides ever reach the launch. Those freshly written defaults carry no overrides, and `SteamLibrary.preferredOverrides` filters empty candidates, so a just-materialized Program could never win: every one of those writes was pure waste, plus main-actor work right on the Play click.

## What changed

- `ProgramSettings.decodeIfPresent(from:)`: a read-only decode that returns nil for a missing file instead of writing defaults. `decode(from:)` is now a wrapper over it, so the write-on-miss behavior of real Program instantiation is untouched.
- `Program.settingsLocations(for:bottleURL:legacyName:)`: pure path computation split out of `settingsURL(for:in:legacyName:)`, which keeps the directory creation and legacy-plist migration for the init path.
- `Program.persistedOverrides(for:bottleURL:)`: reads an executable's persisted overrides without materializing a `Program`. Identity-keyed plist first, legacy filename-keyed plist read in place as fallback; an unreadable plist reads as no overrides.
- `SteamLauncher.userOverrides` now uses that read-only lookup for executables the bottle scan has not reached, instead of `Program(url:bottle:peFile:)`.

## Winner contract, unchanged

- Precedence is identical: in-memory scanned overrides first, then the persisted plist, and user-tuned settings still beat the GameDB profile in `LaunchResolver.plan`.
- The winner's plist necessarily already exists (empty overrides never win the resolution), so the read-only load returns byte-identical content and the timing of the winner's default plist creation is unchanged.
- Legacy plist migration and corrupt plist quarantine stay with `Program` init (scans, Programs tab). Play performs neither, keeping resolution fully write-free.

## Tests

New suite `SteamOverrideResolutionTests`, on-disk fixtures in the `SteamLauncherTests` style:

- Resolution writes no settings plists for the losing executables (fails on the old code: three plists instead of one)
- A game with nothing tuned resolves nil and writes nothing
- A legacy filename-keyed plist is honored in place, not migrated
- The shallowest tuned executable's overrides win
- An unreadable plist reads as no overrides and is left untouched

`swift test --package-path WhiskyKit` green (1206 XCTest + 117 Swift Testing), `swiftlint lint --strict` and `swiftformat --lint .` (0.58.7) clean.

Part of #173.
