### PR TITLE
fix: fall back to the regular capacity figure on external volumes

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLocationValidation.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLocationValidation.swift
@@ -132,7 +132,7 @@ public enum BottleLocationValidation {
 
         if isExternalOrCustom {
             if let values = try? directory.resourceValues(forKeys: [.volumeAvailableCapacityKey]),
-                let basic = values.volumeAvailableCapacity {
+               let basic = values.volumeAvailableCapacity {
                 return Int64(basic)
             }
             return nil

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLocationValidation.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLocationValidation.swift
@@ -122,7 +122,22 @@ public enum BottleLocationValidation {
 
     /// Reads available capacity, preferring the "important usage" figure (which
     /// counts purgeable space, so it errs optimistic and won't false-positive).
+    /// However, that sometimes doesn't work on removable drives, so we fall
+    /// back to normal figure.
     private static func availableCapacity(at directory: URL) -> Int64? {
+        let isExternalOrCustom: Bool = {
+            guard let values = try? directory.resourceValues(forKeys: [.volumeIsInternalKey]) else { return false }
+            return values.volumeIsInternal == false
+        }()
+
+        if isExternalOrCustom {
+            if let values = try? directory.resourceValues(forKeys: [.volumeAvailableCapacityKey]),
+                let basic = values.volumeAvailableCapacity {
+                return Int64(basic)
+            }
+            return nil
+        }
+
         let keys: Set<URLResourceKey> = [
             .volumeAvailableCapacityForImportantUsageKey,
             .volumeAvailableCapacityKey


### PR DESCRIPTION
by @glutesha, opened on my fork as dappermint/Whisky#1 and forwarded here with their commit intact, since it fixes upstream too.

the important usage figure counts purgeable space and is an apfs facility. on a removable drive it can come back as zero while the disk is healthy and has room, and `availableCapacity` returned it without looking further, so bottle creation refused the drive as full.

we hit this on an exfat stick. the app log shows what is behind it:

```
CacheDeleteCopyAvailableSpaceForVolume ENTRY, volume: /Volumes/Netac
CacheDeleteCopyAvailableSpaceForVolume failed for volume /Volumes/Netac:
  Error Domain=CacheDeleteErrorDomain Code=10 {Invalid volume=/Volumes/Netac}
```

CacheDelete is the service the important usage key reads through, and there is nothing behind it on a non apfs volume, so it was never going to answer. the fallback goes to `volumeAvailableCapacityKey` on external volumes and leaves the internal path alone.

one commit of mine on top, a single space of continuation indent that swiftformat wanted. their logic is untouched. suite green, 1217.
