### PR TITLE
fix: volumeIsInternal is nil on the volumes both new checks care about

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLocationValidation.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleLocationValidation.swift
@@ -162,7 +162,13 @@ public enum BottleLocationValidation {
         guard let volume = try? url.resourceValues(forKeys: [.volumeURLKey]).volume,
               let values = try? volume.resourceValues(forKeys: [.volumeIsInternalKey, .volumeIsLocalKey])
         else { return false }
-        return values.volumeIsLocal == false || values.volumeIsInternal == false
+        // `volumeIsInternal` is nil, not false, on volumes macOS cannot place on a
+        // bus: disk images and some enclosures report that way. Comparing it to
+        // false therefore classified exactly the gated volumes as internal, so
+        // nothing was ever reported as a consent problem. Only a definite true
+        // rules a volume out.
+        if values.volumeIsLocal == false { return true }
+        return values.volumeIsInternal != true
     }
 
     /// Reads available capacity, preferring the "important usage" figure (which
@@ -172,7 +178,8 @@ public enum BottleLocationValidation {
     private static func availableCapacity(at directory: URL) -> Int64? {
         let isExternalOrCustom: Bool = {
             guard let values = try? directory.resourceValues(forKeys: [.volumeIsInternalKey]) else { return false }
-            return values.volumeIsInternal == false
+            // nil, not false, on the removable volumes this exists for.
+            return values.volumeIsInternal != true
         }()
 
         if isExternalOrCustom {

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleLocationValidationTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleLocationValidationTests.swift
@@ -81,6 +81,60 @@ final class BottleLocationValidationTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(available, 0)
     }
 
+    // MARK: - Against a real volume
+
+    /// Opt-in, because it needs a volume the machine running the suite may not
+    /// have. Point `WHISKY_TEST_VOLUME` at a mounted external or network volume
+    /// to check the classification against the real thing rather than a temp
+    /// directory on the boot disk:
+    ///
+    ///     WHISKY_TEST_VOLUME=/Volumes/MyDrive swift test
+    ///
+    /// A disk image works: `hdiutil create -size 50m -fs APFS -volname T t.dmg`
+    /// then `hdiutil attach t.dmg` mounts as External/Removable.
+    func testRealExternalVolumeIsConsentGated() throws {
+        guard let path = ProcessInfo.processInfo.environment["WHISKY_TEST_VOLUME"] else {
+            throw XCTSkip("set WHISKY_TEST_VOLUME to a mounted external volume")
+        }
+        let volume = URL(fileURLWithPath: path)
+        XCTAssertTrue(
+            BottleLocationValidation.isConsentGatedVolume(volume),
+            "\(path) should be consent gated; is it actually external or a network mount?"
+        )
+    }
+
+    /// The distinction the UI hangs on: on a consent-gated volume a permission
+    /// refusal is `.accessDenied` (privacy can fix it), and anything else is
+    /// `.notWritable` (privacy cannot).
+    func testRealExternalVolumeRefusalIsAccessDenied() throws {
+        guard let path = ProcessInfo.processInfo.environment["WHISKY_TEST_VOLUME"] else {
+            throw XCTSkip("set WHISKY_TEST_VOLUME to a mounted external volume")
+        }
+        let volume = URL(fileURLWithPath: path)
+        let locked = volume.appendingPathComponent("whisky-denied-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: locked, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: locked.path)
+            try? FileManager.default.removeItem(at: locked)
+        }
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: locked.path)
+
+        XCTAssertEqual(BottleLocationValidation.probeWrite(in: locked, fileManager: .default), .denied)
+        guard case .accessDenied = BottleLocationValidation.validate(at: locked, minimumFreeBytes: 0) else {
+            return XCTFail("a permission refusal on a consent gated volume must be .accessDenied")
+        }
+    }
+
+    func testRealExternalVolumeWritesCleanly() throws {
+        guard let path = ProcessInfo.processInfo.environment["WHISKY_TEST_VOLUME"] else {
+            throw XCTSkip("set WHISKY_TEST_VOLUME to a mounted external volume")
+        }
+        let dir = URL(fileURLWithPath: path).appendingPathComponent("whisky-ok-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        XCTAssertEqual(BottleLocationValidation.validate(at: dir, minimumFreeBytes: 0), .valid)
+    }
+
     // MARK: - Permission-shaped refusals
 
     /// The privacy pointer must only appear for a refusal privacy can explain.


### PR DESCRIPTION
follow up to #191 and #192, both of which are broken in the same way and neither of which shows it on a boot disk.

`volumeIsInternal` is nil, not false, when macos cannot place a volume on a bus. a disk image reports exactly that:

```
/Volumes/ConsentTest   isInternal=nil    isLocal=true  isRemovable=true  isEjectable=true
/                      isInternal=true   isLocal=true  isRemovable=false isEjectable=false
```

both call sites compare it to false, and `nil == false` is false in swift, so the removable volumes each check exists for were classified as internal:

- `isConsentGatedVolume` never returned true, so `.accessDenied` was unreachable and the privacy pointer i added in #191 was dead code
- `availableCapacity` never took the fallback branch on an external drive, which is the only case #192 was written for

only a definite `true` rules a volume out now.

i found this by writing the opt-in tests in this pr and pointing them at a real removable volume, which is included here because a temp directory on the boot disk cannot exercise any of it:

```sh
hdiutil create -size 50m -fs APFS -volname T /tmp/t.dmg && hdiutil attach /tmp/t.dmg
TEST_RUNNER_WHISKY_TEST_VOLUME=/Volumes/T xcodebuild test -scheme WhiskyKit -destination 'platform=macOS'
```

they skip when the variable is unset, so ci is unaffected. against /Volumes/T two of the three failed before this change and all three pass after. worth running against a real usb drive too if you have one to hand, since a disk image is only one of the shapes that reports nil.

suite green, 1256 with the three skipped when no volume is given.
