### PR TITLE
give the bottle action bar one primary control

### DIFF
--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		6E40495A29CCA19C006E3F1B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6E40495929CCA19C006E3F1B /* Assets.xcassets */; };
 		6E40495D29CCA19C006E3F1B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6E40495C29CCA19C006E3F1B /* Preview Assets.xcassets */; };
 		6E40498129CCA8B0006E3F1B /* BottleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E40498029CCA8B0006E3F1B /* BottleView.swift */; };
+		C1A2B3C4E5F60601A9B0B1D8 /* BottleActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4E5F60601A9B0B1D9 /* BottleActionBar.swift */; };
 		A5175A536850D4926FE4C480 /* SteamLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1453C3A95B17CD3DE867F7 /* SteamLibraryView.swift */; };
 		6E40498329CCA91B006E3F1B /* Bottle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E40498229CCA91B006E3F1B /* Bottle+Extensions.swift */; };
 		6E49E0212AECB7DB00009CAC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E49E0202AECB7DB00009CAC /* SettingsView.swift */; };
@@ -231,6 +232,7 @@
 		6E40495C29CCA19C006E3F1B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		6E40495E29CCA19C006E3F1B /* Whisky.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Whisky.entitlements; sourceTree = "<group>"; };
 		6E40498029CCA8B0006E3F1B /* BottleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleView.swift; sourceTree = "<group>"; };
+		C1A2B3C4E5F60601A9B0B1D9 /* BottleActionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleActionBar.swift; sourceTree = "<group>"; };
 		BB1453C3A95B17CD3DE867F7 /* SteamLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteamLibraryView.swift; sourceTree = "<group>"; };
 		6E40498229CCA91B006E3F1B /* Bottle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bottle+Extensions.swift"; sourceTree = "<group>"; };
 		6E49E0202AECB7DB00009CAC /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -436,6 +438,7 @@
 			children = (
 				C1A2B3C4E5F60601A9B0C1D9 /* AudioConfigSection.swift */,
 				6E40498029CCA8B0006E3F1B /* BottleView.swift */,
+				C1A2B3C4E5F60601A9B0B1D9 /* BottleActionBar.swift */,
 				BB1453C3A95B17CD3DE867F7 /* SteamLibraryView.swift */,
 				6365C4C22B1AA8CD00AAE1FD /* BottleListEntry.swift */,
 				6E50D98429CDF25B008C39F6 /* BottleCreationView.swift */,
@@ -990,6 +993,7 @@
 				6E7C07C02AAF570100F6E66B /* FileOpenView.swift in Sources */,
 				6E6C0CF22A419A6800356232 /* WelcomeView.swift in Sources */,
 				6E40498129CCA8B0006E3F1B /* BottleView.swift in Sources */,
+				C1A2B3C4E5F60601A9B0B1D8 /* BottleActionBar.swift in Sources */,
 				A5175A536850D4926FE4C480 /* SteamLibraryView.swift in Sources */,
 				6E355E5E29D7D85D002D83BE /* ProgramView.swift in Sources */,
 				954F64484BFDF7786A5B184E /* LauncherDetection.swift in Sources */,

