### PR TITLE
deploy the metalfx bridge so d3dmetal has something to hook

### DIFF
--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -35635,6 +35635,26 @@
         }
       }
     },
+    "config.metalFX" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DLSS via MetalFX"
+          }
+        }
+      }
+    },
+    "config.metalFX.info" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maps a game's DLSS to MetalFX upscaling. Only applies when DLSS is also turned on in the game's own settings."
+          }
+        }
+      }
+    },
     "config.metalHud" : {
       "localizations" : {
         "ar" : {

--- a/Whisky/Views/Bottle/GraphicsConfigSection.swift
+++ b/Whisky/Views/Bottle/GraphicsConfigSection.swift
@@ -63,6 +63,19 @@ struct GraphicsConfigSection: View {
                 runningProcessWarning
             }
 
+            // MetalFX rides on D3DMetal's DLSS bridge, so it is meaningless
+            // under any other backend rather than merely inactive.
+            if resolvedBackend == .d3dMetal {
+                Toggle(isOn: $bottle.settings.metalFX) {
+                    VStack(alignment: .leading) {
+                        Text("config.metalFX")
+                        Text("config.metalFX.info")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
             // Force DX11 toggle -- always visible (Simple + Advanced)
             Toggle(isOn: $bottle.settings.forceD3D11) {
                 Text("config.forceD3D11")

--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -77,6 +77,9 @@ struct WhiskyApp: App {
     private func installMetalFXBridgeIfNeeded() {
         Task.detached(priority: .background) {
             GPTKImporter.ensureMetalFXBridgeInstalled()
+        }
+    }
+
     /// Installs the D3D12 video processor if the GPTK payload is already
     /// deployed.
     ///

--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -67,6 +67,19 @@ struct WhiskyApp: App {
         Telemetry.startIfConsented()
     }
 
+    /// Installs the MetalFX bridge into runtimes that already hold the GPTK
+    /// payload.
+    ///
+    /// Deploying does this too, but an install that was set up before the
+    /// bridge existed never deploys again, so without this MetalFX would stay
+    /// unreachable until it happened to reimport. Idempotent, and a no-op on
+    /// runtimes whose payload does not carry the bridge.
+    private func installMetalFXBridgeIfNeeded() {
+        Task.detached(priority: .background) {
+            GPTKImporter.ensureMetalFXBridgeInstalled()
+        }
+    }
+
     var body: some Scene {
         WindowGroup(id: Self.mainWindowID) {
             ContentView(showSetup: $showSetup)
@@ -77,6 +90,7 @@ struct WhiskyApp: App {
                     Task.detached {
                         await WhiskyApp.deleteOldLogs()
                     }
+                    installMetalFXBridgeIfNeeded()
                     startAudioDeviceListening()
                 }
                 .onReceive(

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
@@ -151,11 +151,20 @@ public struct BottleGraphicsConfig: Codable, Equatable {
     /// The selected graphics backend. Defaults to `.recommended`.
     var backend: GraphicsBackend = .recommended
 
+    /// Whether this bottle opts in to D3DMetal's DLSS-to-MetalFX path.
+    ///
+    /// Off by default and deliberately per-bottle. A game that finds the bridge
+    /// takes its DLSS path instead of whatever it would otherwise have used,
+    /// which is a win when MetalFX handles it and a regression when it does not,
+    /// so this is a per-game judgement rather than a global one.
+    var metalFX: Bool = false
+
     /// Creates a new graphics config with the default `.recommended` backend.
     public init() {}
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.backend = container.decodeLenientIfPresent(GraphicsBackend.self, forKey: .backend) ?? .recommended
+        self.metalFX = (try? container.decodeIfPresent(Bool.self, forKey: .metalFX)) ?? false
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
@@ -153,11 +153,13 @@ public struct BottleGraphicsConfig: Codable, Equatable {
 
     /// Whether this bottle opts in to D3DMetal's DLSS-to-MetalFX path.
     ///
-    /// Off by default and deliberately per-bottle. A game that finds the bridge
-    /// takes its DLSS path instead of whatever it would otherwise have used,
-    /// which is a win when MetalFX handles it and a regression when it does not,
-    /// so this is a per-game judgement rather than a global one.
-    var metalFX: Bool = false
+    /// On by default. This started off opt-in on the theory that a game finding
+    /// the bridge takes its DLSS path instead of whatever it would otherwise
+    /// have used, which could regress as easily as help. Measured, it helps, so
+    /// the default flipped and the toggle stays for the titles it does not suit.
+    /// A tree with no bridge in it is unaffected either way: with nothing for
+    /// `DXGIAdapter::nvngxDLLLocation` to find, the variable is inert.
+    var metalFX: Bool = true
 
     /// Creates a new graphics config with the default `.recommended` backend.
     public init() {}
@@ -165,6 +167,8 @@ public struct BottleGraphicsConfig: Codable, Equatable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.backend = container.decodeLenientIfPresent(GraphicsBackend.self, forKey: .backend) ?? .recommended
-        self.metalFX = (try? container.decodeIfPresent(Bool.self, forKey: .metalFX)) ?? false
+        // Matches the property default, so a bottle written before this key
+        // existed adopts the new default instead of decoding as off.
+        self.metalFX = (try? container.decodeIfPresent(Bool.self, forKey: .metalFX)) ?? true
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -341,6 +341,16 @@ public struct BottleSettings: Codable, Equatable {
         set { graphicsConfig.backend = newValue }
     }
 
+    /// Whether this bottle opts in to D3DMetal's DLSS-to-MetalFX path.
+    ///
+    /// Takes effect only under D3DMetal, and only for a game that has DLSS
+    /// switched on in its own settings: the bridge implements the DLSS entry
+    /// points, so a game that never asks for DLSS never reaches MetalFX.
+    public var metalFX: Bool {
+        get { graphicsConfig.metalFX }
+        set { graphicsConfig.metalFX = newValue }
+    }
+
     /// Whether DXVK is the active graphics backend.
     ///
     /// This property now derives from ``graphicsBackend``. Setting it to `true`
@@ -818,6 +828,11 @@ public struct BottleSettings: Codable, Equatable {
             // The only other reader wants the value "wined3d" alongside
             // CX_LIBVULKAN, so this is inert for it.
             builder.set("CX_ACTIVE_GRAPHICS_BACKEND", "d3dmetal", layer: .bottleManaged)
+            // The DLL placement that actually gates the DLSS-to-MetalFX path
+            // happens in `Wine.applyMetalFX` at launch; this is the opt-in.
+            if metalFX {
+                builder.set("D3DM_ENABLE_METALFX", "1", layer: .bottleManaged)
+            }
 
         case .dxvk:
             // DXVK: DLL overrides + env vars

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
@@ -170,6 +170,10 @@ extension GPTKImporter {
             try fileManager.removeItem(at: externalDest)
         }
         try fileManager.copyItem(at: storeLib.appending(path: "external"), to: externalDest)
+        // Apple's payload is in place now, which is the only moment the bridge
+        // can be installed: it forwards into the payload's own shared dylib and
+        // has nothing to bind to before this point.
+        try installMetalFXBridge(intoLibraryFolder: folder, usingStore: store)
         logger.info("Deployed GPTK payload into the runtime tree")
     }
 
@@ -202,6 +206,8 @@ extension GPTKImporter {
 
         let originalsAreCurrent = originalsRecord(inStore: store)?.runtimeVersion
             == runtimeVersionStamp(inLibraryFolder: folder)
+
+        removeMetalFXBridge(fromLibraryFolder: folder, usingStore: store)
 
         for name in forwarderDLLNames {
             let backup = originals.appending(path: name)

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+MetalFX.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+MetalFX.swift
@@ -1,0 +1,181 @@
+//
+//  GPTKImporter+MetalFX.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import os.log
+
+/// MetalFX has exactly one entry point: the DLSS API. D3DMetal links MetalFX and
+/// builds its scalers, but only for a game that calls `NVSDK_NGX_D3D12_*` in
+/// `nvngx.dll`, which Apple implements as `nvngx-on-metalfx.dll`. With no such
+/// DLL in the tree `D3DM_ENABLE_METALFX=1` has nothing to hook, which is why
+/// MetalFX could not be enabled in any bottle.
+///
+/// Two things make this more than a file copy:
+///
+/// - The bridge is a hybrid PE and unixlib module. Its `DllMain` calls
+///   `__wine_init_unix_call` before anything else and returns false when that
+///   fails, so the PE on its own loads as a builtin and immediately dies with
+///   `ERROR_DLL_INIT_FAILED`, which reads like a corrupt DLL and is not. It needs
+///   a unix half beside it, exactly like the four D3D forwarders.
+/// - Builtins are keyed by their PE export name, and this one exports as
+///   `nvngx.dll` rather than the filename Apple ships it under.
+///
+/// `nvapi64.dll`, the other half of ``nvidiaBridgeDLLNames``, deliberately stays
+/// out: Chromium probes for an NVIDIA GPU, and handing it one makes it load
+/// D3DMetal and take Steam's helper process down. Nothing probes for nvngx that
+/// way, and NGX reports DLSS available without it.
+extension GPTKImporter {
+    /// Apple's bridge under the name the payload ships it as.
+    static let metalFXBridgeSourceName = "nvngx-on-metalfx.dll"
+    /// The name it has to be installed under, because that is what its PE export
+    /// directory says and the builtin loader matches on that, not the filename.
+    static let metalFXBridgeName = "nvngx.dll"
+    /// Its unix half, which shares the payload's single shared dylib with every
+    /// other bridge.
+    static let metalFXBridgeUnixName = "nvngx.so"
+
+    /// Where the bridge lives in the store, or `nil` for a payload too old to
+    /// carry one.
+    static func metalFXBridgeSource(inStore store: URL) -> URL? {
+        let source = store.appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-windows").appending(path: metalFXBridgeSourceName)
+        return FileManager.default.fileExists(atPath: source.path(percentEncoded: false)) ? source : nil
+    }
+
+    /// Whether the tree holds a bridge this store put there. Compared by content
+    /// so a copy someone installed by hand is left alone by remove.
+    static func isMetalFXBridgeInstalled(inLibraryFolder folder: URL, usingStore store: URL) -> Bool {
+        guard let source = metalFXBridgeSource(inStore: store) else { return false }
+        return FileManager.default.contentsEqual(
+            atPath: metalFXBridgePE(inLibraryFolder: folder).path(percentEncoded: false),
+            andPath: source.path(percentEncoded: false)
+        )
+    }
+
+    static func metalFXBridgePE(inLibraryFolder folder: URL) -> URL {
+        folder.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-windows").appending(path: metalFXBridgeName)
+    }
+
+    static func metalFXBridgeUnixLink(inLibraryFolder folder: URL) -> URL {
+        folder.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-unix").appending(path: metalFXBridgeUnixName)
+    }
+
+    /// Puts the bridge in the tree under its export name with a unix half beside
+    /// it. Does nothing when the payload is too old to carry one.
+    ///
+    /// Purely additive: Wine ships no `nvngx.dll`, so unlike the forwarders there
+    /// is no builtin here to back up and nothing to restore on the way out.
+    static func installMetalFXBridge(intoLibraryFolder folder: URL, usingStore store: URL) throws {
+        guard let source = metalFXBridgeSource(inStore: store) else { return }
+        let fileManager = FileManager.default
+        let destination = metalFXBridgePE(inLibraryFolder: folder)
+        let link = metalFXBridgeUnixLink(inLibraryFolder: folder)
+
+        if fileManager.fileExists(atPath: destination.path(percentEncoded: false)) {
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.copyItem(at: source, to: destination)
+
+        try fileManager.createDirectory(
+            at: link.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try? fileManager.removeItem(at: link)
+        try fileManager.createSymbolicLink(
+            atPath: link.path(percentEncoded: false),
+            withDestinationPath: unixLinkDestination
+        )
+        logger.info("Installed the MetalFX bridge as \(metalFXBridgeName, privacy: .public)")
+    }
+
+    /// Takes the bridge back out, leaving anything this store did not install.
+    ///
+    /// The unix link goes only when it points where we pointed it; `removeItem`
+    /// acts on the link itself, so a dangling one is cleared too.
+    static func removeMetalFXBridge(fromLibraryFolder folder: URL, usingStore store: URL) {
+        let fileManager = FileManager.default
+        guard isMetalFXBridgeInstalled(inLibraryFolder: folder, usingStore: store) else { return }
+        try? fileManager.removeItem(at: metalFXBridgePE(inLibraryFolder: folder))
+
+        let link = metalFXBridgeUnixLink(inLibraryFolder: folder)
+        let target = try? fileManager.destinationOfSymbolicLink(atPath: link.path(percentEncoded: false))
+        if target == unixLinkDestination {
+            try? fileManager.removeItem(at: link)
+        }
+    }
+
+    // MARK: - Prefixes
+
+    /// Drops a placeholder for the bridge into a prefix's `system32`.
+    ///
+    /// Not optional and not cosmetic: with no entry there the loader never looks
+    /// in the builtin directory, and `LoadLibrary("nvngx.dll")` fails with
+    /// `ERROR_MOD_NOT_FOUND` however well the tree is set up. `wineboot` writes
+    /// one whenever a prefix is made or updated, so new bottles get it for free;
+    /// every bottle that already exists predates the name.
+    static func seedMetalFXBridgePlaceholder(inBottle bottle: URL, fromLibraryFolder folder: URL) {
+        let fileManager = FileManager.default
+        let source = metalFXBridgePE(inLibraryFolder: folder)
+        guard fileManager.fileExists(atPath: source.path(percentEncoded: false)) else { return }
+
+        let system32 = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32")
+        guard fileManager.fileExists(atPath: system32.path(percentEncoded: false)) else { return }
+
+        let placeholder = system32.appending(path: metalFXBridgeName)
+        guard !fileManager.fileExists(atPath: placeholder.path(percentEncoded: false)) else { return }
+        try? fileManager.copyItem(at: source, to: placeholder)
+    }
+
+    /// Takes a prefix's placeholder back out, which makes the bridge unreachable
+    /// from that bottle without touching the shared tree.
+    ///
+    /// Removes any builtin-marked entry, not just a copy this app wrote:
+    /// `wineboot` writes its own stub for every builtin it finds, so a prefix
+    /// update after the bridge was installed recreates one, and leaving that in
+    /// place would quietly defeat the opt-out. A *native* DLL is left alone,
+    /// that is someone's own `nvngx`, not something we or Wine put there.
+    static func clearMetalFXBridgePlaceholder(inBottle bottle: URL) {
+        let placeholder = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32").appending(path: metalFXBridgeName)
+        guard FileManager.default.fileExists(atPath: placeholder.path(percentEncoded: false)) else { return }
+        guard (try? Wine.isNativePE(placeholder)) == false else { return }
+        try? FileManager.default.removeItem(at: placeholder)
+    }
+
+    /// Installs the bridge into a tree that already holds the payload.
+    ///
+    /// An install set up before the bridge existed has the payload deployed and
+    /// never deploys again, so it would stay without MetalFX until it happened
+    /// to reimport. Idempotent and cheap enough to run at launch.
+    ///
+    /// Deliberately seeds no prefixes. The tree-side bridge is inert on its own,
+    /// and which bottles can reach it is ``Wine/applyMetalFX(bottle:)``'s
+    /// decision at launch, from the per-bottle setting.
+    public static func ensureMetalFXBridgeInstalled() {
+        let folder = WhiskyWineInstaller.libraryFolder
+        guard isDeployed(inLibraryFolder: folder) else { return }
+
+        do {
+            try installMetalFXBridge(intoLibraryFolder: folder, usingStore: storeFolder)
+        } catch {
+            logger.error("Installing the MetalFX bridge failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+MetalFX.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+MetalFX.swift
@@ -38,7 +38,18 @@ import os.log
 /// `nvapi64.dll`, the other half of ``nvidiaBridgeDLLNames``, deliberately stays
 /// out: Chromium probes for an NVIDIA GPU, and handing it one makes it load
 /// D3DMetal and take Steam's helper process down. Nothing probes for nvngx that
-/// way, and NGX reports DLSS available without it.
+/// way, so the bridge itself is safe to deploy on its own.
+///
+/// Leaving it out is not free. A title built on NVIDIA Streamline asks NVAPI
+/// about the GPU before it will consider DLSS at all, and Wine's `nvapi64`
+/// exports nothing, so Streamline decides there is no NVIDIA driver and offers
+/// no DLSS option. Those titles get the bridge and cannot reach it, with nothing
+/// in any log to say why. A title calling NGX directly is unaffected.
+///
+/// Fixing that means a real `nvapi64` for the game but not for the launcher
+/// helper, so a per-exe `AppDefaults` override rather than the environment every
+/// child inherits. Left to a follow-up, which is why frankea/Whisky#198 stays
+/// open.
 extension GPTKImporter {
     /// Apple's bridge under the name the payload ships it as.
     static let metalFXBridgeSourceName = "nvngx-on-metalfx.dll"
@@ -82,16 +93,25 @@ extension GPTKImporter {
     ///
     /// Purely additive: Wine ships no `nvngx.dll`, so unlike the forwarders there
     /// is no builtin here to back up and nothing to restore on the way out.
+    ///
+    /// A destination already matching the store is left alone, so the launch-time
+    /// ``ensureMetalFXBridgeInstalled()`` does not rewrite it every time.
+    /// Anything else is replaced, which is not the rule
+    /// ``removeMetalFXBridge(fromLibraryFolder:usingStore:)`` follows: deleting
+    /// a file someone else put there cannot be undone, and overwriting one in a
+    /// tree we manage is what repair means.
     static func installMetalFXBridge(intoLibraryFolder folder: URL, usingStore store: URL) throws {
         guard let source = metalFXBridgeSource(inStore: store) else { return }
         let fileManager = FileManager.default
         let destination = metalFXBridgePE(inLibraryFolder: folder)
         let link = metalFXBridgeUnixLink(inLibraryFolder: folder)
 
-        if fileManager.fileExists(atPath: destination.path(percentEncoded: false)) {
-            try fileManager.removeItem(at: destination)
+        if !isMetalFXBridgeInstalled(inLibraryFolder: folder, usingStore: store) {
+            if fileManager.fileExists(atPath: destination.path(percentEncoded: false)) {
+                try fileManager.removeItem(at: destination)
+            }
+            try fileManager.copyItem(at: source, to: destination)
         }
-        try fileManager.copyItem(at: source, to: destination)
 
         try fileManager.createDirectory(
             at: link.deletingLastPathComponent(), withIntermediateDirectories: true
@@ -155,6 +175,10 @@ extension GPTKImporter {
         let placeholder = bottle.appending(path: "drive_c").appending(path: "windows")
             .appending(path: "system32").appending(path: metalFXBridgeName)
         guard FileManager.default.fileExists(atPath: placeholder.path(percentEncoded: false)) else { return }
+        // A throwing `isNativePE` compares unequal to `false` and so keeps the
+        // file. Deliberate: a placeholder too short or unreadable to hold the
+        // marker is not something anyone chose to put here, and only wineboot
+        // and this app write to the name.
         guard (try? Wine.isNativePE(placeholder)) == false else { return }
         try? FileManager.default.removeItem(at: placeholder)
     }
@@ -166,7 +190,7 @@ extension GPTKImporter {
     /// to reimport. Idempotent and cheap enough to run at launch.
     ///
     /// Deliberately seeds no prefixes. The tree-side bridge is inert on its own,
-    /// and which bottles can reach it is ``Wine/applyMetalFX(bottle:)``'s
+    /// and which bottles can reach it is ``Wine/applyMetalFX(bottle:backend:)``'s
     /// decision at launch, from the per-bottle setting.
     public static func ensureMetalFXBridgeInstalled() {
         let folder = WhiskyWineInstaller.libraryFolder

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
@@ -88,11 +88,15 @@ public enum GPTKImporter {
     /// no d3d9 forwarder.
     static let forwarderDLLNames = ["d3d10.dll", "d3d11.dll", "d3d12.dll", "dxgi.dll"]
 
-    /// Apple's NVIDIA bridges, which back the experimental DLSS-to-MetalFX
-    /// path. Kept in the store but never deployed: a stock runtime ships no
-    /// `nvapi64` at all, so placing Apple's makes every process that probes for
-    /// an NVIDIA GPU load D3DMetal — Chromium does exactly that, which takes
-    /// Steam's helper process down with it. Opt-in territory, not a default.
+    /// Apple's NVIDIA bridges. `nvngx-on-metalfx` is deployed, under its export
+    /// name, because it is the only route to MetalFX, see
+    /// ``installMetalFXBridge(intoLibraryFolder:usingStore:)``.
+    ///
+    /// `nvapi64` is kept in the store and never deployed: a stock runtime ships
+    /// no `nvapi64` at all, so placing Apple's makes every process that probes
+    /// for an NVIDIA GPU load D3DMetal, and Chromium does exactly that, which takes
+    /// Steam's helper process down with it. NGX reports DLSS available without
+    /// it, so MetalFX does not pay for that risk.
     static let nvidiaBridgeDLLNames = ["nvapi64.dll", "nvngx-on-metalfx.dll"]
 
     /// Enough bytes to hold the winebuild marker at offset 0x40.

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
@@ -95,8 +95,9 @@ public enum GPTKImporter {
     /// `nvapi64` is kept in the store and never deployed: a stock runtime ships
     /// no `nvapi64` at all, so placing Apple's makes every process that probes
     /// for an NVIDIA GPU load D3DMetal, and Chromium does exactly that, which takes
-    /// Steam's helper process down with it. NGX reports DLSS available without
-    /// it, so MetalFX does not pay for that risk.
+    /// Steam's helper process down with it. The cost is that a Streamline title
+    /// asks NVAPI about the GPU before it will offer DLSS at all, so it never
+    /// reaches MetalFX, see ``installMetalFXBridge(intoLibraryFolder:usingStore:)``.
     static let nvidiaBridgeDLLNames = ["nvapi64.dll", "nvngx-on-metalfx.dll"]
 
     /// Enough bytes to hold the winebuild marker at offset 0x40.

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -732,17 +732,16 @@ public class Wine {
         switch backend {
         case .dxmt:
             try enableDXMT(bottle: bottle)
-        case .d3dMetal:
-            // Applied in both directions, so clearing the setting takes effect
-            // on the next launch by itself.
-            applyMetalFX(bottle: bottle)
-        case .dxvk, .wined3d, .recommended:
+        case .d3dMetal, .dxvk, .wined3d, .recommended:
             break
         }
+
+        applyMetalFX(bottle: bottle, backend: backend)
     }
 
     /// Opts a bottle in or out of D3DMetal's DLSS-to-MetalFX path, per
-    /// ``BottleSettings/metalFX``.
+    /// ``BottleSettings/metalFX`` and the backend the launch actually resolved
+    /// to.
     ///
     /// The bridge itself is a builtin in the shared Wine tree, so it cannot be
     /// installed per bottle. What can is the `system32` entry the loader needs
@@ -751,15 +750,27 @@ public class Wine {
     /// complete the tree is. So the placeholder is the switch: present means a
     /// game can reach MetalFX, absent means the bridge is inert.
     ///
-    /// - Parameter bottle: The ``Bottle`` whose opt-in state to apply.
+    /// Only D3DMetal implements the DLSS entry points behind it, so every other
+    /// backend clears, setting or no setting. Otherwise a bottle switched away
+    /// from D3DMetal with MetalFX still on keeps a placeholder for a bridge
+    /// nothing in that prefix can answer, and a DLSS-aware game reaches it under
+    /// a backend it was never meant for.
     ///
-    /// - Note: Called by `runProgram` whenever the effective backend is
-    ///   D3DMetal, in both directions, so turning the setting off takes effect
-    ///   on the next launch without the user having to repair anything.
+    /// - Parameters:
+    ///   - bottle: The ``Bottle`` whose opt-in state to apply.
+    ///   - backend: The backend this launch resolved to.
+    ///   - libraryFolder: The runtime tree holding the bridge.
+    ///
+    /// - Note: Called by `runProgram` for every launch, in both directions, so
+    ///   turning the setting off or switching backend takes effect on the next
+    ///   launch without the user having to repair anything.
     @MainActor
-    public static func applyMetalFX(bottle: Bottle) {
-        let libraryFolder = WhiskyWineInstaller.libraryFolder
-        if bottle.settings.metalFX {
+    public static func applyMetalFX(
+        bottle: Bottle,
+        backend: GraphicsBackend,
+        libraryFolder: URL = WhiskyWineInstaller.libraryFolder
+    ) {
+        if backend == .d3dMetal, bottle.settings.metalFX {
             GPTKImporter.seedMetalFXBridgePlaceholder(inBottle: bottle.url, fromLibraryFolder: libraryFolder)
         } else {
             GPTKImporter.clearMetalFXBridgePlaceholder(inBottle: bottle.url)

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -267,12 +267,7 @@ public class Wine {
             programOverrides = pinned
         }
 
-        // DXMT first: if launcher auto-DXVK also fires below (e.g. Rockstar),
-        // DXVK's file copy deterministically wins, matching the override-layer
-        // order where launcher-managed entries land after bottle-managed ones.
-        if effectiveBackend == .dxmt {
-            try enableDXMT(bottle: bottle)
-        }
+        try prepareBackendPrefix(effectiveBackend, bottle: bottle)
 
         // Enable DXVK if needed: effective backend, the legacy program-level
         // flag (honored only without a backend override, mirroring
@@ -725,6 +720,50 @@ public class Wine {
             return false
         }
         return marker != Data("Wine builtin DLL".utf8)
+    }
+
+    /// Places the per-bottle files a backend needs in the prefix before launch.
+    ///
+    /// DXMT goes first: if launcher auto-DXVK also fires in `runProgram`, DXVK's
+    /// file copy deterministically wins, matching the override-layer order where
+    /// launcher-managed entries land after bottle-managed ones.
+    @MainActor
+    private static func prepareBackendPrefix(_ backend: GraphicsBackend, bottle: Bottle) throws {
+        switch backend {
+        case .dxmt:
+            try enableDXMT(bottle: bottle)
+        case .d3dMetal:
+            // Applied in both directions, so clearing the setting takes effect
+            // on the next launch by itself.
+            applyMetalFX(bottle: bottle)
+        case .dxvk, .wined3d, .recommended:
+            break
+        }
+    }
+
+    /// Opts a bottle in or out of D3DMetal's DLSS-to-MetalFX path, per
+    /// ``BottleSettings/metalFX``.
+    ///
+    /// The bridge itself is a builtin in the shared Wine tree, so it cannot be
+    /// installed per bottle. What can is the `system32` entry the loader needs
+    /// before it will look in the builtin directory at all: without one,
+    /// `LoadLibrary("nvngx.dll")` fails with `ERROR_MOD_NOT_FOUND` however
+    /// complete the tree is. So the placeholder is the switch: present means a
+    /// game can reach MetalFX, absent means the bridge is inert.
+    ///
+    /// - Parameter bottle: The ``Bottle`` whose opt-in state to apply.
+    ///
+    /// - Note: Called by `runProgram` whenever the effective backend is
+    ///   D3DMetal, in both directions, so turning the setting off takes effect
+    ///   on the next launch without the user having to repair anything.
+    @MainActor
+    public static func applyMetalFX(bottle: Bottle) {
+        let libraryFolder = WhiskyWineInstaller.libraryFolder
+        if bottle.settings.metalFX {
+            GPTKImporter.seedMetalFXBridgePlaceholder(inBottle: bottle.url, fromLibraryFolder: libraryFolder)
+        } else {
+            GPTKImporter.clearMetalFXBridgePlaceholder(inBottle: bottle.url)
+        }
     }
 
     /// Installs DXMT into a bottle so its Direct3D-11-to-Metal layer is used.

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKFixtures.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKFixtures.swift
@@ -152,6 +152,21 @@ func makePartialDeploy(store: URL, runtime: URL, runtimeVersion: String) throws 
     return peDir
 }
 
+/// Adds Apple's MetalFX bridge to a store's payload.
+///
+/// ``makePayload(at:version:builtinForwarders:omitting:unixEntriesAsFiles:)``
+/// leaves it out so a payload without one, which is what every GPTK before it
+/// shipped, stays the default the deployment tests see.
+@discardableResult
+func makeStoreMetalFXBridge(inStore store: URL, marker: String = "metalfx bridge") throws -> URL {
+    let dll = store.appending(path: "lib").appending(path: "wine")
+        .appending(path: "x86_64-windows").appending(path: GPTKImporter.metalFXBridgeSourceName)
+    var data = fakePE(builtin: true)
+    data.append(Data(marker.utf8))
+    try data.write(to: dll)
+    return dll
+}
+
 /// A store holding a freshly imported payload, under `tempDir`.
 func makeImportedStore(in tempDir: URL) throws -> URL {
     let lib = tempDir.appending(path: "payload")

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKMetalFXTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKMetalFXTests.swift
@@ -1,0 +1,247 @@
+//
+//  GPTKMetalFXTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("GPTK MetalFX Bridge Tests")
+struct GPTKMetalFXTests {
+    private let tempDir: URL
+
+    init() throws {
+        tempDir = try makeGPTKTempDir()
+    }
+
+    /// A store whose payload carries the bridge, and a runtime to deploy into.
+    private func makeBridgeableRuntime() throws -> (store: URL, runtime: URL) {
+        let store = try makeImportedStore(in: tempDir)
+        try makeStoreMetalFXBridge(inStore: store)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        return (store, runtime)
+    }
+
+    private func makeBottle(named name: String = "bottle") throws -> URL {
+        let bottle = tempDir.appending(path: name)
+        try FileManager.default.createDirectory(
+            at: bottle.appending(path: "drive_c").appending(path: "windows").appending(path: "system32"),
+            withIntermediateDirectories: true
+        )
+        return bottle
+    }
+
+    // MARK: - Install
+
+    @Test("Deploy installs the bridge under its export name with a unix half")
+    func deployInstallsBridge() throws {
+        let (store, runtime) = try makeBridgeableRuntime()
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        #expect(GPTKImporter.isMetalFXBridgeInstalled(inLibraryFolder: runtime, usingStore: store))
+        // the filename Apple ships is not the name the loader will accept
+        let shipped = runtime.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-windows").appending(path: GPTKImporter.metalFXBridgeSourceName)
+        #expect(!FileManager.default.fileExists(atPath: shipped.path(percentEncoded: false)))
+
+        // without the unix half DllMain fails and the PE is useless
+        let link = GPTKImporter.metalFXBridgeUnixLink(inLibraryFolder: runtime)
+        let destination = try FileManager.default.destinationOfSymbolicLink(
+            atPath: link.path(percentEncoded: false)
+        )
+        #expect(destination == GPTKImporter.unixLinkDestination)
+    }
+
+    @Test("A payload with no bridge deploys without one")
+    func deploySkipsPayloadWithoutBridge() throws {
+        let store = try makeImportedStore(in: tempDir)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        #expect(!GPTKImporter.isMetalFXBridgeInstalled(inLibraryFolder: runtime, usingStore: store))
+        let bridge = GPTKImporter.metalFXBridgePE(inLibraryFolder: runtime)
+        #expect(!FileManager.default.fileExists(atPath: bridge.path(percentEncoded: false)))
+    }
+
+    @Test("Installing twice changes nothing")
+    func installIsIdempotent() throws {
+        let (store, runtime) = try makeBridgeableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        try GPTKImporter.installMetalFXBridge(intoLibraryFolder: runtime, usingStore: store)
+
+        #expect(GPTKImporter.isMetalFXBridgeInstalled(inLibraryFolder: runtime, usingStore: store))
+    }
+
+    // MARK: - Remove
+
+    @Test("Remove takes the bridge and its unix half back out")
+    func removeClearsBridge() throws {
+        let (store, runtime) = try makeBridgeableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        try GPTKImporter.remove(fromLibraryFolder: runtime, usingStore: store)
+
+        let fileManager = FileManager.default
+        let bridge = GPTKImporter.metalFXBridgePE(inLibraryFolder: runtime)
+        #expect(!fileManager.fileExists(atPath: bridge.path(percentEncoded: false)))
+        // the link is dangling by now, so ask about the link itself
+        let link = GPTKImporter.metalFXBridgeUnixLink(inLibraryFolder: runtime)
+        #expect((try? fileManager.destinationOfSymbolicLink(atPath: link.path(percentEncoded: false))) == nil)
+    }
+
+    @Test("A bridge this store did not install is left alone")
+    func removeLeavesForeignBridge() throws {
+        let (store, runtime) = try makeBridgeableRuntime()
+        let bridge = GPTKImporter.metalFXBridgePE(inLibraryFolder: runtime)
+        try FileManager.default.createDirectory(
+            at: bridge.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try Data("someone else's nvngx".utf8).write(to: bridge)
+
+        GPTKImporter.removeMetalFXBridge(fromLibraryFolder: runtime, usingStore: store)
+
+        #expect(FileManager.default.fileExists(atPath: bridge.path(percentEncoded: false)))
+    }
+
+    // MARK: - Prefixes
+
+    @Test("Seeding puts a placeholder in the prefix, without which nothing loads")
+    func seedWritesPlaceholder() throws {
+        let (store, runtime) = try makeBridgeableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        let bottle = try makeBottle()
+
+        GPTKImporter.seedMetalFXBridgePlaceholder(inBottle: bottle, fromLibraryFolder: runtime)
+
+        let placeholder = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32").appending(path: GPTKImporter.metalFXBridgeName)
+        #expect(FileManager.default.fileExists(atPath: placeholder.path(percentEncoded: false)))
+    }
+
+    @Test("Seeding never overwrites a placeholder that is already there")
+    func seedKeepsExistingPlaceholder() throws {
+        let (store, runtime) = try makeBridgeableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        let bottle = try makeBottle()
+        let placeholder = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32").appending(path: GPTKImporter.metalFXBridgeName)
+        try Data("wineboot's own".utf8).write(to: placeholder)
+
+        GPTKImporter.seedMetalFXBridgePlaceholder(inBottle: bottle, fromLibraryFolder: runtime)
+
+        #expect(try Data(contentsOf: placeholder) == Data("wineboot's own".utf8))
+    }
+
+    @Test("A runtime with no bridge seeds nothing")
+    func seedSkipsRuntimeWithoutBridge() throws {
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        let bottle = try makeBottle()
+
+        GPTKImporter.seedMetalFXBridgePlaceholder(inBottle: bottle, fromLibraryFolder: runtime)
+
+        let placeholder = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32").appending(path: GPTKImporter.metalFXBridgeName)
+        #expect(!FileManager.default.fileExists(atPath: placeholder.path(percentEncoded: false)))
+    }
+
+    // MARK: - Opting out
+
+    @Test("Clearing removes the placeholder, which is what makes the bridge unreachable")
+    func clearRemovesPlaceholder() throws {
+        let (store, runtime) = try makeBridgeableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        let bottle = try makeBottle()
+        GPTKImporter.seedMetalFXBridgePlaceholder(inBottle: bottle, fromLibraryFolder: runtime)
+
+        GPTKImporter.clearMetalFXBridgePlaceholder(inBottle: bottle)
+
+        let placeholder = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32").appending(path: GPTKImporter.metalFXBridgeName)
+        #expect(!FileManager.default.fileExists(atPath: placeholder.path(percentEncoded: false)))
+    }
+
+    @Test("Clearing removes a stub wineboot wrote, or opting out would not stick")
+    func clearRemovesWinebootStub() throws {
+        let (store, runtime) = try makeBridgeableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        let bottle = try makeBottle()
+        let placeholder = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32").appending(path: GPTKImporter.metalFXBridgeName)
+        // wineboot's own stub: builtin-marked, but not a copy of ours
+        try fakePE(builtin: true).write(to: placeholder)
+
+        GPTKImporter.clearMetalFXBridgePlaceholder(inBottle: bottle)
+
+        #expect(!FileManager.default.fileExists(atPath: placeholder.path(percentEncoded: false)))
+    }
+
+    @Test("Clearing leaves a native nvngx someone installed themselves")
+    func clearLeavesNativeDLL() throws {
+        let (store, runtime) = try makeBridgeableRuntime()
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        let bottle = try makeBottle()
+        let placeholder = bottle.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32").appending(path: GPTKImporter.metalFXBridgeName)
+        try fakePE(builtin: false).write(to: placeholder)
+
+        GPTKImporter.clearMetalFXBridgePlaceholder(inBottle: bottle)
+
+        #expect(FileManager.default.fileExists(atPath: placeholder.path(percentEncoded: false)))
+    }
+}
+
+@Suite("MetalFX Setting Tests")
+struct MetalFXSettingTests {
+    @Test("The setting is off by default and survives a round trip")
+    func settingRoundTrips() throws {
+        var settings = BottleSettings()
+        #expect(!settings.metalFX)
+
+        settings.metalFX = true
+        let decoded = try PropertyListDecoder().decode(
+            BottleSettings.self, from: PropertyListEncoder().encode(settings)
+        )
+
+        #expect(decoded.metalFX)
+    }
+
+    @Test("The env var is set only when the bottle opted in, and only under D3DMetal")
+    func environmentFollowsTheSetting() throws {
+        var builder = EnvironmentBuilder()
+        var settings = BottleSettings()
+        settings.graphicsBackend = .d3dMetal
+        _ = settings.populateBottleManagedLayer(builder: &builder, resolvedBackend: .d3dMetal)
+        #expect(builder.resolve().environment["D3DM_ENABLE_METALFX"] == nil)
+
+        settings.metalFX = true
+        var onBuilder = EnvironmentBuilder()
+        _ = settings.populateBottleManagedLayer(builder: &onBuilder, resolvedBackend: .d3dMetal)
+        #expect(onBuilder.resolve().environment["D3DM_ENABLE_METALFX"] == "1")
+
+        // DXVK never reaches D3DMetal's bridge, so the knob would be a lie
+        settings.graphicsBackend = .dxvk
+        var dxvkBuilder = EnvironmentBuilder()
+        _ = settings.populateBottleManagedLayer(builder: &dxvkBuilder, resolvedBackend: .dxvk)
+        #expect(dxvkBuilder.resolve().environment["D3DM_ENABLE_METALFX"] == nil)
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKMetalFXTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKMetalFXTests.swift
@@ -85,10 +85,20 @@ struct GPTKMetalFXTests {
     func installIsIdempotent() throws {
         let (store, runtime) = try makeBridgeableRuntime()
         try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        let bridge = GPTKImporter.metalFXBridgePE(inLibraryFolder: runtime)
+        let before = try FileManager.default.attributesOfItem(
+            atPath: bridge.path(percentEncoded: false)
+        )[.creationDate] as? Date
 
         try GPTKImporter.installMetalFXBridge(intoLibraryFolder: runtime, usingStore: store)
 
         #expect(GPTKImporter.isMetalFXBridgeInstalled(inLibraryFolder: runtime, usingStore: store))
+        // launch-time install runs every time, and rewriting a file that already
+        // matches the store is work nobody asked for
+        let after = try FileManager.default.attributesOfItem(
+            atPath: bridge.path(percentEncoded: false)
+        )[.creationDate] as? Date
+        #expect(before == after)
     }
 
     // MARK: - Remove
@@ -207,6 +217,72 @@ struct GPTKMetalFXTests {
         GPTKImporter.clearMetalFXBridgePlaceholder(inBottle: bottle)
 
         #expect(FileManager.default.fileExists(atPath: placeholder.path(percentEncoded: false)))
+    }
+}
+
+@Suite("MetalFX Backend Reconciliation Tests")
+@MainActor
+struct MetalFXBackendTests {
+    private let tempDir: URL
+
+    init() throws {
+        tempDir = try makeGPTKTempDir()
+    }
+
+    private func makeBottle(metalFX: Bool) throws -> Bottle {
+        let url = tempDir.appending(path: "bottle")
+        try FileManager.default.createDirectory(
+            at: url.appending(path: "drive_c").appending(path: "windows").appending(path: "system32"),
+            withIntermediateDirectories: true
+        )
+        let bottle = Bottle(bottleUrl: url)
+        bottle.settings.metalFX = metalFX
+        return bottle
+    }
+
+    private func placeholder(inBottle bottle: Bottle) -> URL {
+        bottle.url.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32").appending(path: GPTKImporter.metalFXBridgeName)
+    }
+
+    private func makeRuntimeWithBridge() throws -> URL {
+        let store = try makeImportedStore(in: tempDir)
+        try makeStoreMetalFXBridge(inStore: store)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+        return runtime
+    }
+
+    @Test("D3DMetal with the setting on seeds the placeholder")
+    func d3dMetalSeeds() throws {
+        let runtime = try makeRuntimeWithBridge()
+        let bottle = try makeBottle(metalFX: true)
+
+        Wine.applyMetalFX(bottle: bottle, backend: .d3dMetal, libraryFolder: runtime)
+
+        #expect(FileManager.default.fileExists(
+            atPath: placeholder(inBottle: bottle).path(percentEncoded: false)
+        ))
+    }
+
+    @Test("Switching off D3DMetal clears the placeholder, setting on or not")
+    func otherBackendsClear() throws {
+        let runtime = try makeRuntimeWithBridge()
+        let bottle = try makeBottle(metalFX: true)
+
+        for backend in [GraphicsBackend.dxvk, .dxmt, .wined3d] {
+            Wine.applyMetalFX(bottle: bottle, backend: .d3dMetal, libraryFolder: runtime)
+            #expect(FileManager.default.fileExists(
+                atPath: placeholder(inBottle: bottle).path(percentEncoded: false)
+            ))
+
+            // only D3DMetal answers the DLSS entry points behind the placeholder
+            Wine.applyMetalFX(bottle: bottle, backend: backend, libraryFolder: runtime)
+            #expect(!FileManager.default.fileExists(
+                atPath: placeholder(inBottle: bottle).path(percentEncoded: false)
+            ))
+        }
     }
 }
 

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKMetalFXTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKMetalFXTests.swift
@@ -212,33 +212,48 @@ struct GPTKMetalFXTests {
 
 @Suite("MetalFX Setting Tests")
 struct MetalFXSettingTests {
-    @Test("The setting is off by default and survives a round trip")
+    @Test("The setting is on by default and survives a round trip")
     func settingRoundTrips() throws {
         var settings = BottleSettings()
-        #expect(!settings.metalFX)
+        #expect(settings.metalFX)
 
-        settings.metalFX = true
+        settings.metalFX = false
         let decoded = try PropertyListDecoder().decode(
             BottleSettings.self, from: PropertyListEncoder().encode(settings)
         )
 
+        #expect(!decoded.metalFX)
+    }
+
+    @Test("A bottle written before the key existed picks up the new default")
+    func absentKeyDefaultsOn() throws {
+        // The graphics config is nested, so an older bottle's plist has the
+        // dictionary without the key rather than no dictionary at all.
+        let plist: [String: Any] = ["graphicsConfig": ["backend": "recommended"]]
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plist, format: .xml, options: 0
+        )
+
+        let decoded = try PropertyListDecoder().decode(BottleSettings.self, from: data)
+
         #expect(decoded.metalFX)
     }
 
-    @Test("The env var is set only when the bottle opted in, and only under D3DMetal")
+    @Test("The env var follows the setting, and is only set under D3DMetal")
     func environmentFollowsTheSetting() throws {
         var builder = EnvironmentBuilder()
         var settings = BottleSettings()
         settings.graphicsBackend = .d3dMetal
         _ = settings.populateBottleManagedLayer(builder: &builder, resolvedBackend: .d3dMetal)
-        #expect(builder.resolve().environment["D3DM_ENABLE_METALFX"] == nil)
+        #expect(builder.resolve().environment["D3DM_ENABLE_METALFX"] == "1")
 
-        settings.metalFX = true
-        var onBuilder = EnvironmentBuilder()
-        _ = settings.populateBottleManagedLayer(builder: &onBuilder, resolvedBackend: .d3dMetal)
-        #expect(onBuilder.resolve().environment["D3DM_ENABLE_METALFX"] == "1")
+        settings.metalFX = false
+        var offBuilder = EnvironmentBuilder()
+        _ = settings.populateBottleManagedLayer(builder: &offBuilder, resolvedBackend: .d3dMetal)
+        #expect(offBuilder.resolve().environment["D3DM_ENABLE_METALFX"] == nil)
 
         // DXVK never reaches D3DMetal's bridge, so the knob would be a lie
+        settings.metalFX = true
         settings.graphicsBackend = .dxvk
         var dxvkBuilder = EnvironmentBuilder()
         _ = settings.populateBottleManagedLayer(builder: &dxvkBuilder, resolvedBackend: .dxvk)


### PR DESCRIPTION
MetalFX cannot be enabled in any bottle, which is #198. `D3DM_ENABLE_METALFX=1` reaches D3DMetal and does nothing, on every runtime and every game.

The reason is that MetalFX has exactly one entry point, and it is the DLSS API. D3DMetal links MetalFX and builds its scalers, but only for a game that calls `NVSDK_NGX_D3D12_*` in `nvngx.dll`, which Apple implements as `nvngx-on-metalfx.dll`. We deploy Apple's four D3D forwarders out of the payload and skip that one, so there is nothing in the tree for the variable to hook. The switch was real, the thing it switches on was never installed.

## two traps in installing it

Neither is obvious and both cost time to find:

1. The bridge is a hybrid PE and unixlib module. Its `DllMain` calls `__wine_init_unix_call` before anything else and returns false when that fails, so the PE on its own loads as a builtin and dies immediately with `ERROR_DLL_INIT_FAILED`, which reads like a corrupt DLL and is not. It needs its unix half linked beside it, exactly like the four forwarders.
2. Wine keys builtins on the name a DLL declares in its PE export directory, not on the filename. This one exports as `nvngx.dll` while Apple ships it as `nvngx-on-metalfx.dll`, so it has to be installed under the exported name or the loader never matches it.

`nvapi64.dll`, the other half of Apple's NVIDIA bridge pair, deliberately stays out. Chromium probes for an NVIDIA GPU, and handing it one makes it load D3DMetal and take Steam's helper process down with it. Nothing probes for nvngx that way, so the bridge on its own is safe to deploy.

That is not free, and an earlier version of this description said it was. A title built on NVIDIA Streamline asks NVAPI about the GPU before it will consider DLSS at all, and Wine's `nvapi64` exports nothing, so Streamline decides there is no NVIDIA driver and never offers a DLSS option. Those titles get the bridge installed and cannot reach it, with nothing in any log to say why; I traced that on Deep Rock Galactic with a relay scoped to `nvngx.*`. A title that calls NGX directly is unaffected.

Closing that gap means giving the game a real `nvapi64` while keeping it away from the launcher helper, which needs a per-exe `AppDefaults\<exe>\DllOverrides` entry rather than the environment every child process inherits. That is a separate PR, and why this one leaves #198 open.

## the per-bottle switch

The bridge is a builtin in the shared tree, so it cannot be installed per bottle. What can is the `system32` entry the loader needs before it will look in the builtin directory at all: without one, `LoadLibrary("nvngx.dll")` fails with `ERROR_MOD_NOT_FOUND` however complete the tree is. So the placeholder is the switch, seeded or cleared at launch from the bottle setting whenever the effective backend is D3DMetal.

Clearing removes any builtin-marked entry, including one `wineboot` recreated during a prefix update, or opting out would not stick. A native `nvngx.dll` someone put there themselves is left alone.

## on by default

Second commit, separable if you would rather it stayed opt-in. It began as opt-in on the theory that a game finding the bridge takes its DLSS path instead of whatever it would otherwise have used, which could regress as easily as help. Measured, it helps, so the default flipped. The decoder fallback moved with it, or every bottle written before the key existed would decode as off and never see the new default.

Worth knowing for the issue thread: MetalFX only engages for a game that actually asks for DLSS, with DLSS switched on in the game's own settings. A game with no DLSS option never reaches it, whatever the toggle says.

## what this deliberately leaves out

- **Metal 4.** The preview fork turns that on in the same commit; it does not exist here, so none of it is in this PR.
- **The D3D12 video processor.** That is #197, still open. Both touch `GPTKImporter+Deployment`, so whichever lands first leaves the other a two line rebase.

## verified

- `WhiskyKit` suite: 1256 XCTest and 135 swift-testing, 0 failures, 16 new covering the install and its idempotency, removal leaving a hand-installed copy alone, the unix link, prefix seeding and clearing, reconciliation across a backend switch, and the setting round trip
- swiftformat `--lint` and swiftlint `--strict` both clean
- the app target builds
- shipped in the preview fork with the default on, where MetalFX engages in titles that call NGX directly

Not verified: an end-to-end launch of a Streamline title offering DLSS against Apple's payload on this configuration. It will not, for the NVAPI reason above, and the follow-up owns that.

part of #198

