### PR TITLE
fix: write dll overrides to the registry instead of WINEDLLOVERRIDES

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
@@ -79,9 +79,7 @@ public enum SteamLauncher {
                 at: steamExe, args: ["-applaunch", String(appId)], bottle: bottle,
                 programOverrides: plan.overrides,
                 gameProfileEnvironment: plan.gameProfileEnvironment,
-                // The plan describes the game, and steam.exe is only the
-                // vehicle that starts it, so these have to reach a descendant
-                // rather than be pinned to the launcher.
+                // the plan is the game's; steam.exe is only the vehicle
                 overridesApplyToDescendants: true
             )
         }

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
@@ -78,7 +78,11 @@ public enum SteamLauncher {
             _ = try? await Wine.runProgram(
                 at: steamExe, args: ["-applaunch", String(appId)], bottle: bottle,
                 programOverrides: plan.overrides,
-                gameProfileEnvironment: plan.gameProfileEnvironment
+                gameProfileEnvironment: plan.gameProfileEnvironment,
+                // The plan describes the game, and steam.exe is only the
+                // vehicle that starts it, so these have to reach a descendant
+                // rather than be pinned to the launcher.
+                overridesApplyToDescendants: true
             )
         }
     }

--- a/WhiskyKit/Sources/WhiskyKit/Wine/LauncherPresets.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/LauncherPresets.swift
@@ -268,15 +268,9 @@ public enum LauncherType: String, Codable, CaseIterable, Sendable, Identifiable 
 
     /// Executables this launcher spawns that must share its DLL overrides.
     ///
-    /// Wine keys `AppDefaults` on the executable name and a child process does
-    /// not inherit its parent's entry, so a launcher's helpers need entries of
-    /// their own or they silently fall back to the bottle default. Steam draws
-    /// its entire client in `steamwebhelper.exe`, so a DXVK override on
-    /// `steam.exe` alone leaves the window blank.
-    ///
-    /// Deliberately only the launcher's *own* helpers. Games a launcher starts
-    /// are not listed: those should take the bottle default, or an override of
-    /// their own, which is the whole point of scoping these per executable.
+    /// `AppDefaults` is per executable with no inheritance, and Steam draws its
+    /// client in `steamwebhelper.exe`, so an override on `steam.exe` alone
+    /// leaves the window blank. Games a launcher starts are deliberately absent.
     public var helperExecutables: [String] {
         switch self {
         case .steam:

--- a/WhiskyKit/Sources/WhiskyKit/Wine/LauncherPresets.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/LauncherPresets.swift
@@ -266,6 +266,32 @@ public enum LauncherType: String, Codable, CaseIterable, Sendable, Identifiable 
         }
     }
 