--- a/Whisky/Views/Bottle/BottleActionBar.swift
+++ b/Whisky/Views/Bottle/BottleActionBar.swift
@@ -1,0 +1,178 @@
+//
+//  BottleActionBar.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+import WhiskyKit
+
+/// The four actions along the bottom of a bottle.
+struct BottleActionBar: View {
+    @ObservedObject var bottle: Bottle
+    @Binding var showWinetricksSheet: Bool
+    @Binding var programLoading: Bool
+    @Binding var toast: ToastData?
+    /// Called after a launch so the caller can refresh what it keeps in step
+    /// with the prefix, the start menu among it.
+    let onLaunch: () async -> Void
+
+    /// The bar's four actions.
+    ///
+    /// Running a program is the reason the app exists, so it is the only
+    /// prominent control here; the other three were visually identical to it
+    /// before, which made opening a terminal look as important as launching a
+    /// game.
+    ///
+    /// Liquid Glass where the system has it. GlassEffectContainer is macOS 26
+    /// only and is what lets the capsules blend instead of stacking their own
+    /// layers, so the older path is the same buttons in bordered styles, which
+    /// still carries the emphasis.
+    @ViewBuilder
+    var body: some View {
+        if #available(macOS 26.0, *) {
+            GlassEffectContainer(spacing: 8) {
+                buttons
+            }
+        } else {
+            buttons
+        }
+    }
+
+    @ViewBuilder
+    private var buttons: some View {
+        HStack {
+            Spacer()
+            Button("button.cDrive") {
+                bottle.openCDrive()
+            }
+            .glassButton()
+            .accessibilityIdentifier("bottle.openCDrive")
+            Button("button.terminal") {
+                bottle.openTerminal()
+            }
+            .glassButton()
+            .accessibilityIdentifier("bottle.openTerminal")
+            Button("button.winetricks") {
+                showWinetricksSheet.toggle()
+            }
+            .glassButton()
+            .accessibilityIdentifier("bottle.openWinetricks")
+            Button("button.run") {
+                let panel = NSOpenPanel()
+                panel.allowsMultipleSelection = false
+                panel.canChooseDirectories = false
+                panel.canChooseFiles = true
+                panel.allowedContentTypes = [
+                    UTType.exe,
+                    UTType(exportedAs: "com.microsoft.msi-installer"),
+                    UTType(exportedAs: "com.microsoft.bat"),
+                    UTType(exportedAs: "com.microsoft.msix-package"),
+                    UTType(exportedAs: "com.microsoft.appx-package"),
+                    UTType(exportedAs: "com.microsoft.application-reference"),
+                    UTType(exportedAs: "com.microsoft.windows-internet-shortcut")
+                ]
+                panel.directoryURL = bottle.url.appending(path: "drive_c")
+                panel.begin { result in
+                    programLoading = true
+                    Task(priority: .userInitiated) {
+                        if result == .OK {
+                            if let url = panel.urls.first {
+                                do {
+                                    // Auto-detect launcher and apply fixes if compatibility mode enabled
+                                    // This completes synchronously on MainActor, ensuring settings are
+                                    // persisted before Wine.runProgram() reads them
+                                    LauncherFixes.detectAndApply(from: url, for: bottle)
+
+                                    Telemetry.capture(.firstProgramLaunchAttempted)
+                                    if url.pathExtension == "bat" {
+                                        try await Wine.runBatchFile(url: url, bottle: bottle)
+                                    } else {
+                                        try await Wine.runProgram(at: url, bottle: bottle)
+                                    }
+                                    await MainActor.run {
+                                        withAnimation {
+                                            toast = ToastData(
+                                                message: String(
+                                                    localized: "status.launched \(url.lastPathComponent)"
+                                                ),
+                                                style: .success
+                                            )
+                                        }
+                                    }
+                                } catch {
+                                    let errDesc = error.localizedDescription
+                                    await MainActor.run {
+                                        withAnimation {
+                                            toast = ToastData(
+                                                message: String(
+                                                    localized: "status.launchFailed \(errDesc)"
+                                                ),
+                                                style: .error,
+                                                autoDismiss: false
+                                            )
+                                        }
+                                    }
+                                }
+                                await MainActor.run {
+                                    programLoading = false
+                                }
+                            }
+                        } else {
+                            await MainActor.run {
+                                programLoading = false
+                            }
+                        }
+                        await onLaunch()
+                    }
+                }
+            }
+            // Running a program is the reason the app exists, so it is
+            // the only prominent control on this bar.
+            .glassButton(prominent: true)
+            .accessibilityIdentifier("bottle.runProgram")
+            .disabled(programLoading)
+            if programLoading {
+                Spacer()
+                    .frame(width: 10)
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .padding()
+    }
+}
+
+private extension View {
+    /// Glass on macOS 26, bordered before it. The emphasis is the point and it
+    /// survives either way.
+    @ViewBuilder
+    func glassButton(prominent: Bool = false) -> some View {
+        if #available(macOS 26.0, *) {
+            if prominent {
+                buttonStyle(.glassProminent)
+            } else {
+                buttonStyle(.glass)
+            }
+        } else {
+            if prominent {
+                buttonStyle(.borderedProminent)
+            } else {
+                buttonStyle(.bordered)
+            }
+        }
+    }
+}

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -95,99 +95,13 @@ struct BottleView: View {
                 .scrollDisabled(true)
             }
             .bottomBar {
-                HStack {
-                    Spacer()
-                    Button("button.cDrive") {
-                        bottle.openCDrive()
-                    }
-                    .accessibilityIdentifier("bottle.openCDrive")
-                    Button("button.terminal") {
-                        bottle.openTerminal()
-                    }
-                    .accessibilityIdentifier("bottle.openTerminal")
-                    Button("button.winetricks") {
-                        showWinetricksSheet.toggle()
-                    }
-                    .accessibilityIdentifier("bottle.openWinetricks")
-                    Button("button.run") {
-                        let panel = NSOpenPanel()
-                        panel.allowsMultipleSelection = false
-                        panel.canChooseDirectories = false
-                        panel.canChooseFiles = true
-                        panel.allowedContentTypes = [
-                            UTType.exe,
-                            UTType(exportedAs: "com.microsoft.msi-installer"),
-                            UTType(exportedAs: "com.microsoft.bat"),
-                            UTType(exportedAs: "com.microsoft.msix-package"),
-                            UTType(exportedAs: "com.microsoft.appx-package"),
-                            UTType(exportedAs: "com.microsoft.application-reference"),
-                            UTType(exportedAs: "com.microsoft.windows-internet-shortcut")
-                        ]
-                        panel.directoryURL = bottle.url.appending(path: "drive_c")
-                        panel.begin { result in
-                            programLoading = true
-                            Task(priority: .userInitiated) {
-                                if result == .OK {
-                                    if let url = panel.urls.first {
-                                        do {
-                                            // Auto-detect launcher and apply fixes if compatibility mode enabled
-                                            // This completes synchronously on MainActor, ensuring settings are
-                                            // persisted before Wine.runProgram() reads them
-                                            LauncherFixes.detectAndApply(from: url, for: bottle)
-
-                                            Telemetry.capture(.firstProgramLaunchAttempted)
-                                            if url.pathExtension == "bat" {
-                                                try await Wine.runBatchFile(url: url, bottle: bottle)
-                                            } else {
-                                                try await Wine.runProgram(at: url, bottle: bottle)
-                                            }
-                                            await MainActor.run {
-                                                withAnimation {
-                                                    toast = ToastData(
-                                                        message: String(
-                                                            localized: "status.launched \(url.lastPathComponent)"
-                                                        ),
-                                                        style: .success
-                                                    )
-                                                }
-                                            }
-                                        } catch {
-                                            let errDesc = error.localizedDescription
-                                            await MainActor.run {
-                                                withAnimation {
-                                                    toast = ToastData(
-                                                        message: String(
-                                                            localized: "status.launchFailed \(errDesc)"
-                                                        ),
-                                                        style: .error,
-                                                        autoDismiss: false
-                                                    )
-                                                }
-                                            }
-                                        }
-                                        await MainActor.run {
-                                            programLoading = false
-                                        }
-                                    }
-                                } else {
-                                    await MainActor.run {
-                                        programLoading = false
-                                    }
-                                }
-                                await updateStartMenu()
-                            }
-                        }
-                    }
-                    .accessibilityIdentifier("bottle.runProgram")
-                    .disabled(programLoading)
-                    if programLoading {
-                        Spacer()
-                            .frame(width: 10)
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-                }
-                .padding()
+                BottleActionBar(
+                    bottle: bottle,
+                    showWinetricksSheet: $showWinetricksSheet,
+                    programLoading: $programLoading,
+                    toast: $toast,
+                    onLaunch: updateStartMenu
+                )
             }
             .task {
                 await updateStartMenu()


### PR DESCRIPTION
Open C: Drive, Terminal, Winetricks and Run are four identical flat labels on a material strip. Running a program is the reason the app exists, and it currently looks exactly as important as opening a terminal.

Run becomes the only prominent control on the bar.

## on macOS 26 and before

`GlassEffectContainer` is what lets adjacent capsules blend instead of each stacking its own layer, and it is macOS 26 only. So the bar has two paths: glass styles inside a container where the system has them, bordered styles where it does not. The emphasis is the point and it lands either way; the material is the part that varies.

Both paths go through one `glassButton(prominent:)` helper rather than being written twice.

## why a new file

The bar moves to `BottleActionBar`. `BottleView` was already close enough to the type body length limit that adding two computed properties crossed it, and a bar with four actions and a launch flow is a component rather than something that belongs inline in a screen.

## verified

- the app target builds
- swiftformat `--lint` and swiftlint `--strict` both clean
