### PR TITLE
fix: bottle registry duplicates and whisky run option passthrough

### DIFF
--- a/WhiskyCmd/Main.swift
+++ b/WhiskyCmd/Main.swift
@@ -33,7 +33,9 @@ struct DomainError: LocalizedError {
         self.message = message
     }
 
-    var errorDescription: String? { message }
+    var errorDescription: String? {
+        message
+    }
 }
 
 @main
@@ -205,6 +207,11 @@ extension Whisky {
             Runs a Windows program directly using Wine. Use --command to print \
             the command instead. Use --follow to stream program output to the \
             terminal in real time. Use --tail-log to follow the Wine log file.
+
+            Options the program itself takes (for example --disable-gpu) are \
+            passed through as written. If a program option has the same name \
+            as one of run's own options, put it after a bare -- separator: \
+            whisky run MyBottle app.exe -- --follow
             """
         )
 
@@ -218,7 +225,12 @@ extension Whisky {
         @Argument(help: "Path to the Windows executable")
         var path: String
 
-        @Argument(help: "Additional arguments to pass to the program")
+        /// .allUnrecognized keeps run's own flags working anywhere on the
+        /// command line while options the parser doesn't know (--disable-gpu)
+        /// flow through to the program instead of erroring. A program flag
+        /// that collides with one of run's flag names still needs the `--`
+        /// terminator to reach the program.
+        @Argument(parsing: .allUnrecognized, help: "Additional arguments to pass to the program")
         var args: [String] = []
 
         @Flag(name: .shortAndLong, help: "Print the Wine command instead of running it")
@@ -232,6 +244,14 @@ extension Whisky {
 
         @MainActor
         mutating func run() async throws {
+            // .allUnrecognized captures the -- terminator itself instead of
+            // consuming it the way default parsing does. Drop the first one
+            // so `run B app.exe -- --follow` hands the program --follow, not
+            // `-- --follow`; any later -- stays, as it always has.
+            if let terminator = args.firstIndex(of: "--") {
+                args.remove(at: terminator)
+            }
+
             var bottlesList = BottleData()
             let bottles = bottlesList.loadBottles()
 

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleData.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleData.swift
@@ -61,6 +61,13 @@ public struct BottleData: Codable {
 
     public var paths: [URL] = [] {
         didSet {
+            // Callers append to paths directly, so the registry holds its own
+            // uniqueness invariant here rather than trusting every call site.
+            // Reassigning inside didSet does not re-trigger the observer.
+            let deduped = Self.dedupedPaths(paths)
+            if deduped.count != paths.count {
+                paths = deduped
+            }
             encode()
         }
     }
@@ -166,7 +173,22 @@ public struct BottleData: Codable {
     /// (trailing slash, `/private/var`) match registered paths (`/var`, no
     /// slash) for the same directory.
     private static func comparablePath(_ url: URL) -> String {
-        url.standardizedFileURL.resolvingSymlinksInPath().path(percentEncoded: false)
+        // resolvingSymlinksInPath() appends a trailing slash for existing
+        // directories, but only for URLs that have touched the filesystem;
+        // URLs decoded from the registry plist keep whatever form was stored.
+        // Strip the slash so the same directory compares equal in every form.
+        var path = url.standardizedFileURL.resolvingSymlinksInPath().path(percentEncoded: false)
+        if path.count > 1, path.hasSuffix("/") {
+            path.removeLast()
+        }
+        return path
+    }
+
+    /// Removes entries that name the same directory in a different URL form
+    /// (trailing slash, `/private/var` symlink), keeping the first occurrence.
+    private static func dedupedPaths(_ paths: [URL]) -> [URL] {
+        var seen = Set<String>()
+        return paths.filter { seen.insert(comparablePath($0)).inserted }
     }
 
     /// Appends a bottle path to the registry and verifies the entries file on
@@ -175,10 +197,13 @@ public struct BottleData: Codable {
     ///
     /// - Returns: `true` when the path is durably persisted.
     public mutating func registerBottlePath(_ url: URL) -> Bool {
-        if !paths.contains(url) {
+        let target = Self.comparablePath(url)
+        if !paths.contains(where: { Self.comparablePath($0) == target }) {
             paths.append(url) // didSet persists via encode()
         }
-        return persistedPaths()?.contains(url) ?? false
+        // Compare by canonical path: the bottle may already be registered
+        // under a different URL form (trailing slash) than the caller's.
+        return persistedPaths()?.contains { Self.comparablePath($0) == target } ?? false
     }
 
     /// Reads the bottle paths back from the entries file, accepting both the
@@ -226,10 +251,20 @@ public struct BottleData: Codable {
                 )
                 // Keep the registered paths; init() re-encodes them in the
                 // current format instead of discarding them.
-                self = replacement(paths: decoded.paths)
+                self = replacement(paths: Self.dedupedPaths(decoded.paths))
                 return false
             }
-            self = replacement(paths: decoded.paths)
+            let deduped = Self.dedupedPaths(decoded.paths)
+            self = replacement(paths: deduped)
+            if deduped.count != decoded.paths.count {
+                // Heal registries dirtied by releases that compared URLs for
+                // exact equality: persist the deduplicated list now, since
+                // assigning self here doesn't run the paths observer.
+                Logger.wineKit.warning(
+                    "Removed \(decoded.paths.count - deduped.count) duplicate bottle path(s) from registry"
+                )
+                encode()
+            }
             return true
         } catch {
             Logger.wineKit.error("Failed to decode BottleData: \(error)")
@@ -238,7 +273,7 @@ public struct BottleData: Codable {
         // shape written by encodeFallback() before treating it as corrupt.
         if let minimal = try? decoder.decode(BottleDataMinimal.self, from: data) {
             Logger.wineKit.warning("Recovered \(minimal.paths.count) bottle path(s) from minimal registry")
-            self = replacement(paths: minimal.paths)
+            self = replacement(paths: Self.dedupedPaths(minimal.paths))
             return false
         }
         // Truly unreadable: move the file aside so the fresh registry written

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleDataTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleDataTests.swift
@@ -77,6 +77,60 @@ final class BottleDataTests: XCTestCase {
         XCTAssertEqual(BottleData(entriesFile: entriesFile).paths, [bottle])
     }
 
+    // MARK: - Duplicate paths (trailing-slash variants)
+
+    func testRegisterBottlePathRejectsTrailingSlashDuplicate() {
+        var data = BottleData(entriesFile: entriesFile)
+        let bottle = tempDir.appendingPathComponent("Bottle")
+        let slashed = URL(fileURLWithPath: bottle.path + "/", isDirectory: true)
+
+        XCTAssertTrue(data.registerBottlePath(bottle))
+        // The slash variant is the same bottle: no new entry, but the
+        // registration must still report the bottle as durably persisted.
+        XCTAssertTrue(data.registerBottlePath(slashed))
+
+        XCTAssertEqual(data.paths, [bottle])
+        XCTAssertEqual(BottleData(entriesFile: entriesFile).paths, [bottle])
+    }
+
+    func testDirectPathsMutationCollapsesDuplicates() {
+        // Several call sites append to paths directly, bypassing
+        // registerBottlePath. The registry must hold its own invariant.
+        var data = BottleData(entriesFile: entriesFile)
+        let bottle = tempDir.appendingPathComponent("Bottle")
+
+        data.paths.append(bottle)
+        data.paths.append(URL(fileURLWithPath: bottle.path + "/", isDirectory: true))
+
+        XCTAssertEqual(data.paths, [bottle])
+    }
+
+    func testDecodeHealsRegistryDirtiedByOlderReleases() throws {
+        // Handcraft a registry containing the same bottle twice, with and
+        // without a trailing slash, as written by releases that compared
+        // URLs for exact equality.
+        let bottle = tempDir.appendingPathComponent("Bottle")
+        let plist: [String: Any] = [
+            "fileVersion": ["major": 1, "minor": 0, "patch": 0, "preRelease": "", "build": ""],
+            "paths": [
+                ["relative": bottle.absoluteString],
+                ["relative": bottle.absoluteString + "/"]
+            ]
+        ]
+        try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+            .write(to: entriesFile)
+
+        let data = BottleData(entriesFile: entriesFile)
+        XCTAssertEqual(data.paths, [bottle])
+
+        // The healed list must be persisted, not just deduplicated in memory.
+        let onDisk = try PropertyListSerialization.propertyList(
+            from: Data(contentsOf: entriesFile), format: nil
+        )
+        let paths = try XCTUnwrap((onDisk as? [String: Any])?["paths"] as? [Any])
+        XCTAssertEqual(paths.count, 1)
+    }
+
     // MARK: - Corrupt registry (issue #61)
 
     func testCorruptRegistryIsBackedUpNotOverwritten() throws {


### PR DESCRIPTION
Two CLI-adjacent bugs found while reproducing #168 locally.

**Duplicate bottle registry entries.** The same bottle can be registered twice when one entry carries a trailing slash (this had happened on a real registry here: the bottle then shows up twice in `whisky list` and in the app's bottle list). Root cause: membership checks compared URLs for exact equality, and several call sites append to `BottleData.paths` directly, bypassing `registerBottlePath`. A latent contributor: `comparablePath` documented stripping trailing slashes but never did; `resolvingSymlinksInPath()` adds one only for URLs that have touched the filesystem, so freshly built URLs and plist-decoded URLs disagree about the same directory.

`BottleData` now enforces uniqueness itself: canonical-path comparison in the `paths` observer (covers direct appends), in `registerBottlePath` (including its persisted-verification, which could previously report a registered bottle as unpersisted), and at decode time, which heals already-dirty registries on first load.

**`whisky run` rejected program options.** `whisky run MyBottle app.exe --disable-gpu` failed with an unknown-option error unless the user knew to insert a bare `--` first, and the error never mentioned that. `args` now uses the `allUnrecognized` parsing strategy: run's own flags work anywhere on the command line, unrecognized options flow through to the program. The first `--` is consumed as before (the strategy would otherwise leak it into the program's argv), later ones pass through literally, and the help text documents the collision case.

Tests: three new registry tests (slash-variant registration, direct-append collapse, decode healing of a handcrafted dirty registry); full WhiskyKit suite passes (1212 tests). Passthrough verified against the built CLI: unknown flag forwarded, own flags still parse after positionals, first `--` consumed, later `--` literal, exit codes unchanged (64 malformed / 1 domain).