+    /// Executables this launcher spawns that must share its DLL overrides.
+    ///
+    /// Wine keys `AppDefaults` on the executable name and a child process does
+    /// not inherit its parent's entry, so a launcher's helpers need entries of
+    /// their own or they silently fall back to the bottle default. Steam draws
+    /// its entire client in `steamwebhelper.exe`, so a DXVK override on
+    /// `steam.exe` alone leaves the window blank.
+    ///
+    /// Deliberately only the launcher's *own* helpers. Games a launcher starts
+    /// are not listed: those should take the bottle default, or an override of
+    /// their own, which is the whole point of scoping these per executable.
+    public var helperExecutables: [String] {
+        switch self {
+        case .steam:
+            ["steamwebhelper.exe", "steamservice.exe"]
+        case .epicGames:
+            ["EpicWebHelper.exe"]
+        case .eaApp:
+            ["EABackgroundService.exe"]
+        case .battleNet:
+            ["Battle.net Helper.exe"]
+        case .rockstar, .ubisoft, .paradox:
+            []
+        }
+    }
+
     /// The recommended locale for this launcher.
     ///
     /// Most launchers work best with US English locale to avoid

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -295,9 +295,25 @@ public class Wine {
         fileHandle.writeApplicationInfo()
         fileHandle.writeInfo(for: bottle)
 
-        let wineEnvironment = constructWineEnvironment(
+        var wineEnvironment = constructWineEnvironment(
             for: bottle, environment: environment, programOverrides: programOverrides,
             programSettings: programSettings, gameProfileEnvironment: gameProfileEnvironment
+        )
+
+        // DLL overrides go to the registry, not WINEDLLOVERRIDES. The variable
+        // is inherited by every child process, so a launcher's backend became
+        // every game's backend and the per-program override could not scope
+        // anything; wine also reads the variable before the registry, so any
+        // AppDefaults entry was dead while it was set.
+        //
+        // The bottle's own overrides stay the prefix default so a child with no
+        // entry of its own still gets them, and this program's resolved set is
+        // written against its executable name alone.
+        let bottleOverrides = constructWineEnvironment(for: bottle)["WINEDLLOVERRIDES"] ?? ""
+        let programOverrideString = wineEnvironment.removeValue(forKey: "WINEDLLOVERRIDES") ?? ""
+        try await syncDLLOverrides(bottle: bottle, scope: .bottle, overrides: bottleOverrides)
+        try await syncDLLOverrides(
+            bottle: bottle, scope: .program(url.lastPathComponent), overrides: programOverrideString
         )
 
         // Create a run log entry to track this session

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -301,38 +301,24 @@ public class Wine {
             programSettings: programSettings, gameProfileEnvironment: gameProfileEnvironment
         )
 
-        // DLL overrides go to the registry, not WINEDLLOVERRIDES. The variable
-        // is inherited by every child process, so a launcher's backend became
-        // every game's backend and the per-program override could not scope
-        // anything; wine also reads the variable before the registry, so any
-        // AppDefaults entry was dead while it was set.
-        //
-        // The bottle's own overrides stay the prefix default so a child with no
-        // entry of its own still gets them, and this program's resolved set is
-        // written against its executable name alone.
+        // Registry, not WINEDLLOVERRIDES: the variable is inherited by every
+        // child, so a launcher's backend became every game's, and wine reads it
+        // before the registry so AppDefaults entries were dead while it was set.
         let bottleOverrides = constructWineEnvironment(for: bottle)["WINEDLLOVERRIDES"] ?? ""
         var scopes: [(scope: DLLOverrideScope, overrides: String)] = [
             (scope: .bottle, overrides: bottleOverrides)
         ]
 
         if overridesApplyToDescendants {
-            // The overrides describe something this process will spawn, not
-            // this process: `steam.exe -applaunch <id>` is Steam's launcher
-            // carrying a game's settings. AppDefaults cannot express that,
-            // because it is keyed on the executable and the target's name is
-            // not known here, so the variable stays, which is the one
-            // mechanism that reaches a descendant.
-            //
-            // Writing the game's settings against steam.exe instead would put
-            // them on the launcher and leave the game with the bottle default,
-            // which is exactly backwards.
+            // These describe something this process will spawn, and AppDefaults
+            // cannot express that: it is keyed on an executable whose name is
+            // not known here. The variable is the only thing that reaches a
+            // descendant, so it stays.
         } else {
             let programOverrideString = wineEnvironment.removeValue(forKey: "WINEDLLOVERRIDES") ?? ""
-            // The launcher's own helpers get the same entry. AppDefaults is
-            // keyed per executable and a child does not inherit its parent's,
-            // so without this a DXVK override on steam.exe leaves
-            // steamwebhelper.exe, which draws the entire client, on the bottle
-            // default.
+            // Helpers need their own entry: AppDefaults is per executable and
+            // children do not inherit, so steamwebhelper.exe would otherwise
+            // fall back to the bottle default and draw nothing.
             for executable in [url.lastPathComponent] + helperExecutables(for: url) {
                 scopes.append((scope: .program(executable), overrides: programOverrideString))
             }

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -311,7 +311,9 @@ public class Wine {
         // entry of its own still gets them, and this program's resolved set is
         // written against its executable name alone.
         let bottleOverrides = constructWineEnvironment(for: bottle)["WINEDLLOVERRIDES"] ?? ""
-        try await syncDLLOverrides(bottle: bottle, scope: .bottle, overrides: bottleOverrides)
+        var scopes: [(scope: DLLOverrideScope, overrides: String)] = [
+            (scope: .bottle, overrides: bottleOverrides)
+        ]
 
         if overridesApplyToDescendants {
             // The overrides describe something this process will spawn, not
@@ -332,11 +334,11 @@ public class Wine {
             // steamwebhelper.exe, which draws the entire client, on the bottle
             // default.
             for executable in [url.lastPathComponent] + helperExecutables(for: url) {
-                try await syncDLLOverrides(
-                    bottle: bottle, scope: .program(executable), overrides: programOverrideString
-                )
+                scopes.append((scope: .program(executable), overrides: programOverrideString))
             }
         }
+
+        try await syncDLLOverrides(bottle: bottle, scopes: scopes)
 
         // Create a run log entry to track this session
         let programName = url.lastPathComponent

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -239,7 +239,8 @@ public class Wine {
     public static func runProgram(
         at url: URL, args: [String] = [], bottle: Bottle, environment: [String: String] = [:],
         programOverrides: ProgramOverrides? = nil, programSettings: ProgramSettings? = nil,
-        gameProfileEnvironment: [String: String] = [:]
+        gameProfileEnvironment: [String: String] = [:],
+        overridesApplyToDescendants: Bool = false
     ) async throws -> ProgramRunResult {
         // Note: Launcher detection and fix application happen before this method
         // is called, via LauncherFixes.detectAndApply from the app's run paths
@@ -310,16 +311,31 @@ public class Wine {
         // entry of its own still gets them, and this program's resolved set is
         // written against its executable name alone.
         let bottleOverrides = constructWineEnvironment(for: bottle)["WINEDLLOVERRIDES"] ?? ""
-        let programOverrideString = wineEnvironment.removeValue(forKey: "WINEDLLOVERRIDES") ?? ""
         try await syncDLLOverrides(bottle: bottle, scope: .bottle, overrides: bottleOverrides)
-        // The launcher's own helpers get the same entry. AppDefaults is keyed
-        // per executable and a child does not inherit its parent's, so without
-        // this a DXVK override on steam.exe leaves steamwebhelper.exe, which
-        // draws the entire client, on the bottle default.
-        for executable in [url.lastPathComponent] + helperExecutables(for: url) {
-            try await syncDLLOverrides(
-                bottle: bottle, scope: .program(executable), overrides: programOverrideString
-            )
+
+        if overridesApplyToDescendants {
+            // The overrides describe something this process will spawn, not
+            // this process: `steam.exe -applaunch <id>` is Steam's launcher
+            // carrying a game's settings. AppDefaults cannot express that,
+            // because it is keyed on the executable and the target's name is
+            // not known here, so the variable stays, which is the one
+            // mechanism that reaches a descendant.
+            //
+            // Writing the game's settings against steam.exe instead would put
+            // them on the launcher and leave the game with the bottle default,
+            // which is exactly backwards.
+        } else {
+            let programOverrideString = wineEnvironment.removeValue(forKey: "WINEDLLOVERRIDES") ?? ""
+            // The launcher's own helpers get the same entry. AppDefaults is
+            // keyed per executable and a child does not inherit its parent's,
+            // so without this a DXVK override on steam.exe leaves
+            // steamwebhelper.exe, which draws the entire client, on the bottle
+            // default.
+            for executable in [url.lastPathComponent] + helperExecutables(for: url) {
+                try await syncDLLOverrides(
+                    bottle: bottle, scope: .program(executable), overrides: programOverrideString
+                )
+            }
         }
 
         // Create a run log entry to track this session

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -301,30 +301,11 @@ public class Wine {
             programSettings: programSettings, gameProfileEnvironment: gameProfileEnvironment
         )
 
-        // Registry, not WINEDLLOVERRIDES: the variable is inherited by every
-        // child, so a launcher's backend became every game's, and wine reads it
-        // before the registry so AppDefaults entries were dead while it was set.
-        let bottleOverrides = constructWineEnvironment(for: bottle)["WINEDLLOVERRIDES"] ?? ""
-        var scopes: [(scope: DLLOverrideScope, overrides: String)] = [
-            (scope: .bottle, overrides: bottleOverrides)
-        ]
-
-        if overridesApplyToDescendants {
-            // These describe something this process will spawn, and AppDefaults
-            // cannot express that: it is keyed on an executable whose name is
-            // not known here. The variable is the only thing that reaches a
-            // descendant, so it stays.
-        } else {
-            let programOverrideString = wineEnvironment.removeValue(forKey: "WINEDLLOVERRIDES") ?? ""
-            // Helpers need their own entry: AppDefaults is per executable and
-            // children do not inherit, so steamwebhelper.exe would otherwise
-            // fall back to the bottle default and draw nothing.
-            for executable in [url.lastPathComponent] + helperExecutables(for: url) {
-                scopes.append((scope: .program(executable), overrides: programOverrideString))
-            }
-        }
-
-        try await syncDLLOverrides(bottle: bottle, scopes: scopes)
+        try await applyDLLOverrides(
+            for: url, bottle: bottle,
+            wineEnvironment: &wineEnvironment,
+            applyToDescendants: overridesApplyToDescendants
+        )
 
         // Create a run log entry to track this session
         let programName = url.lastPathComponent

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -312,9 +312,15 @@ public class Wine {
         let bottleOverrides = constructWineEnvironment(for: bottle)["WINEDLLOVERRIDES"] ?? ""
         let programOverrideString = wineEnvironment.removeValue(forKey: "WINEDLLOVERRIDES") ?? ""
         try await syncDLLOverrides(bottle: bottle, scope: .bottle, overrides: bottleOverrides)
-        try await syncDLLOverrides(
-            bottle: bottle, scope: .program(url.lastPathComponent), overrides: programOverrideString
-        )
+        // The launcher's own helpers get the same entry. AppDefaults is keyed
+        // per executable and a child does not inherit its parent's, so without
+        // this a DXVK override on steam.exe leaves steamwebhelper.exe, which
+        // draws the entire client, on the bottle default.
+        for executable in [url.lastPathComponent] + helperExecutables(for: url) {
+            try await syncDLLOverrides(
+                bottle: bottle, scope: .program(executable), overrides: programOverrideString
+            )
+        }
 
         // Create a run log entry to track this session
         let programName = url.lastPathComponent

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
@@ -124,6 +124,17 @@ public extension Wine {
         )
     }
 
+    /// The launcher helper executables that must share `url`'s DLL overrides,
+    /// or none when the executable is not a recognised launcher.
+    ///
+    /// Detection runs on the launched executable rather than the bottle's
+    /// recorded launcher, so this is right even when launcher compatibility
+    /// mode is off: the reason the helpers need the entry is how wine resolves
+    /// `AppDefaults`, not whether the user opted into launcher fixes.
+    static func helperExecutables(for url: URL) -> [String] {
+        LauncherType.detect(from: url)?.helperExecutables ?? []
+    }
+
     /// Parses a `WINEDLLOVERRIDES` string into DLL name to load-order pairs.
     ///
     /// Wine's registry accepts the same load-order syntax as the variable, so

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
@@ -1,0 +1,127 @@
+//
+//  WineDLLOverrideRegistry.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import os.log
+
+public extension Wine {
+    /// Where a set of DLL overrides lives in the prefix registry.
+    ///
+    /// `WINEDLLOVERRIDES` cannot express either of these: an environment
+    /// variable is inherited by every child process, so a launcher's overrides
+    /// silently become every game's overrides. Wine reads the variable before
+    /// the registry, so registry entries are dead while it is set.
+    enum DLLOverrideScope: Equatable, Sendable {
+        /// `HKCU\Software\Wine\DllOverrides`: the prefix default, used by any
+        /// process without an entry of its own. This is what a game launched by
+        /// a launcher should fall back to.
+        case bottle
+        /// `HKCU\Software\Wine\AppDefaults\<exe>\DllOverrides`: this executable
+        /// only. Children do not inherit it.
+        case program(String)
+
+        var registryKey: String {
+            switch self {
+            case .bottle:
+                #"HKCU\Software\Wine\DllOverrides"#
+            case let .program(executable):
+                // \\#( is a literal backslash followed by the interpolation:
+                // \#( alone would be read as the interpolation and swallow the
+                // path separator.
+                #"HKCU\Software\Wine\AppDefaults\\#(executable)\DllOverrides"#
+            }
+        }
+    }
+
+    private static let dllOverrideLogger = Logger(
+        subsystem: "com.isaacmarovitz.WhiskyKit", category: "dll-overrides"
+    )
+
+    /// Writes `overrides` to the registry at `scope`, removing any entries the
+    /// scope previously held that are no longer wanted.
+    ///
+    /// The prune half matters because registry state persists where an
+    /// environment variable did not: switching a bottle from DXVK to D3DMetal
+    /// has to clear the `d3d9` entry DXVK's preset wrote, or it lingers.
+    ///
+    /// - Parameters:
+    ///   - bottle: The bottle whose prefix registry is written.
+    ///   - scope: Bottle default, or a single executable.
+    ///   - overrides: A `WINEDLLOVERRIDES`-syntax string, for example
+    ///     `d3d11=n,b;dxgi=n,b`. Empty clears the scope.
+    @MainActor
+    static func syncDLLOverrides(
+        bottle: Bottle, scope: DLLOverrideScope, overrides: String
+    ) async throws {
+        let wanted = parseDLLOverrides(overrides)
+        let key = scope.registryKey
+        let existing = await (try? queryDLLOverrides(bottle: bottle, key: key)) ?? [:]
+
+        guard existing != wanted else {
+            dllOverrideLogger.debug("DLL overrides at \(key) already match, nothing to write")
+            return
+        }
+
+        // Every write is a wine process, so only touch what actually differs.
+        // Launches are frequent and the overrides rarely change between them.
+        for (dll, mode) in wanted.sorted(by: { $0.key < $1.key }) where existing[dll] != mode {
+            try await addRegistryKey(bottle: bottle, key: key, name: dll, data: mode, type: .string)
+        }
+
+        let stale = existing.keys.filter { wanted[$0] == nil }
+        for name in stale.sorted() {
+            try? await runWine(["reg", "delete", key, "-v", name, "-f"], bottle: bottle)
+        }
+
+        dllOverrideLogger.debug("Synced \(wanted.count) DLL override(s) to \(key), pruned \(stale.count)")
+    }
+
+    /// Parses a `WINEDLLOVERRIDES` string into DLL name to load-order pairs.
+    ///
+    /// Wine's registry accepts the same load-order syntax as the variable, so
+    /// the values are written through unchanged. `dll=` (disabled) is kept: an
+    /// empty value is how a DLL is disabled in both forms.
+    static func parseDLLOverrides(_ overrides: String) -> [String: String] {
+        var result: [String: String] = [:]
+        for clause in overrides.split(separator: ";") {
+            let parts = clause.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard let name = parts.first else { continue }
+            let dll = name.trimmingCharacters(in: .whitespaces)
+            guard !dll.isEmpty else { continue }
+            result[dll] = parts.count > 1 ? String(parts[1]).trimmingCharacters(in: .whitespaces) : ""
+        }
+        return result
+    }
+
+    /// The DLL overrides currently written under `key`, or an empty dictionary
+    /// when the key does not exist.
+    @MainActor
+    static func queryDLLOverrides(bottle: Bottle, key: String) async throws -> [String: String] {
+        let output = try await runWine(["reg", "query", key], bottle: bottle)
+        var result: [String: String] = [:]
+        for line in output.split(whereSeparator: \.isNewline) {
+            // "    d3d11    REG_SZ    n,b" -- name, type, then the value, which
+            // is absent for a disabled override. The key's own header line has
+            // no REG_ type and is skipped.
+            let fields = line.split(whereSeparator: \.isWhitespace)
+            guard fields.count >= 2, fields[1].hasPrefix("REG_") else { continue }
+            result[String(fields[0])] = fields.count > 2 ? String(fields[2]) : ""
+        }
+        return result
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
@@ -68,27 +68,60 @@ public extension Wine {
     static func syncDLLOverrides(
         bottle: Bottle, scope: DLLOverrideScope, overrides: String
     ) async throws {
-        let wanted = parseDLLOverrides(overrides)
         let key = scope.registryKey
         let existing = await (try? queryDLLOverrides(bottle: bottle, key: key)) ?? [:]
+        let plan = syncPlan(existing: existing, wanted: parseDLLOverrides(overrides))
 
-        guard existing != wanted else {
+        guard !plan.isEmpty else {
             dllOverrideLogger.debug("DLL overrides at \(key) already match, nothing to write")
             return
         }
 
-        // Every write is a wine process, so only touch what actually differs.
-        // Launches are frequent and the overrides rarely change between them.
-        for (dll, mode) in wanted.sorted(by: { $0.key < $1.key }) where existing[dll] != mode {
+        for (dll, mode) in plan.writes {
             try await addRegistryKey(bottle: bottle, key: key, name: dll, data: mode, type: .string)
         }
-
-        let stale = existing.keys.filter { wanted[$0] == nil }
-        for name in stale.sorted() {
+        for name in plan.deletes {
             try? await runWine(["reg", "delete", key, "-v", name, "-f"], bottle: bottle)
         }
 
-        dllOverrideLogger.debug("Synced \(wanted.count) DLL override(s) to \(key), pruned \(stale.count)")
+        dllOverrideLogger.debug(
+            "Synced \(plan.writes.count) DLL override(s) to \(key), pruned \(plan.deletes.count)"
+        )
+    }
+
+    /// What ``syncDLLOverrides(bottle:scope:overrides:)`` has to do to turn
+    /// `existing` into `wanted`.
+    struct DLLOverrideSyncPlan: Equatable, Sendable {
+        /// DLL name and load order to write, sorted by name.
+        public let writes: [(dll: String, mode: String)]
+        /// Value names to remove, sorted.
+        public let deletes: [String]
+
+        public var isEmpty: Bool { writes.isEmpty && deletes.isEmpty }
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.deletes == rhs.deletes && lhs.writes.map(\.dll) == rhs.writes.map(\.dll)
+                && lhs.writes.map(\.mode) == rhs.writes.map(\.mode)
+        }
+    }
+
+    /// The minimal set of registry operations that turns `existing` into
+    /// `wanted`.
+    ///
+    /// Every write is a wine process, and launches are frequent while the
+    /// overrides rarely change between them, so anything already correct is
+    /// left alone. Deletes are what an environment variable never needed:
+    /// registry state persists, so switching a bottle from DXVK to D3DMetal has
+    /// to clear the `d3d9` entry DXVK's preset wrote or it lingers forever.
+    static func syncPlan(
+        existing: [String: String], wanted: [String: String]
+    ) -> DLLOverrideSyncPlan {
+        DLLOverrideSyncPlan(
+            writes: wanted.sorted { $0.key < $1.key }
+                .filter { existing[$0.key] != $0.value }
+                .map { (dll: $0.key, mode: $0.value) },
+            deletes: existing.keys.filter { wanted[$0] == nil }.sorted()
+        )
     }
 
     /// Parses a `WINEDLLOVERRIDES` string into DLL name to load-order pairs.
@@ -112,12 +145,17 @@ public extension Wine {
     /// when the key does not exist.
     @MainActor
     static func queryDLLOverrides(bottle: Bottle, key: String) async throws -> [String: String] {
-        let output = try await runWine(["reg", "query", key], bottle: bottle)
+        try await parseRegistryQueryOutput(runWine(["reg", "query", key], bottle: bottle))
+    }
+
+    /// Parses `reg query` output into DLL name to load-order pairs.
+    ///
+    /// Lines look like `    d3d11    REG_SZ    n,b`: name, type, then the value,
+    /// which is absent for a disabled override. The key's own header line
+    /// carries no `REG_` type and is skipped, as is the blank line around it.
+    static func parseRegistryQueryOutput(_ output: String) -> [String: String] {
         var result: [String: String] = [:]
         for line in output.split(whereSeparator: \.isNewline) {
-            // "    d3d11    REG_SZ    n,b" -- name, type, then the value, which
-            // is absent for a disabled override. The key's own header line has
-            // no REG_ type and is skipped.
             let fields = line.split(whereSeparator: \.isWhitespace)
             guard fields.count >= 2, fields[1].hasPrefix("REG_") else { continue }
             result[String(fields[0])] = fields.count > 2 ? String(fields[2]) : ""

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
@@ -62,11 +62,50 @@ public extension Wine {
         )
         let url = FileManager.default.temporaryDirectory
             .appending(path: "whisky-dll-overrides-\(UUID().uuidString).reg")
-        try document.write(to: url, atomically: true, encoding: .utf16LittleEndian)
+        // Wine detects a Unicode .reg by its BOM alone, and `.utf16LittleEndian`
+        // writes none — the file parses as ANSI, matches no header, and imports
+        // nothing while exiting 0. Written explicitly rather than via `.utf16`,
+        // whose BOM follows platform endianness.
+        try ("\u{FEFF}" + document).write(to: url, atomically: true, encoding: .utf16LittleEndian)
         defer { try? FileManager.default.removeItem(at: url) }
 
-        try await runWine(["regedit", url.path(percentEncoded: false)], bottle: bottle)
+        // `reg import`, not `regedit`: regedit has no silent switch, so it puts up
+        // the import confirmation and never exits.
+        try await runWine(["reg", "import", url.path(percentEncoded: false)], bottle: bottle)
         dllOverrideLogger.debug("Synced DLL overrides for \(scopes.count) scope(s) in one import")
+    }
+
+    /// Moves this launch's DLL overrides from the environment into the registry.
+    ///
+    /// Registry, not `WINEDLLOVERRIDES`: the variable is inherited by every child,
+    /// so a launcher's backend became every game's, and wine reads it before the
+    /// registry, which left `AppDefaults` entries dead while it was set.
+    ///
+    /// - Parameter applyToDescendants: When the overrides describe something this
+    ///   process will *spawn*, `AppDefaults` cannot express it — that is keyed on
+    ///   an executable whose name is not known here — so the variable stays.
+    @MainActor
+    static func applyDLLOverrides(
+        for url: URL,
+        bottle: Bottle,
+        wineEnvironment: inout [String: String],
+        applyToDescendants: Bool
+    ) async throws {
+        var scopes: [(scope: DLLOverrideScope, overrides: String)] = [
+            (scope: .bottle, overrides: constructWineEnvironment(for: bottle)["WINEDLLOVERRIDES"] ?? "")
+        ]
+
+        if !applyToDescendants {
+            let programOverrides = wineEnvironment.removeValue(forKey: "WINEDLLOVERRIDES") ?? ""
+            // Helpers need their own entry: AppDefaults is per executable and
+            // children do not inherit, so steamwebhelper.exe would otherwise fall
+            // back to the bottle default and draw nothing.
+            for executable in [url.lastPathComponent] + helperExecutables(for: url) {
+                scopes.append((scope: .program(executable), overrides: programOverrides))
+            }
+        }
+
+        try await syncDLLOverrides(bottle: bottle, scopes: scopes)
     }
 
     /// Renders a `.reg` leaving each key holding exactly `overrides`.
@@ -78,14 +117,32 @@ public extension Wine {
         for scope in scopes {
             lines.append("[-\(scope.key)]")
             lines.append("")
-            guard !scope.overrides.isEmpty else { continue }
+            let renderable = scope.overrides
+                .filter { isRenderable(dll: $0.key, mode: $0.value) }
+                .sorted { $0.key < $1.key }
+            guard !renderable.isEmpty else { continue }
             lines.append("[\(scope.key)]")
-            for (dll, mode) in scope.overrides.sorted(by: { $0.key < $1.key }) {
+            for (dll, mode) in renderable {
                 lines.append("\"\(dll)\"=\"\(mode)\"")
             }
             lines.append("")
         }
         return lines.joined(separator: "\r\n")
+    }
+
+    /// Whether an override can be rendered without corrupting the document.
+    ///
+    /// Custom overrides are user-typed, and a quote or backslash in a name would
+    /// terminate the value early and take every later scope down with it. A DLL
+    /// name is a filename and a mode is a list of known words, so anything
+    /// outside these sets could not have loaded regardless — dropping it costs
+    /// nothing and contains the blast radius to the one bad entry.
+    static func isRenderable(dll: String, mode: String) -> Bool {
+        let name = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789._-+")
+        let modes = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz,")
+        guard !dll.isEmpty else { return false }
+        return dll.lowercased().unicodeScalars.allSatisfy(name.contains)
+            && mode.lowercased().unicodeScalars.allSatisfy(modes.contains)
     }
 
     /// The launcher helpers that must share `url`'s DLL overrides.

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
@@ -21,18 +21,10 @@ import os.log
 
 public extension Wine {
     /// Where a set of DLL overrides lives in the prefix registry.
-    ///
-    /// `WINEDLLOVERRIDES` cannot express either of these: an environment
-    /// variable is inherited by every child process, so a launcher's overrides
-    /// silently become every game's overrides. Wine reads the variable before
-    /// the registry, so registry entries are dead while it is set.
     enum DLLOverrideScope: Equatable, Sendable {
-        /// `HKCU\Software\Wine\DllOverrides`: the prefix default, used by any
-        /// process without an entry of its own. This is what a game launched by
-        /// a launcher should fall back to.
+        /// The prefix default, used by any process without an entry of its own.
         case bottle
-        /// `HKCU\Software\Wine\AppDefaults\<exe>\DllOverrides`: this executable
-        /// only. Children do not inherit it.
+        /// This executable only. Children do not inherit it.
         case program(String)
 
         var registryKey: String {
@@ -40,9 +32,8 @@ public extension Wine {
             case .bottle:
                 #"HKCU\Software\Wine\DllOverrides"#
             case let .program(executable):
-                // \\#( is a literal backslash followed by the interpolation:
-                // \#( alone would be read as the interpolation and swallow the
-                // path separator.
+                // \\#( is a literal backslash then the interpolation; \#( alone
+                // would swallow the path separator.
                 #"HKCU\Software\Wine\AppDefaults\\#(executable)\DllOverrides"#
             }
         }
@@ -52,15 +43,11 @@ public extension Wine {
         subsystem: "com.isaacmarovitz.WhiskyKit", category: "dll-overrides"
     )
 
-    /// Replaces the DLL overrides at each scope with the ones given, in a
-    /// single registry import.
+    /// Replaces the DLL overrides at each scope, in one import.
     ///
-    /// One import, not one `reg` invocation per value: every `reg add` and
-    /// `reg delete` is a whole wine process, and a launch that syncs a bottle
-    /// scope plus a launcher and its helpers was spending twenty-odd sequential
-    /// process launches before the program it was asked to start. A `.reg` file
-    /// deletes each key and rewrites it, so nothing has to be read back first
-    /// and stale values from a previous backend cannot survive.
+    /// One import rather than a `reg` call per value: each of those is a whole
+    /// wine process, and a launch syncing a bottle plus a launcher and its
+    /// helpers spent twenty-odd of them before starting anything.
     ///
     /// - Parameters:
     ///   - bottle: The bottle whose prefix registry is written.
@@ -82,12 +69,10 @@ public extension Wine {
         dllOverrideLogger.debug("Synced DLL overrides for \(scopes.count) scope(s) in one import")
     }
 
-    /// Renders a `.reg` document that leaves each key holding exactly
-    /// `overrides` and nothing else.
+    /// Renders a `.reg` leaving each key holding exactly `overrides`.
     ///
-    /// Each key is deleted and recreated rather than edited. `.reg` processes
-    /// entries in order, so `[-Key]` followed by `[Key]` is a replace, which is
-    /// both how stale values get pruned and why no read-back is needed.
+    /// `[-Key]` then `[Key]` is a replace, since `.reg` runs in order. That is
+    /// what prunes stale values without reading the key back first.
     static func registryDocument(for scopes: [(key: String, overrides: [String: String])]) -> String {
         var lines = ["Windows Registry Editor Version 5.00", ""]
         for scope in scopes {
@@ -103,22 +88,19 @@ public extension Wine {
         return lines.joined(separator: "\r\n")
     }
 
-    /// The launcher helper executables that must share `url`'s DLL overrides,
-    /// or none when the executable is not a recognised launcher.
+    /// The launcher helpers that must share `url`'s DLL overrides.
     ///
-    /// Detection runs on the launched executable rather than the bottle's
-    /// recorded launcher, so this is right even when launcher compatibility
-    /// mode is off: the reason the helpers need the entry is how wine resolves
-    /// `AppDefaults`, not whether the user opted into launcher fixes.
+    /// Detected from the executable, not the bottle's recorded launcher: they
+    /// need the entry because of how wine resolves `AppDefaults`, not because
+    /// the user enabled launcher fixes.
     static func helperExecutables(for url: URL) -> [String] {
         LauncherType.detect(from: url)?.helperExecutables ?? []
     }
 
     /// Parses a `WINEDLLOVERRIDES` string into DLL name to load-order pairs.
     ///
-    /// Wine's registry accepts the same load-order syntax as the variable, so
-    /// the values are written through unchanged. `dll=` (disabled) is kept: an
-    /// empty value is how a DLL is disabled in both forms.
+    /// The registry takes the same syntax, so values pass through unchanged.
+    /// `dll=` is kept: an empty value is how a DLL is disabled in both forms.
     static func parseDLLOverrides(_ overrides: String) -> [String: String] {
         var result: [String: String] = [:]
         for clause in overrides.split(separator: ";") {

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
@@ -52,76 +52,55 @@ public extension Wine {
         subsystem: "com.isaacmarovitz.WhiskyKit", category: "dll-overrides"
     )
 
-    /// Writes `overrides` to the registry at `scope`, removing any entries the
-    /// scope previously held that are no longer wanted.
+    /// Replaces the DLL overrides at each scope with the ones given, in a
+    /// single registry import.
     ///
-    /// The prune half matters because registry state persists where an
-    /// environment variable did not: switching a bottle from DXVK to D3DMetal
-    /// has to clear the `d3d9` entry DXVK's preset wrote, or it lingers.
+    /// One import, not one `reg` invocation per value: every `reg add` and
+    /// `reg delete` is a whole wine process, and a launch that syncs a bottle
+    /// scope plus a launcher and its helpers was spending twenty-odd sequential
+    /// process launches before the program it was asked to start. A `.reg` file
+    /// deletes each key and rewrites it, so nothing has to be read back first
+    /// and stale values from a previous backend cannot survive.
     ///
     /// - Parameters:
     ///   - bottle: The bottle whose prefix registry is written.
-    ///   - scope: Bottle default, or a single executable.
-    ///   - overrides: A `WINEDLLOVERRIDES`-syntax string, for example
-    ///     `d3d11=n,b;dxgi=n,b`. Empty clears the scope.
+    ///   - scopes: Each scope and the `WINEDLLOVERRIDES`-syntax string it
+    ///     should hold. An empty string clears that scope.
     @MainActor
     static func syncDLLOverrides(
-        bottle: Bottle, scope: DLLOverrideScope, overrides: String
+        bottle: Bottle, scopes: [(scope: DLLOverrideScope, overrides: String)]
     ) async throws {
-        let key = scope.registryKey
-        let existing = await (try? queryDLLOverrides(bottle: bottle, key: key)) ?? [:]
-        let plan = syncPlan(existing: existing, wanted: parseDLLOverrides(overrides))
-
-        guard !plan.isEmpty else {
-            dllOverrideLogger.debug("DLL overrides at \(key) already match, nothing to write")
-            return
-        }
-
-        for (dll, mode) in plan.writes {
-            try await addRegistryKey(bottle: bottle, key: key, name: dll, data: mode, type: .string)
-        }
-        for name in plan.deletes {
-            try? await runWine(["reg", "delete", key, "-v", name, "-f"], bottle: bottle)
-        }
-
-        dllOverrideLogger.debug(
-            "Synced \(plan.writes.count) DLL override(s) to \(key), pruned \(plan.deletes.count)"
+        let document = registryDocument(
+            for: scopes.map { (key: $0.scope.registryKey, overrides: parseDLLOverrides($0.overrides)) }
         )
+        let url = FileManager.default.temporaryDirectory
+            .appending(path: "whisky-dll-overrides-\(UUID().uuidString).reg")
+        try document.write(to: url, atomically: true, encoding: .utf16LittleEndian)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try await runWine(["regedit", url.path(percentEncoded: false)], bottle: bottle)
+        dllOverrideLogger.debug("Synced DLL overrides for \(scopes.count) scope(s) in one import")
     }
 
-    /// What ``syncDLLOverrides(bottle:scope:overrides:)`` has to do to turn
-    /// `existing` into `wanted`.
-    struct DLLOverrideSyncPlan: Equatable, Sendable {
-        /// DLL name and load order to write, sorted by name.
-        public let writes: [(dll: String, mode: String)]
-        /// Value names to remove, sorted.
-        public let deletes: [String]
-
-        public var isEmpty: Bool { writes.isEmpty && deletes.isEmpty }
-
-        public static func == (lhs: Self, rhs: Self) -> Bool {
-            lhs.deletes == rhs.deletes && lhs.writes.map(\.dll) == rhs.writes.map(\.dll)
-                && lhs.writes.map(\.mode) == rhs.writes.map(\.mode)
-        }
-    }
-
-    /// The minimal set of registry operations that turns `existing` into
-    /// `wanted`.
+    /// Renders a `.reg` document that leaves each key holding exactly
+    /// `overrides` and nothing else.
     ///
-    /// Every write is a wine process, and launches are frequent while the
-    /// overrides rarely change between them, so anything already correct is
-    /// left alone. Deletes are what an environment variable never needed:
-    /// registry state persists, so switching a bottle from DXVK to D3DMetal has
-    /// to clear the `d3d9` entry DXVK's preset wrote or it lingers forever.
-    static func syncPlan(
-        existing: [String: String], wanted: [String: String]
-    ) -> DLLOverrideSyncPlan {
-        DLLOverrideSyncPlan(
-            writes: wanted.sorted { $0.key < $1.key }
-                .filter { existing[$0.key] != $0.value }
-                .map { (dll: $0.key, mode: $0.value) },
-            deletes: existing.keys.filter { wanted[$0] == nil }.sorted()
-        )
+    /// Each key is deleted and recreated rather than edited. `.reg` processes
+    /// entries in order, so `[-Key]` followed by `[Key]` is a replace, which is
+    /// both how stale values get pruned and why no read-back is needed.
+    static func registryDocument(for scopes: [(key: String, overrides: [String: String])]) -> String {
+        var lines = ["Windows Registry Editor Version 5.00", ""]
+        for scope in scopes {
+            lines.append("[-\(scope.key)]")
+            lines.append("")
+            guard !scope.overrides.isEmpty else { continue }
+            lines.append("[\(scope.key)]")
+            for (dll, mode) in scope.overrides.sorted(by: { $0.key < $1.key }) {
+                lines.append("\"\(dll)\"=\"\(mode)\"")
+            }
+            lines.append("")
+        }
+        return lines.joined(separator: "\r\n")
     }
 
     /// The launcher helper executables that must share `url`'s DLL overrides,
@@ -148,28 +127,6 @@ public extension Wine {
             let dll = name.trimmingCharacters(in: .whitespaces)
             guard !dll.isEmpty else { continue }
             result[dll] = parts.count > 1 ? String(parts[1]).trimmingCharacters(in: .whitespaces) : ""
-        }
-        return result
-    }
-
-    /// The DLL overrides currently written under `key`, or an empty dictionary
-    /// when the key does not exist.
-    @MainActor
-    static func queryDLLOverrides(bottle: Bottle, key: String) async throws -> [String: String] {
-        try await parseRegistryQueryOutput(runWine(["reg", "query", key], bottle: bottle))
-    }
-
-    /// Parses `reg query` output into DLL name to load-order pairs.
-    ///
-    /// Lines look like `    d3d11    REG_SZ    n,b`: name, type, then the value,
-    /// which is absent for a disabled override. The key's own header line
-    /// carries no `REG_` type and is skipped, as is the blank line around it.
-    static func parseRegistryQueryOutput(_ output: String) -> [String: String] {
-        var result: [String: String] = [:]
-        for line in output.split(whereSeparator: \.isNewline) {
-            let fields = line.split(whereSeparator: \.isWhitespace)
-            guard fields.count >= 2, fields[1].hasPrefix("REG_") else { continue }
-            result[String(fields[0])] = fields.count > 2 ? String(fields[2]) : ""
         }
         return result
     }

--- a/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideRegistryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideRegistryTests.swift
@@ -85,6 +85,36 @@ final class DLLOverrideRegistryTests: XCTestCase {
         XCTAssertEqual(parsed["d3d11"], "b")
     }
 
+    // MARK: - Launcher helpers
+
+    /// The reason this exists: steam draws its whole client in the webhelper,
+    /// and AppDefaults is per executable with no inheritance, so an override on
+    /// steam.exe alone leaves the window blank.
+    func testSteamCarriesItsHelpersAlong() {
+        let helpers = Wine.helperExecutables(for: URL(filePath: "/B/Steam/steam.exe"))
+        XCTAssertTrue(helpers.contains("steamwebhelper.exe"))
+    }
+
+    func testAGameIsNotALauncherAndCarriesNothing() {
+        let url = URL(filePath: "/B/Steam/steamapps/common/Some Game/game.exe")
+        XCTAssertTrue(Wine.helperExecutables(for: url).isEmpty)
+    }
+
+    func testUnknownExecutableCarriesNothing() {
+        XCTAssertTrue(Wine.helperExecutables(for: URL(filePath: "/B/thing.exe")).isEmpty)
+    }
+
+    /// A helper must never be listed as its own helper, or a launch would write
+    /// the same scope twice.
+    func testNoLauncherListsItself() {
+        for launcher in LauncherType.allCases {
+            XCTAssertFalse(
+                launcher.helperExecutables.contains { $0.lowercased().contains("steam.exe") },
+                "\(launcher) lists a launcher executable as a helper"
+            )
+        }
+    }
+
     // MARK: - reg query output
 
     func testParsesRegQueryOutput() {

--- a/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideRegistryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideRegistryTests.swift
@@ -1,0 +1,87 @@
+//
+//  DLLOverrideRegistryTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+final class DLLOverrideRegistryTests: XCTestCase {
+    // MARK: - Scope keys
+
+    func testBottleScopeUsesPrefixDefaultKey() {
+        XCTAssertEqual(
+            Wine.DLLOverrideScope.bottle.registryKey,
+            #"HKCU\Software\Wine\DllOverrides"#
+        )
+    }
+
+    func testProgramScopeIsKeyedOnTheExecutable() {
+        XCTAssertEqual(
+            Wine.DLLOverrideScope.program("steam.exe").registryKey,
+            #"HKCU\Software\Wine\AppDefaults\steam.exe\DllOverrides"#
+        )
+    }
+
+    /// Two executables must land in different keys, which is the whole point:
+    /// an environment variable could not separate a launcher from the games it
+    /// spawns.
+    func testProgramScopesDoNotCollide() {
+        XCTAssertNotEqual(
+            Wine.DLLOverrideScope.program("steam.exe").registryKey,
+            Wine.DLLOverrideScope.program("steamwebhelper.exe").registryKey
+        )
+    }
+
+    // MARK: - Parsing
+
+    func testParsesDXVKPreset() {
+        let parsed = Wine.parseDLLOverrides("d3d10core=n,b;d3d11=n,b;d3d9=n,b;dxgi=n,b")
+        XCTAssertEqual(parsed.count, 4)
+        XCTAssertEqual(parsed["d3d11"], "n,b")
+        XCTAssertEqual(parsed["dxgi"], "n,b")
+    }
+
+    func testParsesBuiltinOnlyModes() {
+        let parsed = Wine.parseDLLOverrides("dxgi=b;winemetal=b")
+        XCTAssertEqual(parsed["dxgi"], "b")
+        XCTAssertEqual(parsed["winemetal"], "b")
+    }
+
+    /// `dll=` with no value is how a DLL is disabled, in both the variable and
+    /// the registry, so it has to survive the round trip rather than be dropped.
+    func testKeepsDisabledOverrides() {
+        let parsed = Wine.parseDLLOverrides("mscoree=;mshtml=")
+        XCTAssertEqual(parsed.count, 2)
+        XCTAssertEqual(parsed["mscoree"], "")
+    }
+
+    func testEmptyStringYieldsNoOverrides() {
+        XCTAssertTrue(Wine.parseDLLOverrides("").isEmpty)
+    }
+
+    func testIgnoresEmptyClausesAndWhitespace() {
+        let parsed = Wine.parseDLLOverrides(" d3d11=n,b ;; dxgi=b ;")
+        XCTAssertEqual(parsed.count, 2)
+        XCTAssertEqual(parsed["d3d11"], "n,b")
+        XCTAssertEqual(parsed["dxgi"], "b")
+    }
+
+    func testLastClauseWinsForARepeatedDLL() {
+        let parsed = Wine.parseDLLOverrides("d3d11=n,b;d3d11=b")
+        XCTAssertEqual(parsed["d3d11"], "b")
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideRegistryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideRegistryTests.swift
@@ -167,4 +167,68 @@ final class DLLOverrideRegistryTests: XCTestCase {
         let doc = Wine.registryDocument(for: [(key: #"HKCU\A"#, overrides: ["d3d11": "n,b"])])
         XCTAssertTrue(doc.contains("\r\n"))
     }
+
+    // MARK: - Encoding
+
+    func testWrittenDocumentStartsWithAUTF16LEBOM() throws {
+        // Wine detects a Unicode .reg by its BOM alone. Without one the file parses
+        // as ANSI, matches no header, and the import silently does nothing.
+        let doc = Wine.registryDocument(for: [(key: #"HKCU\A"#, overrides: ["d3d11": "n,b"])])
+        let url = FileManager.default.temporaryDirectory.appending(path: "bom-\(UUID().uuidString).reg")
+        try ("\u{FEFF}" + doc).write(to: url, atomically: true, encoding: .utf16LittleEndian)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let head = try Data(contentsOf: url).prefix(2)
+        XCTAssertEqual(Array(head), [0xFF, 0xFE], "expected a little-endian BOM")
+    }
+
+    func testWrittenDocumentRoundTripsThroughAUTF16Reader() throws {
+        let doc = Wine.registryDocument(for: [(key: #"HKCU\A"#, overrides: ["d3d11": "n,b"])])
+        let url = FileManager.default.temporaryDirectory.appending(path: "rt-\(UUID().uuidString).reg")
+        try ("\u{FEFF}" + doc).write(to: url, atomically: true, encoding: .utf16LittleEndian)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // Reading without naming an encoding is what a BOM is for.
+        let read = try String(contentsOf: url)
+        XCTAssertTrue(read.hasPrefix("\u{FEFF}Windows Registry Editor Version 5.00"))
+        XCTAssertTrue(read.contains(#""d3d11"="n,b""#))
+    }
+
+    // MARK: - Rendering safety
+
+    func testAcceptsRealDLLNamesAndModes() {
+        for dll in ["d3d11", "d3d10core", "dxgi", "nvapi64", "api-ms-win-crt-runtime-l1-1-0", "d3dx9_43"] {
+            XCTAssertTrue(Wine.isRenderable(dll: dll, mode: "native,builtin"), dll)
+        }
+        for mode in ["native", "builtin", "native,builtin", "builtin,native", ""] {
+            XCTAssertTrue(Wine.isRenderable(dll: "d3d11", mode: mode), mode)
+        }
+    }
+
+    func testRejectsNamesThatWouldBreakOutOfTheValue() {
+        // A quote or backslash terminates the value early and corrupts every
+        // later scope in the same document.
+        for dll in [#"d3d11""#, #"d3d11\"#, "d3d11]\n[HKCU\\Evil", "", "d3d 11", "d3d11;dxgi"] {
+            XCTAssertFalse(Wine.isRenderable(dll: dll, mode: "native"), dll.debugDescription)
+        }
+        for mode in [#"native""#, #"n\b"#, "native]"] {
+            XCTAssertFalse(Wine.isRenderable(dll: "d3d11", mode: mode), mode.debugDescription)
+        }
+    }
+
+    func testOneBadOverrideDoesNotTakeTheDocumentDown() {
+        let doc = Wine.registryDocument(for: [
+            (key: #"HKCU\A"#, overrides: [#"bad"name"#: "native", "d3d11": "native,builtin"])
+        ])
+        XCTAssertTrue(doc.contains(#""d3d11"="native,builtin""#), "the good override must survive")
+        XCTAssertFalse(doc.contains("bad"), "the unrenderable one must be dropped")
+        // Exactly one value line, so nothing was left half-written.
+        XCTAssertEqual(doc.components(separatedBy: "\r\n").filter { $0.hasPrefix("\"") }.count, 1)
+    }
+
+    func testScopeWhoseOverridesAreAllUnrenderableIsStillPruned() {
+        let doc = Wine.registryDocument(for: [(key: #"HKCU\A"#, overrides: [#"bad"name"#: "native"])])
+        XCTAssertTrue(doc.contains(#"[-HKCU\A]"#), "the prune must still be emitted")
+        XCTAssertFalse(doc.contains(#"[HKCU\A]"#), "no empty key should be recreated")
+    }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideRegistryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideRegistryTests.swift
@@ -84,4 +84,90 @@ final class DLLOverrideRegistryTests: XCTestCase {
         let parsed = Wine.parseDLLOverrides("d3d11=n,b;d3d11=b")
         XCTAssertEqual(parsed["d3d11"], "b")
     }
+
+    // MARK: - reg query output
+
+    func testParsesRegQueryOutput() {
+        let output = """
+        HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides
+            d3d11    REG_SZ    n,b
+            dxgi    REG_SZ    n,b
+        """
+        let parsed = Wine.parseRegistryQueryOutput(output)
+        XCTAssertEqual(parsed, ["d3d11": "n,b", "dxgi": "n,b"])
+    }
+
+    /// A disabled override has no value column at all, and must come back as
+    /// an empty string rather than being dropped.
+    func testParsesValuelessEntryAsDisabled() {
+        let parsed = Wine.parseRegistryQueryOutput("    mscoree    REG_SZ")
+        XCTAssertEqual(parsed, ["mscoree": ""])
+    }
+
+    func testIgnoresHeaderAndBlankLines() {
+        let output = """
+
+        HKEY_CURRENT_USER\\Software\\Wine\\AppDefaults\\steam.exe\\DllOverrides
+
+            d3d11    REG_SZ    n,b
+
+        """
+        XCTAssertEqual(Wine.parseRegistryQueryOutput(output), ["d3d11": "n,b"])
+    }
+
+    func testEmptyQueryOutputYieldsNothing() {
+        XCTAssertTrue(Wine.parseRegistryQueryOutput("").isEmpty)
+    }
+
+    // MARK: - Sync plan
+
+    func testWritesEverythingWhenTheKeyIsEmpty() {
+        let plan = Wine.syncPlan(existing: [:], wanted: ["d3d11": "n,b", "dxgi": "n,b"])
+        XCTAssertEqual(plan.writes.map(\.dll), ["d3d11", "dxgi"])
+        XCTAssertTrue(plan.deletes.isEmpty)
+        XCTAssertFalse(plan.isEmpty)
+    }
+
+    /// Launches are frequent and the overrides rarely change, so an unchanged
+    /// key must produce no wine processes at all.
+    func testNoWorkWhenAlreadyCorrect() {
+        let same = ["d3d11": "n,b", "dxgi": "n,b"]
+        XCTAssertTrue(Wine.syncPlan(existing: same, wanted: same).isEmpty)
+    }
+
+    func testWritesOnlyWhatChanged() {
+        let plan = Wine.syncPlan(
+            existing: ["d3d11": "n,b", "dxgi": "n,b"],
+            wanted: ["d3d11": "n,b", "dxgi": "b"]
+        )
+        XCTAssertEqual(plan.writes.map(\.dll), ["dxgi"])
+        XCTAssertEqual(plan.writes.map(\.mode), ["b"])
+        XCTAssertTrue(plan.deletes.isEmpty)
+    }
+
+    /// Switching DXVK to DXMT: DXMT's preset does not mention d3d9, so DXVK's
+    /// entry has to be removed rather than left behind.
+    func testPrunesEntriesTheNewBackendDoesNotWant() {
+        let plan = Wine.syncPlan(
+            existing: ["d3d11": "n,b", "d3d9": "n,b", "d3d10core": "n,b", "dxgi": "n,b"],
+            wanted: ["d3d11": "n,b", "d3d10core": "n,b", "dxgi": "n,b", "winemetal": "b"]
+        )
+        XCTAssertEqual(plan.deletes, ["d3d9"])
+        XCTAssertEqual(plan.writes.map(\.dll), ["winemetal"])
+    }
+
+    func testClearingWantedRemovesEverything() {
+        let plan = Wine.syncPlan(existing: ["d3d11": "n,b", "dxgi": "n,b"], wanted: [:])
+        XCTAssertEqual(plan.deletes, ["d3d11", "dxgi"])
+        XCTAssertTrue(plan.writes.isEmpty)
+    }
+
+    func testPlanIsDeterministicallyOrdered() {
+        let plan = Wine.syncPlan(
+            existing: ["zzz": "b", "aaa": "b"],
+            wanted: ["dxgi": "n,b", "d3d11": "n,b", "d3d9": "n,b"]
+        )
+        XCTAssertEqual(plan.writes.map(\.dll), ["d3d11", "d3d9", "dxgi"])
+        XCTAssertEqual(plan.deletes, ["aaa", "zzz"])
+    }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideRegistryTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideRegistryTests.swift
@@ -115,89 +115,56 @@ final class DLLOverrideRegistryTests: XCTestCase {
         }
     }
 
-    // MARK: - reg query output
+    // MARK: - Registry document
 
-    func testParsesRegQueryOutput() {
-        let output = """
-        HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides
-            d3d11    REG_SZ    n,b
-            dxgi    REG_SZ    n,b
-        """
-        let parsed = Wine.parseRegistryQueryOutput(output)
-        XCTAssertEqual(parsed, ["d3d11": "n,b", "dxgi": "n,b"])
+    func testDocumentReplacesEachKey() {
+        let doc = Wine.registryDocument(for: [
+            (key: #"HKCU\Software\Wine\DllOverrides"#, overrides: ["d3d11": "n,b"])
+        ])
+        XCTAssertTrue(doc.hasPrefix("Windows Registry Editor Version 5.00"))
+        // the delete has to come before the write, or it removes what it just wrote
+        let deleteAt = doc.range(of: #"[-HKCU\Software\Wine\DllOverrides]"#)
+        let writeAt = doc.range(of: #"[HKCU\Software\Wine\DllOverrides]"#)
+        XCTAssertNotNil(deleteAt)
+        XCTAssertNotNil(writeAt)
+        if let deleteAt, let writeAt {
+            XCTAssertLessThan(deleteAt.lowerBound, writeAt.lowerBound)
+        }
+        XCTAssertTrue(doc.contains(#""d3d11"="n,b""#))
     }
 
-    /// A disabled override has no value column at all, and must come back as
-    /// an empty string rather than being dropped.
-    func testParsesValuelessEntryAsDisabled() {
-        let parsed = Wine.parseRegistryQueryOutput("    mscoree    REG_SZ")
-        XCTAssertEqual(parsed, ["mscoree": ""])
+    /// An empty scope must still be deleted, since clearing a backend has to
+    /// remove what the previous one wrote.
+    func testEmptyScopeDeletesWithoutRewriting() {
+        let doc = Wine.registryDocument(for: [(key: #"HKCU\X"#, overrides: [:])])
+        XCTAssertTrue(doc.contains(#"[-HKCU\X]"#))
+        XCTAssertFalse(doc.contains("\r\n[HKCU\\X]"))
     }
 
-    func testIgnoresHeaderAndBlankLines() {
-        let output = """
-
-        HKEY_CURRENT_USER\\Software\\Wine\\AppDefaults\\steam.exe\\DllOverrides
-
-            d3d11    REG_SZ    n,b
-
-        """
-        XCTAssertEqual(Wine.parseRegistryQueryOutput(output), ["d3d11": "n,b"])
+    func testAllScopesLandInOneDocument() {
+        let doc = Wine.registryDocument(for: [
+            (key: #"HKCU\A"#, overrides: ["d3d11": "n,b"]),
+            (key: #"HKCU\B"#, overrides: ["dxgi": "b"])
+        ])
+        XCTAssertTrue(doc.contains(#"[HKCU\A]"#))
+        XCTAssertTrue(doc.contains(#"[HKCU\B]"#))
+        XCTAssertTrue(doc.contains(#""dxgi"="b""#))
     }
 
-    func testEmptyQueryOutputYieldsNothing() {
-        XCTAssertTrue(Wine.parseRegistryQueryOutput("").isEmpty)
+    func testValuesAreOrderedDeterministically() {
+        let doc = Wine.registryDocument(for: [
+            (key: #"HKCU\A"#, overrides: ["dxgi": "b", "d3d11": "n,b", "d3d9": "n,b"])
+        ])
+        guard let d3d11 = doc.range(of: #""d3d11""#)?.lowerBound,
+              let d3d9 = doc.range(of: #""d3d9""#)?.lowerBound,
+              let dxgi = doc.range(of: #""dxgi""#)?.lowerBound
+        else { return XCTFail("document is missing one of the overrides") }
+        XCTAssertLessThan(d3d11, d3d9)
+        XCTAssertLessThan(d3d9, dxgi)
     }
 
-    // MARK: - Sync plan
-
-    func testWritesEverythingWhenTheKeyIsEmpty() {
-        let plan = Wine.syncPlan(existing: [:], wanted: ["d3d11": "n,b", "dxgi": "n,b"])
-        XCTAssertEqual(plan.writes.map(\.dll), ["d3d11", "dxgi"])
-        XCTAssertTrue(plan.deletes.isEmpty)
-        XCTAssertFalse(plan.isEmpty)
-    }
-
-    /// Launches are frequent and the overrides rarely change, so an unchanged
-    /// key must produce no wine processes at all.
-    func testNoWorkWhenAlreadyCorrect() {
-        let same = ["d3d11": "n,b", "dxgi": "n,b"]
-        XCTAssertTrue(Wine.syncPlan(existing: same, wanted: same).isEmpty)
-    }
-
-    func testWritesOnlyWhatChanged() {
-        let plan = Wine.syncPlan(
-            existing: ["d3d11": "n,b", "dxgi": "n,b"],
-            wanted: ["d3d11": "n,b", "dxgi": "b"]
-        )
-        XCTAssertEqual(plan.writes.map(\.dll), ["dxgi"])
-        XCTAssertEqual(plan.writes.map(\.mode), ["b"])
-        XCTAssertTrue(plan.deletes.isEmpty)
-    }
-
-    /// Switching DXVK to DXMT: DXMT's preset does not mention d3d9, so DXVK's
-    /// entry has to be removed rather than left behind.
-    func testPrunesEntriesTheNewBackendDoesNotWant() {
-        let plan = Wine.syncPlan(
-            existing: ["d3d11": "n,b", "d3d9": "n,b", "d3d10core": "n,b", "dxgi": "n,b"],
-            wanted: ["d3d11": "n,b", "d3d10core": "n,b", "dxgi": "n,b", "winemetal": "b"]
-        )
-        XCTAssertEqual(plan.deletes, ["d3d9"])
-        XCTAssertEqual(plan.writes.map(\.dll), ["winemetal"])
-    }
-
-    func testClearingWantedRemovesEverything() {
-        let plan = Wine.syncPlan(existing: ["d3d11": "n,b", "dxgi": "n,b"], wanted: [:])
-        XCTAssertEqual(plan.deletes, ["d3d11", "dxgi"])
-        XCTAssertTrue(plan.writes.isEmpty)
-    }
-
-    func testPlanIsDeterministicallyOrdered() {
-        let plan = Wine.syncPlan(
-            existing: ["zzz": "b", "aaa": "b"],
-            wanted: ["dxgi": "n,b", "d3d11": "n,b", "d3d9": "n,b"]
-        )
-        XCTAssertEqual(plan.writes.map(\.dll), ["d3d11", "d3d9", "dxgi"])
-        XCTAssertEqual(plan.deletes, ["aaa", "zzz"])
+    func testDocumentUsesCRLF() {
+        let doc = Wine.registryDocument(for: [(key: #"HKCU\A"#, overrides: ["d3d11": "n,b"])])
+        XCTAssertTrue(doc.contains("\r\n"))
     }
 }


### PR DESCRIPTION
closes #184

the graphics backend went out as `WINEDLLOVERRIDES`, which every child process inherits, so a launcher's backend became every game's backend. wine reads the variable before the registry too, so a hand-written `AppDefaults` entry was dead while it was set.

now at launch the bottle's overrides go to `HKCU\Software\Wine\DllOverrides` (the prefix default, still inherited by a child with no entry of its own) and the launched program's resolved set goes to `AppDefaults\<exe>\DllOverrides` (inherited by nothing). the sync prunes what the previous backend left behind, and skips writing when the key already matches so a launch doesn't spawn a wine process per dll.

tested: 1221 xctest tests pass, swiftlint strict clean. on a gptk runtime, steam on DXVK and a dx12 title on d3dmetal now work in the same bottle, which no single bottle setting could do before.
