### PR TITLE
fix: show the managed dll overrides the selected backend actually applies

### DIFF
--- a/Whisky/Views/Bottle/DLLOverrideConfigSection.swift
+++ b/Whisky/Views/Bottle/DLLOverrideConfigSection.swift
@@ -41,11 +41,9 @@ struct DLLOverrideConfigSection: View {
     private var computedManagedOverrides: [(entry: DLLOverrideEntry, source: String)] {
         var managed: [(entry: DLLOverrideEntry, source: String)] = []
 
-        // Follow the graphics backend, not the legacy `dxvk` flag. The launch
-        // path only honours that flag when no backend is set, so reading it
-        // here listed overrides that disagreed with what actually gets applied:
-        // a DXMT bottle showed none, and a D3DMetal bottle with a stale flag
-        // showed DXVK's four.
+        // The backend, not the legacy `dxvk` flag: the launch path only honours
+        // that flag when no backend is set, so reading it here listed
+        // overrides that were not the ones being applied.
         let backend = bottle.settings.graphicsBackend == .recommended
             ? GraphicsBackendResolver.resolve()
             : bottle.settings.graphicsBackend

--- a/Whisky/Views/Bottle/DLLOverrideConfigSection.swift
+++ b/Whisky/Views/Bottle/DLLOverrideConfigSection.swift
@@ -37,18 +37,20 @@ struct DLLOverrideConfigSection: View {
         }
     }
 
-    /// Computes managed overrides from bottle state (DXVK toggle, launcher presets).
+    /// Computes managed overrides from bottle state (graphics backend, launcher presets).
     private var computedManagedOverrides: [(entry: DLLOverrideEntry, source: String)] {
         var managed: [(entry: DLLOverrideEntry, source: String)] = []
 
-        // DXVK managed entries
-        if bottle.settings.dxvk {
-            for entry in DLLOverrideResolver.dxvkPreset {
-                managed.append((
-                    entry: entry,
-                    source: String(localized: "config.dllOverrides.source.dxvk")
-                ))
-            }
+        // Follow the graphics backend, not the legacy `dxvk` flag. The launch
+        // path only honours that flag when no backend is set, so reading it
+        // here listed overrides that disagreed with what actually gets applied:
+        // a DXMT bottle showed none, and a D3DMetal bottle with a stale flag
+        // showed DXVK's four.
+        let backend = bottle.settings.graphicsBackend == .recommended
+            ? GraphicsBackendResolver.resolve()
+            : bottle.settings.graphicsBackend
+        for entry in DLLOverrideResolver.managedPreset(for: backend) {
+            managed.append((entry: entry, source: backend.displayName))
         }
 
         // Launcher managed entries (when launcher requires DXVK and autoEnableDXVK is on)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/DLLOverride.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/DLLOverride.swift
@@ -173,6 +173,26 @@ public struct DLLOverrideResolver: Sendable {
         ]
     }
 
+    /// The DLL overrides a graphics backend contributes at bottle level.
+    ///
+    /// D3DMetal and WineD3D contribute none: both run on Wine's builtin D3D and
+    /// select between themselves with the `WINED3DMETAL` environment variable
+    /// rather than by overriding DLLs.
+    ///
+    /// Callers must resolve `.recommended` to a concrete backend first,
+    /// otherwise a bottle that never chose one is credited with no overrides
+    /// while its resolved backend applies some.
+    public static func managedPreset(for backend: GraphicsBackend) -> [DLLOverrideEntry] {
+        switch backend {
+        case .dxvk:
+            dxvkPreset
+        case .dxmt:
+            dxmtPreset
+        case .d3dMetal, .wined3d, .recommended:
+            []
+        }
+    }
+
     // swiftlint:disable cyclomatic_complexity
 
     /// Resolves all override sources into a `WINEDLLOVERRIDES` string and warnings.

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/DLLOverride.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/DLLOverride.swift
@@ -176,12 +176,8 @@ public struct DLLOverrideResolver: Sendable {
     /// The DLL overrides a graphics backend contributes at bottle level.
     ///
     /// D3DMetal and WineD3D contribute none: both run on Wine's builtin D3D and
-    /// select between themselves with the `WINED3DMETAL` environment variable
-    /// rather than by overriding DLLs.
-    ///
-    /// Callers must resolve `.recommended` to a concrete backend first,
-    /// otherwise a bottle that never chose one is credited with no overrides
-    /// while its resolved backend applies some.
+    /// pick between themselves with `WINED3DMETAL`. Resolve `.recommended`
+    /// before calling, or a bottle gets credited with the wrong set.
     public static func managedPreset(for backend: GraphicsBackend) -> [DLLOverrideEntry] {
         switch backend {
         case .dxvk:

--- a/WhiskyKit/Tests/WhiskyKitTests/ManagedPresetTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ManagedPresetTests.swift
@@ -1,0 +1,65 @@
+//
+//  ManagedPresetTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+final class ManagedPresetTests: XCTestCase {
+    func testDXVKBackendContributesTheDXVKPreset() {
+        let preset = DLLOverrideResolver.managedPreset(for: .dxvk)
+        XCTAssertEqual(preset.map(\.dllName).sorted(), ["d3d10core", "d3d11", "d3d9", "dxgi"])
+    }
+
+    /// The case the config section used to miss entirely: a DXMT bottle applies
+    /// four overrides at launch and the UI listed none of them.
+    func testDXMTBackendContributesTheDXMTPreset() {
+        let preset = DLLOverrideResolver.managedPreset(for: .dxmt)
+        XCTAssertEqual(preset.map(\.dllName).sorted(), ["d3d10core", "d3d11", "dxgi", "winemetal"])
+    }
+
+    /// D3DMetal and WineD3D both run on Wine's builtin D3D and pick between
+    /// themselves with WINED3DMETAL, so neither overrides a DLL.
+    func testBuiltinBackendsContributeNothing() {
+        XCTAssertTrue(DLLOverrideResolver.managedPreset(for: .d3dMetal).isEmpty)
+        XCTAssertTrue(DLLOverrideResolver.managedPreset(for: .wined3d).isEmpty)
+    }
+
+    /// `.recommended` is not a backend, it is a deferral. Callers resolve it
+    /// first; answering with a preset here would attribute one bottle's
+    /// overrides to another machine's heuristics.
+    func testRecommendedContributesNothingUnresolved() {
+        XCTAssertTrue(DLLOverrideResolver.managedPreset(for: .recommended).isEmpty)
+    }
+
+    func testPresetMatchesWhatTheResolverApplies() {
+        for backend in [GraphicsBackend.dxvk, .dxmt] {
+            let resolver = DLLOverrideResolver(
+                managed: DLLOverrideResolver.managedPreset(for: backend).map { ($0, .dxvk) },
+                bottleCustom: [],
+                programCustom: []
+            )
+            let (overrides, _) = resolver.resolve()
+            for entry in DLLOverrideResolver.managedPreset(for: backend) {
+                XCTAssertTrue(
+                    overrides.contains("\(entry.dllName)=\(entry.mode.rawValue)"),
+                    "\(backend.displayName) preset lost \(entry.dllName) through the resolver"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
the DLL Overrides section built its managed list from the legacy `dxvk` boolean, but the launch path only honours that flag when no graphics backend is set, and deliberately so. there is already a comment there saying the stale flag would otherwise clobber the explicit backend choice.

so the list could disagree with what actually runs:

- a DXMT bottle showed **no** managed overrides, while four are applied at launch
- a D3DMetal bottle carrying a stale flag showed DXVK's four, which are not applied

it follows the resolved graphics backend now, through a shared `managedPreset(for:)` so the view and the launch path cannot drift apart again. `.recommended` is resolved first, since answering for it would credit a bottle that never picked a backend with whatever this machine's heuristics chose.

d3dmetal and wined3d contribute nothing, which is correct rather than an omission: both run on wine's builtin d3d and select between themselves with `WINED3DMETAL` rather than by overriding dlls.

the source label reuses `GraphicsBackend.displayName`, so DXMT needs no new localisation key.

tested: 1217 xctest tests pass, app target builds, swiftformat and swiftlint strict clean.
