### PR TITLE
feat: launchers default to dxvk when d3dmetal is installed

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Wine/GraphicsBackendResolver.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/GraphicsBackendResolver.swift
@@ -48,14 +48,9 @@ public enum GraphicsBackendResolver {
         d3dMetalInstalled: Bool = WhiskyWineInstaller.isD3DMetalInstalled()
     ) -> GraphicsBackend {
         if d3dMetalInstalled {
-            // Launcher clients are Chromium, and Chromium cannot render on
-            // D3DMetal: the window is created, the process tree looks healthy,
-            // and nothing ever paints. Measured on Steam, whose client sat at
-            // luma 0.0 indefinitely with nine processes running.
-            //
-            // Only the launcher itself. Games it starts still resolve to
-            // D3DMetal, which is the reason to have it installed at all, and
-            // per-executable overrides are what keep the two apart.
+            // Launcher clients are Chromium and cannot render on D3DMetal:
+            // the window comes up and never paints. Games they start still get
+            // D3DMetal.
             if launcher != nil {
                 return .dxvk
             }

--- a/WhiskyKit/Sources/WhiskyKit/Wine/GraphicsBackendResolver.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/GraphicsBackendResolver.swift
@@ -42,11 +42,23 @@ public enum GraphicsBackendResolver {
     ///     to checking the installed runtime.
     /// - Returns: A concrete ``GraphicsBackend`` (never `.recommended`).
     public static func resolve(
+        for launcher: LauncherType? = nil,
         macOSVersion: MacOSVersion = .current,
         runtimeInfo: WhiskyWineVersion? = WhiskyWineInstaller.whiskyWineInfo(),
         d3dMetalInstalled: Bool = WhiskyWineInstaller.isD3DMetalInstalled()
     ) -> GraphicsBackend {
         if d3dMetalInstalled {
+            // Launcher clients are Chromium, and Chromium cannot render on
+            // D3DMetal: the window is created, the process tree looks healthy,
+            // and nothing ever paints. Measured on Steam, whose client sat at
+            // luma 0.0 indefinitely with nine processes running.
+            //
+            // Only the launcher itself. Games it starts still resolve to
+            // D3DMetal, which is the reason to have it installed at all, and
+            // per-executable overrides are what keep the two apart.
+            if launcher != nil {
+                return .dxvk
+            }
             return .d3dMetal
         }
         if GraphicsBackend.dxmt.isAvailable(runtimeInfo: runtimeInfo) {

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -258,6 +258,18 @@ public class Wine {
             ? GraphicsBackendResolver.resolve(for: LauncherType.detect(from: url))
             : effectiveBackendChoice
 
+        // The bottle composes its DLL overrides from its own resolution, which
+        // knows nothing about what is being launched, so a launcher steered
+        // onto DXVK above would have had DXVK's files deployed and none of its
+        // overrides set. Pin the decision as a program-level override so the
+        // two halves agree.
+        var programOverrides = programOverrides
+        if effectiveBackendChoice == .recommended, effectiveBackend != GraphicsBackendResolver.resolve() {
+            var pinned = programOverrides ?? ProgramOverrides()
+            pinned.graphicsBackend = effectiveBackend
+            programOverrides = pinned
+        }
+
         // DXMT first: if launcher auto-DXVK also fires below (e.g. Rockstar),
         // DXVK's file copy deterministically wins, matching the override-layer
         // order where launcher-managed entries land after bottle-managed ones.

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -249,9 +249,13 @@ public class Wine {
         // over the bottle setting, and `.recommended` resolves to its concrete
         // backend. This decides which translation layer's files are deployed;
         // the matching WINEDLLOVERRIDES come from the environment layers.
+        // `.recommended` resolves against what is being launched, not just the
+        // machine: on a runtime with D3DMetal installed, a launcher's Chromium
+        // client cannot render on it and needs DXVK, while the games it starts
+        // still want D3DMetal.
         let effectiveBackendChoice = programOverrides?.graphicsBackend ?? bottle.settings.graphicsBackend
         let effectiveBackend = effectiveBackendChoice == .recommended
-            ? GraphicsBackendResolver.resolve()
+            ? GraphicsBackendResolver.resolve(for: LauncherType.detect(from: url))
             : effectiveBackendChoice
 
         // DXMT first: if launcher auto-DXVK also fires below (e.g. Rockstar),

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -250,19 +250,15 @@ public class Wine {
         // backend. This decides which translation layer's files are deployed;
         // the matching WINEDLLOVERRIDES come from the environment layers.
         // `.recommended` resolves against what is being launched, not just the
-        // machine: on a runtime with D3DMetal installed, a launcher's Chromium
-        // client cannot render on it and needs DXVK, while the games it starts
-        // still want D3DMetal.
+        // machine.
         let effectiveBackendChoice = programOverrides?.graphicsBackend ?? bottle.settings.graphicsBackend
         let effectiveBackend = effectiveBackendChoice == .recommended
             ? GraphicsBackendResolver.resolve(for: LauncherType.detect(from: url))
             : effectiveBackendChoice
 
-        // The bottle composes its DLL overrides from its own resolution, which
-        // knows nothing about what is being launched, so a launcher steered
-        // onto DXVK above would have had DXVK's files deployed and none of its
-        // overrides set. Pin the decision as a program-level override so the
-        // two halves agree.
+        // The bottle composes its overrides from its own resolution, which does
+        // not know what is being launched, so pin the decision here or a
+        // steered launcher gets DXVK's files and none of its overrides.
         var programOverrides = programOverrides
         if effectiveBackendChoice == .recommended, effectiveBackend != GraphicsBackendResolver.resolve() {
             var pinned = programOverrides ?? ProgramOverrides()

--- a/WhiskyKit/Tests/WhiskyKitTests/BackendResolverLauncherTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BackendResolverLauncherTests.swift
@@ -1,0 +1,82 @@
+//
+//  BackendResolverLauncherTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+final class BackendResolverLauncherTests: XCTestCase {
+    /// The whole point: with D3DMetal installed a game gets it, because that is
+    /// the reason to install it.
+    func testGameGetsD3DMetalWhenInstalled() {
+        let backend = GraphicsBackendResolver.resolve(for: nil, d3dMetalInstalled: true)
+        XCTAssertEqual(backend, .d3dMetal)
+    }
+
+    /// And a launcher does not. Chromium cannot render on D3DMetal: the window
+    /// comes up, the process tree looks healthy, nothing paints.
+    func testLauncherGetsDXVKWhenD3DMetalIsInstalled() {
+        for launcher in LauncherType.allCases {
+            XCTAssertEqual(
+                GraphicsBackendResolver.resolve(for: launcher, d3dMetalInstalled: true),
+                .dxvk,
+                "\(launcher.displayName) resolved to a backend its client cannot render on"
+            )
+        }
+    }
+
+    /// Without D3DMetal there is nothing to steer around, so a launcher
+    /// resolves exactly like anything else.
+    func testLauncherIsNotSpecialWithoutD3DMetal() {
+        let game = GraphicsBackendResolver.resolve(for: nil, d3dMetalInstalled: false)
+        let launcher = GraphicsBackendResolver.resolve(for: .steam, d3dMetalInstalled: false)
+        XCTAssertEqual(game, launcher)
+    }
+
+    /// Callers that pass nothing keep the old behaviour, so every existing
+    /// call site is unaffected.
+    func testDefaultArgumentMatchesTheGameCase() {
+        XCTAssertEqual(
+            GraphicsBackendResolver.resolve(d3dMetalInstalled: true),
+            GraphicsBackendResolver.resolve(for: nil, d3dMetalInstalled: true)
+        )
+    }
+
+    /// A game inside a Steam library is not the Steam client, so it must not
+    /// be steered onto DXVK.
+    func testSteamLibraryGameResolvesAsAGame() {
+        let url = URL(filePath: "/B/Steam/steamapps/common/Some Game/game.exe")
+        XCTAssertNil(LauncherType.detect(from: url))
+        XCTAssertEqual(
+            GraphicsBackendResolver.resolve(
+                for: LauncherType.detect(from: url), d3dMetalInstalled: true
+            ),
+            .d3dMetal
+        )
+    }
+
+    func testSteamClientResolvesAsALauncher() {
+        let url = URL(filePath: "/B/Steam/steam.exe")
+        XCTAssertEqual(LauncherType.detect(from: url), .steam)
+        XCTAssertEqual(
+            GraphicsBackendResolver.resolve(
+                for: LauncherType.detect(from: url), d3dMetalInstalled: true
+            ),
+            .dxvk
+        )
+    }
+}


### PR DESCRIPTION
with d3dmetal installed, Recommended resolved to it for everything, launchers included. their clients are chromium, and chromium cannot render on d3dmetal: the window is created, the process tree looks healthy, and nothing ever paints. measured on steam, whose client sat at luma 0.0 with nine processes alive.

Recommended now resolves against what is being launched. a launcher gets DXVK, and the games it starts still get d3dmetal, which is the reason to have it installed at all. without d3dmetal there is nothing to steer around, so a launcher resolves like anything else.

detection is the existing `LauncherType.detect`, which already excludes `steamapps/common`, so a game inside a steam library is correctly not the steam client. the new parameter defaults to nil and every existing call site keeps the behaviour it had.

this is what a gptk user currently has to arrive at by hand: set the bottle to d3dmetal, then override the launcher back to DXVK. with #185 landed it is expressible; with this it is the default.

tested: 1218 xctest tests pass, app target builds, swiftformat and swiftlint strict clean.
