### PR TITLE
write the audio registry the settings have always claimed to control

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Extensions/Program+Extensions.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Extensions/Program+Extensions.swift
@@ -93,6 +93,8 @@ public extension Program {
         }
 
         // Normal Wine launch with program-specific settings
+        await Wine.syncAudioRegistry(bottle: bottle)
+
         let arguments = settings.arguments.split { $0.isWhitespace }.map(String.init)
         let environment = generateEnvironment()
 

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
@@ -75,6 +75,7 @@ public enum SteamLauncher {
         let steamExe = steamRoot.appending(path: "steam.exe")
 
         return Task {
+            await Wine.syncAudioRegistry(bottle: bottle)
             _ = try? await Wine.runProgram(
                 at: steamExe, args: ["-applaunch", String(appId)], bottle: bottle,
                 programOverrides: plan.overrides,

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineAudioRegistry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineAudioRegistry.swift
@@ -21,6 +21,44 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.whiskyBundleIdentifier, category: "WineAudioRegistry")
 
+/// The audio registry values Whisky last wrote into a bottle, kept as a
+/// marker file so launches only spawn `wine reg` when the settings changed.
+struct AudioRegistryState: Codable, Equatable {
+    var driver: String
+    var helBuflen: Int
+
+    /// What the bottle's current settings ask the registry to contain.
+    @MainActor
+    static func desired(for bottle: Bottle) -> AudioRegistryState {
+        AudioRegistryState(
+            driver: bottle.settings.audioDriver.rawValue,
+            helBuflen: bottle.settings.audioLatencyPreset.helBuflenValue
+        )
+    }
+
+    /// Auto driver detection and Wine's own default buffer size: the state
+    /// a fresh prefix already has without any registry write.
+    static let factoryDefault = AudioRegistryState(
+        driver: AudioDriverMode.auto.rawValue,
+        helBuflen: AudioLatencyPreset.defaultPreset.helBuflenValue
+    )
+
+    static func markerURL(in bottleURL: URL) -> URL {
+        bottleURL.appending(path: ".audio-registry-state.plist")
+    }
+
+    static func load(from bottleURL: URL) -> AudioRegistryState? {
+        guard let data = try? Data(contentsOf: markerURL(in: bottleURL)) else { return nil }
+        return try? PropertyListDecoder().decode(AudioRegistryState.self, from: data)
+    }
+
+    func save(to bottleURL: URL) throws {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        try encoder.encode(self).write(to: Self.markerURL(in: bottleURL))
+    }
+}
+
 /// Extension on ``Wine`` providing typed read/write methods for Wine audio registry keys.
 ///
 /// Audio driver selection and DirectSound buffer configuration are stored in the Wine
@@ -115,6 +153,39 @@ public extension Wine {
             data: String(helBuflen),
             type: .string
         )
+    }
+
+    /// Brings the bottle's Wine registry in line with its audio settings.
+    ///
+    /// The settings UI and the troubleshooting fixes only mutate
+    /// ``BottleSettings``; the registry values Wine actually reads are written
+    /// here, from the launch path, and only when the marker file shows they
+    /// changed. A missing marker on factory settings is stamped without
+    /// booting wineserver, since a fresh prefix already behaves that way.
+    @MainActor
+    static func syncAudioRegistry(bottle: Bottle) async {
+        let desired = AudioRegistryState.desired(for: bottle)
+        let applied = AudioRegistryState.load(from: bottle.url)
+        guard desired != applied else { return }
+
+        if applied == nil, desired == .factoryDefault {
+            try? desired.save(to: bottle.url)
+            return
+        }
+
+        do {
+            if applied?.driver != desired.driver {
+                try await setAudioDriver(bottle: bottle, driver: bottle.settings.audioDriver)
+            }
+            if applied?.helBuflen != desired.helBuflen {
+                try await setDirectSoundBuffer(bottle: bottle, helBuflen: desired.helBuflen)
+            }
+            try desired.save(to: bottle.url)
+        } catch {
+            logger.error(
+                "Audio registry sync failed for '\(bottle.settings.name)': \(error.localizedDescription)"
+            )
+        }
     }
 
     /// Resets Wine audio device state by clearing cached device mappings and restarting wineserver.

--- a/WhiskyKit/Tests/WhiskyKitTests/AudioRegistrySyncTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/AudioRegistrySyncTests.swift
@@ -1,0 +1,99 @@
+//
+//  AudioRegistrySyncTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+/// Covers the marker bookkeeping around ``Wine/syncAudioRegistry(bottle:)``.
+/// The registry-writing path itself spawns wineserver and is deliberately
+/// not exercised, same policy as the restart-wineserver fix.
+@Suite("Audio Registry Sync Tests")
+struct AudioRegistrySyncTests {
+    private func makeBottleDir() -> (url: URL, cleanup: () -> Void) {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        return (tempDir, { try? FileManager.default.removeItem(at: tempDir) })
+    }
+
+    @Test("Marker round-trips through the plist")
+    func markerRoundTrips() throws {
+        let (dir, cleanup) = makeBottleDir()
+        defer { cleanup() }
+
+        let state = AudioRegistryState(driver: "coreaudio", helBuflen: 131_072)
+        try state.save(to: dir)
+
+        #expect(AudioRegistryState.load(from: dir) == state)
+    }
+
+    @Test("A missing or corrupt marker loads as nil")
+    func missingOrCorruptMarkerIsNil() throws {
+        let (dir, cleanup) = makeBottleDir()
+        defer { cleanup() }
+
+        #expect(AudioRegistryState.load(from: dir) == nil)
+
+        try Data("not a plist".utf8).write(to: AudioRegistryState.markerURL(in: dir))
+        #expect(AudioRegistryState.load(from: dir) == nil)
+    }
+
+    @Test("Desired state mirrors the bottle's audio settings")
+    @MainActor
+    func desiredMirrorsSettings() {
+        let (dir, cleanup) = makeBottleDir()
+        defer { cleanup() }
+
+        let bottle = Bottle(bottleUrl: dir, inFlight: false, isAvailable: true)
+        bottle.settings.audioDriver = .coreaudio
+        bottle.settings.audioLatencyPreset = .stable
+
+        let desired = AudioRegistryState.desired(for: bottle)
+        #expect(desired.driver == "coreaudio")
+        #expect(desired.helBuflen == AudioLatencyPreset.stable.helBuflenValue)
+    }
+
+    @Test("Factory settings stamp the marker without booting wineserver")
+    @MainActor
+    func factoryDefaultsStampWithoutWine() async {
+        let (dir, cleanup) = makeBottleDir()
+        defer { cleanup() }
+
+        let bottle = Bottle(bottleUrl: dir, inFlight: false, isAvailable: true)
+        await Wine.syncAudioRegistry(bottle: bottle)
+
+        #expect(AudioRegistryState.load(from: dir) == .factoryDefault)
+    }
+
+    @Test("A marker matching the settings makes sync a no-op")
+    @MainActor
+    func matchingMarkerIsNoOp() async throws {
+        let (dir, cleanup) = makeBottleDir()
+        defer { cleanup() }
+
+        let bottle = Bottle(bottleUrl: dir, inFlight: false, isAvailable: true)
+        bottle.settings.audioDriver = .coreaudio
+        try AudioRegistryState.desired(for: bottle).save(to: dir)
+        let before = try Data(contentsOf: AudioRegistryState.markerURL(in: dir))
+
+        await Wine.syncAudioRegistry(bottle: bottle)
+
+        let after = try Data(contentsOf: AudioRegistryState.markerURL(in: dir))
+        #expect(before == after)
+    }
+}


### PR DESCRIPTION
the audio driver and latency preset in bottle settings were settings-file decoration: nothing ever wrote them to the wine registry. every launch now syncs them, tracked by a marker file in the bottle so wine reg only spawns when something actually changed. fresh bottles on factory settings just get stamped, no wineserver boot.