### PR TITLE
install a d3d12 video processor with the gptk payload

### DIFF
--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -66,6 +66,21 @@ struct WhiskyApp: App {
         Telemetry.startIfConsented()
     }
 
+    /// Installs the D3D12 video processor if the GPTK payload is already
+    /// deployed.
+    ///
+    /// Deploying does this too, but an install that was set up before the
+    /// interposer existed never deploys again, so without this it would keep
+    /// rendering video through the engine's broken fallback until it happened
+    /// to reimport. Idempotent, and a no-op on runtimes that ship no interposer.
+    private func installVideoProcessorIfNeeded() {
+        var data = BottleData()
+        let bottles = data.loadBottles().map(\.url)
+        Task.detached(priority: .background) {
+            GPTKImporter.ensureVideoProcessorInstalled(bottles: bottles)
+        }
+    }
+
     var body: some Scene {
         WindowGroup(id: Self.mainWindowID) {
             ContentView(showSetup: $showSetup)
@@ -76,6 +91,7 @@ struct WhiskyApp: App {
                     Task.detached {
                         await WhiskyApp.deleteOldLogs()
                     }
+                    installVideoProcessorIfNeeded()
                     startAudioDeviceListening()
                 }
                 .onReceive(

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
@@ -136,6 +136,12 @@ extension GPTKImporter {
         let originals = store.appending(path: "originals")
         try prepareOriginals(inStore: store, forLibraryFolder: folder)
 
+        // A previous install leaves the interposer in the d3d12 slot, where it
+        // matches neither Wine's DLL nor the store's forwarder. Clear it first
+        // so the loop below sees the tree it expects and never files the
+        // interposer away as if it were Wine's own builtin.
+        removeVideoProcessor(fromLibraryFolder: folder, usingStore: store)
+
         for name in forwarderDLLNames {
             let target = peDir.appending(path: name)
             let backup = originals.appending(path: name)
@@ -170,6 +176,10 @@ extension GPTKImporter {
             try fileManager.removeItem(at: externalDest)
         }
         try fileManager.copyItem(at: storeLib.appending(path: "external"), to: externalDest)
+        // Apple's D3D12 is in place now, which is the only moment the swap can
+        // be made: the runtime ships the interposer but has nothing to forward
+        // into until this point.
+        try installVideoProcessor(intoLibraryFolder: folder)
         logger.info("Deployed GPTK payload into the runtime tree")
     }
 
@@ -202,6 +212,12 @@ extension GPTKImporter {
 
         let originalsAreCurrent = originalsRecord(inStore: store)?.runtimeVersion
             == runtimeVersionStamp(inLibraryFolder: folder)
+
+        // Apple's DLL goes back into the d3d12 slot before the loop reads it,
+        // or the slot still holds the interposer, fails the byte match against
+        // the store, and is skipped: the tree would keep a d3d12 that forwards
+        // to a DLL this call is about to delete.
+        removeVideoProcessor(fromLibraryFolder: folder, usingStore: store)
 
         for name in forwarderDLLNames {
             let backup = originals.appending(path: name)

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+VideoProcessor.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+VideoProcessor.swift
@@ -1,0 +1,287 @@
+//
+//  GPTKImporter+VideoProcessor.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+enum GPTKVideoProcessorError: Error, Equatable {
+    /// The DLL is not shaped like the PE the rename expects.
+    case malformedPE(String)
+    /// The export directory holds a name the rename was not written for.
+    case unexpectedExportName(String)
+}
+
+/// D3DMetal answers `QueryInterface` for `ID3D12VideoDevice` with
+/// `E_NOINTERFACE`, so a game that decodes video itself and asks D3D12 to
+/// convert NV12 to RGB gets nothing and falls back to a path no Windows machine
+/// runs. S.T.A.L.K.E.R. Call of Pripyat EE draws its intro at half resolution
+/// with the chroma flat, the olive artifact.
+///
+/// The runtime ships an interposer that supplies the missing video processor.
+/// It cannot simply be installed at build time: it has to sit in the `d3d12.dll`
+/// builtin slot with Apple's DLL renamed alongside it, and Apple's DLL only
+/// exists once the payload here is deployed. So the swap happens on deploy.
+extension GPTKImporter {
+    /// Where the runtime ships the interposer, if it is new enough to carry one.
+    static let videoProcessorShimPath = ["lib", "gptk-video", "d3d12shim.dll"]
+    /// Apple's D3D12 under its second name. Nine characters, and that is not a
+    /// style choice: the export name is patched in place, so it cannot grow.
+    static let videoDeviceDLLName = "d3dmt.dll"
+    static let videoDeviceUnixName = "d3dmt.so"
+    static let videoProcessorSlotName = "d3d12.dll"
+
+    static func videoProcessorShim(inLibraryFolder folder: URL) -> URL {
+        videoProcessorShimPath.reduce(folder.appending(path: "Wine")) { $0.appending(path: $1) }
+    }
+
+    /// Whether `folder`'s runtime carries an interposer to install at all.
+    /// Runtimes older than the one that introduced it simply do without.
+    static func hasVideoProcessor(inLibraryFolder folder: URL) -> Bool {
+        FileManager.default.fileExists(
+            atPath: videoProcessorShim(inLibraryFolder: folder).path(percentEncoded: false)
+        )
+    }
+
+    /// Whether the interposer currently occupies the `d3d12.dll` slot.
+    static func isVideoProcessorInstalled(inLibraryFolder folder: URL) -> Bool {
+        let peDir = folder.appending(path: "Wine").appending(path: "lib")
+            .appending(path: "wine").appending(path: "x86_64-windows")
+        return FileManager.default.contentsEqual(
+            atPath: peDir.appending(path: videoProcessorSlotName).path(percentEncoded: false),
+            andPath: videoProcessorShim(inLibraryFolder: folder).path(percentEncoded: false)
+        )
+    }
+
+    /// Puts the interposer in the `d3d12.dll` slot with Apple's DLL renamed
+    /// beside it. Expects `d3d12.dll` to be Apple's, which is what deploy leaves
+    /// behind, and does nothing if the runtime ships no interposer or the swap
+    /// is already in place.
+    static func installVideoProcessor(intoLibraryFolder folder: URL) throws {
+        let fileManager = FileManager.default
+        let shim = videoProcessorShim(inLibraryFolder: folder)
+        guard hasVideoProcessor(inLibraryFolder: folder) else { return }
+        guard !isVideoProcessorInstalled(inLibraryFolder: folder) else { return }
+
+        let wineLib = folder.appending(path: "Wine").appending(path: "lib")
+        let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
+        let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
+        let slot = peDir.appending(path: videoProcessorSlotName)
+        let renamed = peDir.appending(path: videoDeviceDLLName)
+
+        guard fileManager.fileExists(atPath: slot.path(percentEncoded: false)) else { return }
+
+        if fileManager.fileExists(atPath: renamed.path(percentEncoded: false)) {
+            try fileManager.removeItem(at: renamed)
+        }
+        try fileManager.copyItem(at: slot, to: renamed)
+        try rewriteExportName(at: renamed, from: videoProcessorSlotName, to: videoDeviceDLLName)
+
+        // The renamed PE needs its own unix half or D3DMetal never binds.
+        let link = unixDir.appending(path: videoDeviceUnixName)
+        try? fileManager.removeItem(at: link)
+        try fileManager.createSymbolicLink(
+            atPath: link.path(percentEncoded: false),
+            withDestinationPath: unixLinkDestination
+        )
+
+        try fileManager.removeItem(at: slot)
+        try fileManager.copyItem(at: shim, to: slot)
+        logger.info("Installed the D3D12 video processor, Apple's D3D12 is now \(videoDeviceDLLName)")
+    }
+
+    /// Takes the interposer back out and restores Apple's DLL into the slot from
+    /// the store, which is the only pristine copy: the renamed one on disk has a
+    /// rewritten export name and cannot go back as `d3d12.dll`.
+    ///
+    /// Removal has to happen before the payload itself is removed, or the slot
+    /// still holds the interposer, does not byte-match the store, and the
+    /// restore loop skips it and leaves the tree with no working D3D12 at all.
+    static func removeVideoProcessor(fromLibraryFolder folder: URL, usingStore store: URL) {
+        let fileManager = FileManager.default
+        let wineLib = folder.appending(path: "Wine").appending(path: "lib")
+        let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
+        let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
+        let slot = peDir.appending(path: videoProcessorSlotName)
+
+        if isVideoProcessorInstalled(inLibraryFolder: folder) {
+            let pristine = store.appending(path: "lib").appending(path: "wine")
+                .appending(path: "x86_64-windows").appending(path: videoProcessorSlotName)
+            if fileManager.fileExists(atPath: pristine.path(percentEncoded: false)) {
+                try? fileManager.removeItem(at: slot)
+                try? fileManager.copyItem(at: pristine, to: slot)
+            }
+        }
+        try? fileManager.removeItem(at: peDir.appending(path: videoDeviceDLLName))
+        try? fileManager.removeItem(at: unixDir.appending(path: videoDeviceUnixName))
+    }
+
+    // MARK: - Prefixes
+
+    /// Drops a placeholder for the renamed DLL into a prefix's `system32`.
+    ///
+    /// Without one the loader never looks in the builtin directory at all and
+    /// the interposer cannot reach Apple's DLL, which would take D3D12 down
+    /// with it. `wineboot` writes these when a prefix is made or updated, so new
+    /// bottles get it for free; bottles that already exist predate the name and
+    /// would otherwise need a prefix update before they could run anything.
+    static func seedVideoDevicePlaceholder(inBottle bottle: URL, fromLibraryFolder folder: URL) {
+        let fileManager = FileManager.default
+        let source = folder.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-windows").appending(path: videoDeviceDLLName)
+        guard fileManager.fileExists(atPath: source.path(percentEncoded: false)) else { return }
+
+        let system32 = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32")
+        guard fileManager.fileExists(atPath: system32.path(percentEncoded: false)) else { return }
+
+        let placeholder = system32.appending(path: videoDeviceDLLName)
+        guard !fileManager.fileExists(atPath: placeholder.path(percentEncoded: false)) else { return }
+        try? fileManager.copyItem(at: source, to: placeholder)
+    }
+
+    /// Installs the video processor if the payload is already deployed, and
+    /// seeds every bottle's placeholder.
+    ///
+    /// This is the path for installs that were already set up before the
+    /// interposer existed: they have the payload deployed and never run a deploy
+    /// again, so without this they would keep rendering video through the
+    /// engine's broken fallback until they happened to reimport. Idempotent and
+    /// cheap enough to run at launch.
+    public static func ensureVideoProcessorInstalled(bottles: [URL]) {
+        let folder = WhiskyWineInstaller.libraryFolder
+        guard isDeployed(inLibraryFolder: folder), hasVideoProcessor(inLibraryFolder: folder) else {
+            return
+        }
+        do {
+            try installVideoProcessor(intoLibraryFolder: folder)
+        } catch {
+            logger.error("Installing the D3D12 video processor failed: \(error.localizedDescription)")
+            return
+        }
+        for bottle in bottles {
+            seedVideoDevicePlaceholder(inBottle: bottle, fromLibraryFolder: folder)
+        }
+    }
+
+    // MARK: - The rename
+
+    /// Rewrites a PE's export directory name in place.
+    ///
+    /// Wine keys builtins on the name a DLL declares in its export directory,
+    /// not on its filename, so a plain copy of Apple's D3D12 still says
+    /// `d3d12.dll` and dedups against the original: `LoadLibrary` hands back the
+    /// module that is already loaded and the interposer forwards into itself.
+    /// Patching in place is what caps the new name at the old one's length.
+    static func rewriteExportName(at url: URL, from old: String, to new: String) throws {
+        let oldBytes = Array(old.utf8), newBytes = Array(new.utf8)
+        guard oldBytes.count == newBytes.count else {
+            throw GPTKVideoProcessorError.malformedPE("the replacement name must be the same length")
+        }
+
+        var data = try Data(contentsOf: url)
+        let image = try PEImage(data: data)
+        let nameOffset = try image.fileOffset(of: image.u32(image.exportDirectoryOffset + 12))
+        guard nameOffset + oldBytes.count <= data.count else {
+            throw GPTKVideoProcessorError.malformedPE("the export name runs past the end of the file")
+        }
+
+        let found = (0 ..< oldBytes.count).map { data[data.startIndex + nameOffset + $0] }
+        guard found == oldBytes else {
+            throw GPTKVideoProcessorError.unexpectedExportName(
+                String(bytes: found, encoding: .utf8) ?? "unreadable"
+            )
+        }
+        for (index, value) in newBytes.enumerated() {
+            data[data.startIndex + nameOffset + index] = value
+        }
+        try data.write(to: url)
+    }
+}
+
+/// Just enough of a PE to find the export directory's name string: the section
+/// table, so a relative virtual address can be turned into a file offset, and
+/// the export directory itself.
+struct PEImage {
+    struct Section {
+        let virtualAddress: Int
+        let virtualSize: Int
+        let rawPointer: Int
+    }
+
+    private let data: Data
+    private let sections: [Section]
+    /// The export directory's own position in the file.
+    let exportDirectoryOffset: Int
+
+    init(data: Data) throws {
+        self.data = data
+
+        let peHeader = try Self.u32(data, 0x3C)
+        guard try Self.u32(data, peHeader) == 0x0000_4550 else {
+            throw GPTKVideoProcessorError.malformedPE("no PE signature at e_lfanew")
+        }
+        let sectionCount = try Self.u16(data, peHeader + 6)
+        let optionalHeaderSize = try Self.u16(data, peHeader + 20)
+        let optionalHeader = peHeader + 24
+        // PE32+ carries eight more bytes of image base and four 64 bit sizes
+        // before the data directories than PE32 does.
+        let directories = try optionalHeader + (Self.u16(data, optionalHeader) == 0x20B ? 112 : 96)
+        let exportDirectoryRVA = try Self.u32(data, directories)
+        guard exportDirectoryRVA != 0 else {
+            throw GPTKVideoProcessorError.malformedPE("no export directory")
+        }
+
+        let sectionTable = optionalHeader + optionalHeaderSize
+        sections = try (0 ..< sectionCount).map { index in
+            let entry = sectionTable + index * 40
+            return try Section(
+                virtualAddress: Self.u32(data, entry + 12),
+                virtualSize: Self.u32(data, entry + 8),
+                rawPointer: Self.u32(data, entry + 20)
+            )
+        }
+
+        exportDirectoryOffset = try Self.fileOffset(of: exportDirectoryRVA, in: sections)
+    }
+
+    func u32(_ offset: Int) throws -> Int { try Self.u32(data, offset) }
+
+    func fileOffset(of rva: Int) throws -> Int { try Self.fileOffset(of: rva, in: sections) }
+
+    private static func fileOffset(of rva: Int, in sections: [Section]) throws -> Int {
+        for section in sections
+            where rva >= section.virtualAddress && rva < section.virtualAddress + max(section.virtualSize, 1) {
+            return section.rawPointer + (rva - section.virtualAddress)
+        }
+        throw GPTKVideoProcessorError.malformedPE("rva \(rva) is not inside any section")
+    }
+
+    private static func byte(_ data: Data, _ offset: Int) throws -> Int {
+        guard offset >= 0, offset < data.count else {
+            throw GPTKVideoProcessorError.malformedPE("offset \(offset) is past the end of the file")
+        }
+        return Int(data[data.startIndex + offset])
+    }
+
+    private static func u16(_ data: Data, _ offset: Int) throws -> Int {
+        try byte(data, offset) | (byte(data, offset + 1) << 8)
+    }
+
+    private static func u32(_ data: Data, _ offset: Int) throws -> Int {
+        try u16(data, offset) | (u16(data, offset + 2) << 16)
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKFixtures.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKFixtures.swift
@@ -28,6 +28,63 @@ func fakePE(builtin: Bool) -> Data {
     return data
 }
 
+/// Builds a PE that is structured enough for the export name rewrite to walk:
+/// a DOS header pointing at a PE32+ header, one section, and an export
+/// directory whose name string sits inside it.
+func fakePEWithExportName(_ name: String, builtin: Bool = true) -> Data {
+    var data = Data(count: 0x400)
+    func put16(_ offset: Int, _ value: Int) {
+        for index in 0 ..< 2 {
+            data[offset + index] = UInt8((value >> (8 * index)) & 0xFF)
+        }
+    }
+    func put32(_ offset: Int, _ value: Int) {
+        for index in 0 ..< 4 {
+            data[offset + index] = UInt8((value >> (8 * index)) & 0xFF)
+        }
+    }
+
+    data[0] = 0x4D
+    data[1] = 0x5A
+    if builtin {
+        data.replaceSubrange(0x40 ..< 0x50, with: Data("Wine builtin DLL".utf8))
+    }
+    put32(0x3C, 0x80) // e_lfanew
+    put32(0x80, 0x0000_4550) // "PE\0\0"
+    put16(0x86, 1) // one section
+    put16(0x94, 240) // size of the optional header
+    put16(0x98, 0x20B) // PE32+, so the directories sit 112 bytes in
+    put32(0x108, 0x1000) // export directory rva
+    put32(0x188 + 8, 0x1000) // section virtual size
+    put32(0x188 + 12, 0x1000) // section virtual address
+    put32(0x188 + 20, 0x200) // section pointer to raw data
+    put32(0x200 + 12, 0x1050) // the export directory's name rva
+    data.replaceSubrange(0x250 ..< (0x250 + name.utf8.count), with: Data(name.utf8))
+    return data
+}
+
+/// Gives a store's `d3d12.dll` a walkable export directory, so the swap under
+/// test has something shaped like Apple's DLL to rename.
+func makeStoreD3D12Renameable(inStore store: URL) throws {
+    try fakePEWithExportName("d3d12.dll").write(
+        to: store.appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-windows").appending(path: "d3d12.dll")
+    )
+}
+
+/// Puts an interposer in the runtime where the build ships one.
+@discardableResult
+func makeVideoProcessorShim(at libraryFolder: URL, marker: String = "interposer") throws -> URL {
+    let shim = GPTKImporter.videoProcessorShim(inLibraryFolder: libraryFolder)
+    try FileManager.default.createDirectory(
+        at: shim.deletingLastPathComponent(), withIntermediateDirectories: true
+    )
+    var data = fakePE(builtin: true)
+    data.append(Data(marker.utf8))
+    try data.write(to: shim)
+    return shim
+}
+
 /// Assembles Apple's `redist/lib` payload layout under `libRoot`.
 func makePayload(
     at libRoot: URL,

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKVideoProcessorTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKVideoProcessorTests.swift
@@ -1,0 +1,224 @@
+//
+//  GPTKVideoProcessorTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("GPTK Video Processor Tests")
+struct GPTKVideoProcessorTests {
+    private let tempDir: URL
+
+    init() throws {
+        tempDir = try makeGPTKTempDir()
+    }
+
+    private func peDir(of runtime: URL) -> URL {
+        runtime.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-windows")
+    }
+
+    private func exportName(of url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        return String(bytes: data[0x250 ..< 0x259], encoding: .utf8) ?? "unreadable"
+    }
+
+    /// A runtime holding the payload with an interposer available to install.
+    private func makeDeployableRuntime() throws -> (store: URL, runtime: URL) {
+        let store = try makeImportedStore(in: tempDir)
+        try makeStoreD3D12Renameable(inStore: store)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        try makeVideoProcessorShim(at: runtime)
+        return (store, runtime)
+    }
+
+    // MARK: - The rename
+
+    @Test("The export name is rewritten in place")
+    func rewriteExportName() throws {
+        let dll = tempDir.appending(path: "apple.dll")
+        try fakePEWithExportName("d3d12.dll").write(to: dll)
+
+        try GPTKImporter.rewriteExportName(at: dll, from: "d3d12.dll", to: "d3dmt.dll")
+
+        #expect(try exportName(of: dll) == "d3dmt.dll")
+    }
+
+    @Test("A replacement of a different length is refused")
+    func rewriteRejectsDifferentLength() throws {
+        let dll = tempDir.appending(path: "apple.dll")
+        try fakePEWithExportName("d3d12.dll").write(to: dll)
+
+        #expect(throws: GPTKVideoProcessorError.self) {
+            try GPTKImporter.rewriteExportName(at: dll, from: "d3d12.dll", to: "d3d12metal.dll")
+        }
+    }
+
+    @Test("A DLL that does not declare the expected name is refused")
+    func rewriteRejectsUnexpectedName() throws {
+        let dll = tempDir.appending(path: "other.dll")
+        try fakePEWithExportName("dxgi.dll!").write(to: dll)
+
+        #expect(throws: GPTKVideoProcessorError.unexpectedExportName("dxgi.dll!")) {
+            try GPTKImporter.rewriteExportName(at: dll, from: "d3d12.dll", to: "d3dmt.dll")
+        }
+    }
+
+    @Test("A DLL with no PE header is refused rather than corrupted")
+    func rewriteRejectsNonPE() throws {
+        let dll = tempDir.appending(path: "stub.dll")
+        try fakePE(builtin: true).write(to: dll)
+
+        #expect(throws: GPTKVideoProcessorError.self) {
+            try GPTKImporter.rewriteExportName(at: dll, from: "d3d12.dll", to: "d3dmt.dll")
+        }
+    }
+
+    // MARK: - Install
+
+    @Test("Deploy leaves the interposer in the d3d12 slot with Apple's DLL beside it")
+    func deployInstallsVideoProcessor() throws {
+        let (store, runtime) = try makeDeployableRuntime()
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        #expect(GPTKImporter.isVideoProcessorInstalled(inLibraryFolder: runtime))
+        let renamed = peDir(of: runtime).appending(path: "d3dmt.dll")
+        #expect(FileManager.default.fileExists(atPath: renamed.path(percentEncoded: false)))
+        #expect(try exportName(of: renamed) == "d3dmt.dll")
+
+        // the unix half has to follow the renamed PE or D3DMetal never binds
+        let link = runtime.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-unix").appending(path: "d3dmt.so")
+        let destination = try FileManager.default.destinationOfSymbolicLink(
+            atPath: link.path(percentEncoded: false)
+        )
+        #expect(destination == GPTKImporter.unixLinkDestination)
+    }
+
+    @Test("Installing twice changes nothing")
+    func installIsIdempotent() throws {
+        let (store, runtime) = try makeDeployableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        try GPTKImporter.installVideoProcessor(intoLibraryFolder: runtime)
+
+        #expect(GPTKImporter.isVideoProcessorInstalled(inLibraryFolder: runtime))
+        // the second pass must not rename the interposer into d3dmt.dll
+        let renamed = peDir(of: runtime).appending(path: "d3dmt.dll")
+        #expect(try exportName(of: renamed) == "d3dmt.dll")
+    }
+
+    @Test("A runtime that ships no interposer is left alone")
+    func installSkipsRuntimeWithoutShim() throws {
+        let store = try makeImportedStore(in: tempDir)
+        try makeStoreD3D12Renameable(inStore: store)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        #expect(!GPTKImporter.isVideoProcessorInstalled(inLibraryFolder: runtime))
+        let renamed = peDir(of: runtime).appending(path: "d3dmt.dll")
+        #expect(!FileManager.default.fileExists(atPath: renamed.path(percentEncoded: false)))
+        // and the payload itself still landed
+        #expect(GPTKImporter.isDeployed(inLibraryFolder: runtime))
+    }
+
+    @Test("Redeploying does not file the interposer away as Wine's own DLL")
+    func redeployKeepsOriginals() throws {
+        let (store, runtime) = try makeDeployableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        let backup = store.appending(path: "originals").appending(path: "d3d12.dll")
+        let backupData = try Data(contentsOf: backup)
+        #expect(backupData.suffix(13) == Data("wine original".utf8))
+        #expect(GPTKImporter.isVideoProcessorInstalled(inLibraryFolder: runtime))
+    }
+
+    // MARK: - Remove
+
+    @Test("Removing the payload restores Wine's own d3d12 and clears the rename")
+    func removeRestoresWine() throws {
+        let (store, runtime) = try makeDeployableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        try GPTKImporter.remove(fromLibraryFolder: runtime, usingStore: store)
+
+        let slot = peDir(of: runtime).appending(path: "d3d12.dll")
+        let restored = try Data(contentsOf: slot)
+        #expect(restored.suffix(13) == Data("wine original".utf8))
+
+        let fileManager = FileManager.default
+        #expect(!fileManager.fileExists(atPath: peDir(of: runtime)
+                .appending(path: "d3dmt.dll").path(percentEncoded: false)))
+        let link = runtime.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-unix").appending(path: "d3dmt.so")
+        #expect((try? fileManager.destinationOfSymbolicLink(atPath: link.path(percentEncoded: false))) == nil)
+    }
+
+    // MARK: - Prefixes
+
+    @Test("A bottle gets a placeholder for the renamed DLL")
+    func seedsPlaceholder() throws {
+        let (store, runtime) = try makeDeployableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        let bottle = tempDir.appending(path: "bottle")
+        let system32 = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32")
+        try FileManager.default.createDirectory(at: system32, withIntermediateDirectories: true)
+
+        GPTKImporter.seedVideoDevicePlaceholder(inBottle: bottle, fromLibraryFolder: runtime)
+
+        #expect(FileManager.default.fileExists(
+            atPath: system32.appending(path: "d3dmt.dll").path(percentEncoded: false)
+        ))
+    }
+
+    @Test("A placeholder already in the prefix is left as it is")
+    func keepsExistingPlaceholder() throws {
+        let (store, runtime) = try makeDeployableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        let bottle = tempDir.appending(path: "bottle")
+        let system32 = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32")
+        try FileManager.default.createDirectory(at: system32, withIntermediateDirectories: true)
+        let placeholder = system32.appending(path: "d3dmt.dll")
+        try Data("wineboot wrote this".utf8).write(to: placeholder)
+
+        GPTKImporter.seedVideoDevicePlaceholder(inBottle: bottle, fromLibraryFolder: runtime)
+
+        #expect(try Data(contentsOf: placeholder) == Data("wineboot wrote this".utf8))
+    }
+
+    @Test("A directory that is not a prefix is ignored")
+    func ignoresNonPrefix() throws {
+        let (store, runtime) = try makeDeployableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        let bottle = tempDir.appending(path: "not-a-bottle")
+        try FileManager.default.createDirectory(at: bottle, withIntermediateDirectories: true)
+
+        GPTKImporter.seedVideoDevicePlaceholder(inBottle: bottle, fromLibraryFolder: runtime)
+
+        #expect(!FileManager.default.fileExists(atPath: bottle.appending(path: "drive_c")
+                .path(percentEncoded: false)))
+    }
+}


