### PR TITLE
fix: resolve .recommended in the program override view

### DIFF
--- a/Whisky/Views/Programs/ProgramOverrideSettingsView.swift
+++ b/Whisky/Views/Programs/ProgramOverrideSettingsView.swift
@@ -274,9 +274,11 @@ struct ProgramOverrideSettingsView: View {
                     }
                 }
 
-                // DXVK sub-controls only when backend is DXVK
-                let overriddenBackend = program.settings.overrides?.graphicsBackend ?? .recommended
-                if overriddenBackend == .dxvk {
+                // DXVK sub-controls only when DXVK is what actually runs.
+                // `.recommended` has to be resolved first: unresolved, a program
+                // left on Recommended that resolves to DXVK hid the very
+                // controls that were in effect.
+                if resolvedOverriddenBackend == .dxvk {
                     graphicsControls
                 }
 
@@ -286,7 +288,9 @@ struct ProgramOverrideSettingsView: View {
                     .foregroundStyle(.secondary)
             } else {
                 inheritedSummary(
-                    "\(bottle.settings.graphicsBackend.displayName), "
+                    // Resolved, not raw: a bottle left on Recommended reported
+                    // "Recommended" here instead of the backend it runs.
+                    "\(resolvedBottleBackend.displayName), "
                         + "DXVK Async \(bottle.settings.dxvkAsync ? "On" : "Off"), "
                         + "HUD \(hudDescription(bottle.settings.dxvkHud))"
                 )
@@ -548,6 +552,20 @@ struct ProgramOverrideSettingsView: View {
         program.settings.overrides?.graphicsBackend != nil
     }
 
+    /// The backend this program actually launches with, with `.recommended`
+    /// resolved to the concrete backend it stands for.
+    private var resolvedOverriddenBackend: GraphicsBackend {
+        let backend = program.settings.overrides?.graphicsBackend ?? .recommended
+        return backend == .recommended ? GraphicsBackendResolver.resolve() : backend
+    }
+
+    /// The bottle's backend, resolved the same way, for the inherited summary.
+    private var resolvedBottleBackend: GraphicsBackend {
+        bottle.settings.graphicsBackend == .recommended
+            ? GraphicsBackendResolver.resolve()
+            : bottle.settings.graphicsBackend
+    }
+
     private var hasSyncOverride: Bool {
         program.settings.overrides?.enhancedSync != nil
     }
@@ -608,7 +626,10 @@ struct ProgramOverrideSettingsView: View {
                 ensureOverrides()
                 if isOn {
                     program.settings.overrides?.graphicsBackend = bottle.settings.graphicsBackend
-                    program.settings.overrides?.dxvk = bottle.settings.dxvk
+                    // `dxvk` is deliberately not seeded: the launch path only
+                    // honours it when no backend override is set, and one is
+                    // being set right here, so copying it writes state that can
+                    // never take effect. It is still cleared below.
                     program.settings.overrides?.dxvkAsync = bottle.settings.dxvkAsync
                     program.settings.overrides?.dxvkHud = bottle.settings.dxvkHud
                 } else {
@@ -716,13 +737,6 @@ struct ProgramOverrideSettingsView: View {
         Binding(
             get: { program.settings.overrides?.graphicsBackend ?? bottle.settings.graphicsBackend },
             set: { program.settings.overrides?.graphicsBackend = $0 }
-        )
-    }
-
-    private var dxvkBinding: Binding<Bool> {
-        Binding(
-            get: { program.settings.overrides?.dxvk ?? bottle.settings.dxvk },
-            set: { program.settings.overrides?.dxvk = $0 }
         )
     }
 

--- a/Whisky/Views/Programs/ProgramOverrideSettingsView.swift
+++ b/Whisky/Views/Programs/ProgramOverrideSettingsView.swift
@@ -274,10 +274,8 @@ struct ProgramOverrideSettingsView: View {
                     }
                 }
 
-                // DXVK sub-controls only when DXVK is what actually runs.
-                // `.recommended` has to be resolved first: unresolved, a program
-                // left on Recommended that resolves to DXVK hid the very
-                // controls that were in effect.
+                // Resolved, so a program on Recommended that runs DXVK does
+                // not hide the controls that are in effect.
                 if resolvedOverriddenBackend == .dxvk {
                     graphicsControls
                 }
@@ -288,8 +286,7 @@ struct ProgramOverrideSettingsView: View {
                     .foregroundStyle(.secondary)
             } else {
                 inheritedSummary(
-                    // Resolved, not raw: a bottle left on Recommended reported
-                    // "Recommended" here instead of the backend it runs.
+                    // Resolved, or a bottle on Recommended reports "Recommended".
                     "\(resolvedBottleBackend.displayName), "
                         + "DXVK Async \(bottle.settings.dxvkAsync ? "On" : "Off"), "
                         + "HUD \(hudDescription(bottle.settings.dxvkHud))"
@@ -552,14 +549,13 @@ struct ProgramOverrideSettingsView: View {
         program.settings.overrides?.graphicsBackend != nil
     }
 
-    /// The backend this program actually launches with, with `.recommended`
-    /// resolved to the concrete backend it stands for.
+    /// The backend this program actually launches with.
     private var resolvedOverriddenBackend: GraphicsBackend {
         let backend = program.settings.overrides?.graphicsBackend ?? .recommended
         return backend == .recommended ? GraphicsBackendResolver.resolve() : backend
     }
 
-    /// The bottle's backend, resolved the same way, for the inherited summary.
+    /// The bottle's backend, resolved, for the inherited summary.
     private var resolvedBottleBackend: GraphicsBackend {
         bottle.settings.graphicsBackend == .recommended
             ? GraphicsBackendResolver.resolve()
@@ -626,10 +622,8 @@ struct ProgramOverrideSettingsView: View {
                 ensureOverrides()
                 if isOn {
                     program.settings.overrides?.graphicsBackend = bottle.settings.graphicsBackend
-                    // `dxvk` is deliberately not seeded: the launch path only
-                    // honours it when no backend override is set, and one is
-                    // being set right here, so copying it writes state that can
-                    // never take effect. It is still cleared below.
+                    // `dxvk` is not seeded: the launch path ignores it whenever
+                    // a backend override is set, and one is set right here.
                     program.settings.overrides?.dxvkAsync = bottle.settings.dxvkAsync
                     program.settings.overrides?.dxvkHud = bottle.settings.dxvkHud
                 } else {


### PR DESCRIPTION
`.recommended` is not a backend, it is a deferral, and this view compared it as though it were one. two places reported the wrong thing:

- the DXVK sub-controls were shown only when the override read literally `.dxvk`, so a program left on Recommended that resolves to DXVK hid the async and HUD controls that were actually in effect
- the inherited summary printed the bottle's raw selection, so a bottle on Recommended read "Recommended" rather than the backend it runs

the bottle-level graphics section already resolves for its own helper text, so these just match it now.

also drops `dxvkBinding`, defined and never used, and stops seeding `overrides.dxvk` when a graphics override is switched on: the launch path only honours that flag when no backend override is set, and one is set on the very next line, so it could never take effect. it is still cleared when the override is switched off, so a legacy value already stored goes away.

tested: app target builds, 1212 xctest tests pass, swiftformat and swiftlint strict clean.
