### PR TITLE
Fix/bottle state update after creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Newly created bottles are now immediately interactive: the inFlight guard
+  is reset after a successful creation so that state-dependent actions (move,
+  export, duplicate) no longer require an app restart to become available.
+
 ## [3.6.1] - 2026-08-13 (App)
 
 ### Changed

--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -191,6 +191,7 @@ final class BottleVM: ObservableObject {
             createdBottle.saveBottleSettings()
 
             try persistBottleCreation(request: request)
+            createdBottle.inFlight = false
             loadBottles()
             Telemetry.capture(.firstBottleCreated)
         } catch {


### PR DESCRIPTION
Added code to **update the bottle status** after successful creation to fix the bug that required **restarting the app** to use it.