### PR DESCRIPTION
D3DMetal exposes no `ID3D12VideoDevice` at all. A game that decodes video itself and asks D3D12 to convert NV12 to RGB gets `E_NOINTERFACE` and falls back to a path no Windows machine ever runs: S.T.A.L.K.E.R. Call of Pripyat EE draws its intro and menu backgrounds at half resolution with the chroma flat, an olive cast over the whole frame. The same gap is why it reproduces on Proton.

The runtime now ships an interposer that supplies the missing video processor (`lib/gptk-video/d3d12shim.dll`). This is the app side: the interposer cannot install itself, because it has to sit in the `d3d12.dll` builtin slot with Apple's DLL renamed beside it, and Apple's DLL only exists once the payload here is deployed.

## what it does

- `deploy` performs the swap once Apple's D3D12 is in place: copies it to `d3dmt.dll`, rewrites that copy's export directory name, links the unix half, and puts the interposer in the slot.
- `remove` undoes it and restores Apple's DLL into the slot from the store.
- the app installs it at launch when the payload is already deployed, for installs that predate the interposer and would otherwise never deploy again.

## two ordering constraints worth reviewing

Both bit during development and both are load bearing:

1. after the swap the `d3d12.dll` slot holds the interposer, which byte-matches neither Wine's DLL nor the store's forwarder. Without clearing the swap first, `deploy` files the interposer away as if it were Wine's own builtin, and `remove` hits the `isGPTKForwarder` guard, skips the slot, and leaves a `d3d12.dll` forwarding to a `d3dmt.dll` it has just deleted. Both now call `removeVideoProcessor` before they walk the forwarder list.
2. the rename has to rewrite the export directory name, not just the filename. Wine keys builtins on the name a DLL declares internally, so a plain copy still says `d3d12.dll`, dedups against the original, and `LoadLibrary` hands back the module that is already loaded, which makes the interposer forward into itself. Patching in place is also why the new name is nine characters.

## prefixes

The loader will not search the builtin directory for `d3dmt.dll` unless the prefix has a placeholder for it in `system32`, and without that D3D12 goes down entirely rather than just missing video. `wineboot` writes these when a prefix is created or updated, so new bottles are covered; bottles that already exist predate the name, so the launch path seeds them directly rather than requiring a prefix update.

## safety

Every step is a no-op on a runtime that ships no interposer, so this is inert until a runtime carrying `lib/gptk-video` is installed. Install and remove are idempotent, and the rename refuses anything that is not shaped like the PE it expects rather than writing into it blind.

## verified

- `WhiskyKit` suite: 1256 tests, 0 failures, including 10 new ones covering the rename, install idempotency, redeploy, removal, and prefix seeding
- swiftformat `--lint` and swiftlint `--strict` both clean
- the app target builds
- end to end on a real bottle: the STALKER intro plays at the full 3840x2160 with correct colour, verified by reading back a converted frame and rendering it host side

Runtime side, with the interposer's source and how the conversion works: dappermint/winecx-gptk#6. Upstream reports: ValveSoftware/Proton#8717, HansKristian-Work/vkd3d-proton#3212.
