### PR TITLE
wire the placebo knobs to something real, or cut them

### DIFF
--- a/Whisky/Views/Bottle/GraphicsConfigSection.swift
+++ b/Whisky/Views/Bottle/GraphicsConfigSection.swift
@@ -68,21 +68,9 @@ struct GraphicsConfigSection: View {
                 Text("config.forceD3D11")
             }
 
-            // Sequoia Compatibility Mode -- always visible
-            Toggle(isOn: $bottle.settings.sequoiaCompatMode) {
-                VStack(alignment: .leading) {
-                    Text("config.sequoiaCompat")
-                    if resolvedBackend == .wined3d {
-                        Text("config.sequoiaCompat.d3dmetalOnly")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    } else {
-                        Text("config.sequoiaCompat.info")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
+            // The Sequoia compatibility toggle is gone: everything it set is a
+            // platform-layer fix applied on every supported macOS, so the
+            // switch changed nothing in either position.
 
             // "Advanced settings active" badge in Simple mode
             if !advancedMode, hasAdvancedSettingsConfigured {

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -890,29 +890,19 @@ public struct BottleSettings: Codable, Equatable {
             builder.set("MTL_DEBUG_LAYER", "1", layer: .bottleManaged)
         }
 
-        // macOS Sequoia compatibility mode (whisky-app/whisky#1310, #1372)
-        // Applies additional fixes for graphics and launcher issues on macOS 15.x
-        // Since macOS 15 is now the minimum deployment target, we only check the setting
-        if sequoiaCompatMode {
-            // Disable problematic Metal shader validation on Sequoia
-            // This helps fix graphics corruption issues (whisky-app/whisky#1310)
-            builder.set("MTL_DEBUG_LAYER", "0", layer: .bottleManaged)
-
-            // Stability improvements for D3DMetal on macOS 15.x
-            builder.set("D3DM_VALIDATION", "0", layer: .bottleManaged)
-
-            // Help with Steam and launcher compatibility (whisky-app/whisky#1307, #1372)
-            // Disable Wine's fsync which has issues on Sequoia
-            builder.set("WINEFSYNC", "0", layer: .bottleManaged)
-        }
+        // The old sequoiaCompatMode block is gone: all three values it set
+        // (MTL_DEBUG_LAYER, D3DM_VALIDATION, WINEFSYNC) are platform-layer
+        // fixes on every supported macOS, so the toggle's off position changed
+        // nothing and its on position only hid the provenance.
 
         // Performance preset handling (whisky-app/whisky#1361 - FPS regression fix)
         populatePerformancePreset(builder: &builder)
 
-        // Shader cache control
+        // Shader cache control. DXVK_STATE_CACHE is the variable DXVK actually
+        // reads; the previous pair (a compile-thread throttle and an NVIDIA GL
+        // driver variable) changed nothing on this platform.
         if !shaderCacheEnabled {
-            builder.set("DXVK_SHADER_COMPILE_THREADS", "1", layer: .bottleManaged)
-            builder.set("__GL_SHADER_DISK_CACHE", "0", layer: .bottleManaged)
+            builder.set("DXVK_STATE_CACHE", "0", layer: .bottleManaged)
         }
 
         // Force D3D11 mode - helps with compatibility (whisky-app/whisky#1361)
@@ -977,7 +967,7 @@ public struct BottleSettings: Codable, Equatable {
 
         // Apply GPU spoofing if enabled
         if gpuSpoofing {
-            let gpuEnv = GPUDetection.spoofWithVendor(gpuVendor)
+            let gpuEnv = spoofEnvironment()
             let launcherEnv = detectedLauncher?.environmentOverrides() ?? [:]
             // Don't override values already set by launcher preset (original behavior:
             // merge with "current.isEmpty ? new : current")
@@ -998,15 +988,27 @@ public struct BottleSettings: Codable, Equatable {
             builder.set("WINHTTP_RECEIVE_TIMEOUT", String(networkTimeout * 2), layer: .launcherManaged)
         }
 
-        // Connection pooling fixes for download stalls (whisky-app/whisky#1148, #1072, #1176)
-        builder.set("WINE_MAX_CONNECTIONS_PER_SERVER", "10", layer: .launcherManaged)
-        builder.set("WINE_FORCE_HTTP11", "1", layer: .launcherManaged) // HTTP/2 issues in Wine
-
-        // SSL/TLS compatibility for launchers
-        builder.set("WINE_ENABLE_SSL", "1", layer: .launcherManaged)
-        builder.set("WINE_SSL_VERSION_MIN", "TLS1.2", layer: .launcherManaged)
+        // The connection-pooling and SSL variables that used to be set here
+        // (WINE_MAX_CONNECTIONS_PER_SERVER and friends) exist in no Wine or
+        // WineCX source; nothing ever read them.
 
         return launcherDLLOverrides
+    }
+
+    /// The GPU spoof environment with feature-level keys resolved against the
+    /// bottle's own settings.
+    ///
+    /// Feature level is one resolved decision: force-D3D11 already pinned 12_0
+    /// off in the bottle layer, and the spoof's layer wins, so leaving these
+    /// keys in would silently undo the setting that sits beside the spoof in
+    /// the same screen.
+    private func spoofEnvironment() -> [String: String] {
+        var gpuEnv = GPUDetection.spoofWithVendor(gpuVendor)
+        if forceD3D11 {
+            gpuEnv.removeValue(forKey: "D3DM_FEATURE_LEVEL_12_0")
+            gpuEnv.removeValue(forKey: "D3DM_FEATURE_LEVEL_12_1")
+        }
+        return gpuEnv
     }
 
     /// Populates the ``EnvironmentLayer/bottleManaged`` layer with controller/input compatibility fixes.
@@ -1068,8 +1070,6 @@ public struct BottleSettings: Codable, Equatable {
 
         case .performance:
             // Performance mode - prioritize FPS over visual quality (whisky-app/whisky#1361 fix)
-            // Reduce D3DMetal shader quality for better performance
-            builder.set("D3DM_FAST_SHADER_COMPILE", "1", layer: .bottleManaged)
             // Disable extra validation that can slow down rendering
             builder.set("D3DM_VALIDATION", "0", layer: .bottleManaged)
             builder.set("MTL_DEBUG_LAYER", "0", layer: .bottleManaged)
@@ -1086,8 +1086,6 @@ public struct BottleSettings: Codable, Equatable {
             // Quality mode - prioritize visuals over performance
             // Enable shader optimizations
             builder.set("DXVK_SHADER_OPT_LEVEL", "2", layer: .bottleManaged)
-            // Disable fast shader compile for better quality
-            builder.set("D3DM_FAST_SHADER_COMPILE", "0", layer: .bottleManaged)
 
         case .unity:
             // Unity games optimization (whisky-app/whisky#1313, #1312 - il2cpp fix)
@@ -1103,8 +1101,6 @@ public struct BottleSettings: Codable, Equatable {
                 builder.set("D3DM_FORCE_D3D11", "1", layer: .bottleManaged)
             }
 
-            // Disable features that can cause issues with Unity's IL2CPP runtime
-            builder.set("WINE_HEAP_REUSE", "0", layer: .bottleManaged)
             // Help with thread management for Unity's job system
             builder.set("WINE_DISABLE_NTDLL_THREAD_REGS", "1", layer: .bottleManaged)
 

--- a/WhiskyKit/Sources/WhiskyKit/Wine/GPUDetection.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/GPUDetection.swift
@@ -132,9 +132,6 @@ public enum GPUDetection {
         // GPU model name for launcher display
         env["GPU_DESCRIPTION"] = model ?? vendor.modelName
 
-        // Vulkan configuration (MoltenVK on macOS)
-        env["VK_ICD_FILENAMES"] = "/usr/local/share/vulkan/icd.d/MoltenVK_icd.json"
-
         // VRAM reporting (8GB minimum for modern launchers)
         env["GPU_MEMORY_SIZE"] = "8192" // 8GB in MB
 

--- a/WhiskyKit/Sources/WhiskyKit/Wine/GraphicsBackendResolver.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/GraphicsBackendResolver.swift
@@ -40,12 +40,15 @@ public enum GraphicsBackendResolver {
     ///     runtime's version plist.
     ///   - d3dMetalInstalled: Whether the D3DMetal payload exists on disk. Defaults
     ///     to checking the installed runtime.
+    ///   - dxmtRuntimeNative: Whether the runtime's DXMT payload is the native
+    ///     variant. Defaults to checking the installed runtime.
     /// - Returns: A concrete ``GraphicsBackend`` (never `.recommended`).
     public static func resolve(
         for launcher: LauncherType? = nil,
         macOSVersion: MacOSVersion = .current,
         runtimeInfo: WhiskyWineVersion? = WhiskyWineInstaller.whiskyWineInfo(),
-        d3dMetalInstalled: Bool = WhiskyWineInstaller.isD3DMetalInstalled()
+        d3dMetalInstalled: Bool = WhiskyWineInstaller.isD3DMetalInstalled(),
+        dxmtRuntimeNative: Bool = Wine.isDXMTRuntimeNative()
     ) -> GraphicsBackend {
         if d3dMetalInstalled {
             // Launcher clients are Chromium and cannot render on D3DMetal:
@@ -56,7 +59,16 @@ public enum GraphicsBackendResolver {
             }
             return .d3dMetal
         }
-        if GraphicsBackend.dxmt.isAvailable(runtimeInfo: runtimeInfo) {
+        // The same gate the backend picker applies, not the version record
+        // alone: a version-only check lets auto promise DXMT on a runtime
+        // whose payload is missing or builtin-variant, which then throws
+        // payloadMissing at launch after the picker refused the same choice.
+        if WhiskyWineInstaller.backendAvailability(
+            .dxmt,
+            runtimeInfo: runtimeInfo,
+            d3dMetalInstalled: d3dMetalInstalled,
+            dxmtRuntimeNative: dxmtRuntimeNative
+        ) {
             return .dxmt
         }
         return .dxvk

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
@@ -84,6 +84,19 @@ extension Wine {
         let managedOverrides = bottle.settings.populateBottleManagedLayer(builder: &builder)
         dllResolver.managed.append(contentsOf: managedOverrides)
 
+        // DXVK reads its config from DXVK_CONFIG_FILE or the process working
+        // directory, and the working directory of a launch is never the bottle
+        // root the config editor writes to, so without this line the file is
+        // decoration. Z: maps the host filesystem and DXVK's PE build accepts
+        // forward slashes.
+        let dxvkConf = bottle.url.appending(path: "dxvk.conf")
+        if FileManager.default.fileExists(atPath: dxvkConf.path(percentEncoded: false)) {
+            builder.set(
+                "DXVK_CONFIG_FILE", "Z:\(dxvkConf.path(percentEncoded: false))",
+                layer: .bottleManaged, reason: "dxvk.conf present in the bottle"
+            )
+        }
+
         // Layer 4: Launcher managed -- launcher compatibility overrides
         let launcherOverrides = bottle.settings.populateLauncherManagedLayer(builder: &builder)
         dllResolver.managed.append(contentsOf: launcherOverrides)
@@ -276,14 +289,12 @@ extension Wine {
             }
         }
 
-        // Shader cache override
+        // Shader cache override, on the variable DXVK actually reads.
         if let shaderCache = overrides.shaderCacheEnabled {
             if !shaderCache {
-                builder.set("DXVK_SHADER_COMPILE_THREADS", "1", layer: .programUser)
-                builder.set("__GL_SHADER_DISK_CACHE", "0", layer: .programUser)
+                builder.set("DXVK_STATE_CACHE", "0", layer: .programUser)
             } else {
-                builder.remove("DXVK_SHADER_COMPILE_THREADS", layer: .programUser)
-                builder.remove("__GL_SHADER_DISK_CACHE", layer: .programUser)
+                builder.remove("DXVK_STATE_CACHE", layer: .programUser)
             }
         }
 

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleLauncherConfigTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleLauncherConfigTests.swift
@@ -162,27 +162,18 @@ final class BottleLauncherConfigTests: XCTestCase {
         XCTAssertEqual(env["WINEDLLOVERRIDES"], "d3d10core=n,b;d3d11=n,b;d3d9=n,b;dxgi=n,b")
     }
 
-    func testSSLTLSConfiguration() {
+    func testNoInventedNetworkVariables() {
         var settings = BottleSettings()
         settings.launcherCompatibilityMode = true
 
         var env: [String: String] = [:]
         settings.environmentVariables(wineEnv: &env)
 
-        // Should include SSL/TLS fixes
-        XCTAssertEqual(env["WINE_ENABLE_SSL"], "1")
-        XCTAssertEqual(env["WINE_SSL_VERSION_MIN"], "TLS1.2")
-    }
-
-    func testConnectionPoolingFixes() {
-        var settings = BottleSettings()
-        settings.launcherCompatibilityMode = true
-
-        var env: [String: String] = [:]
-        settings.environmentVariables(wineEnv: &env)
-
-        // Should include connection fixes
-        XCTAssertEqual(env["WINE_MAX_CONNECTIONS_PER_SERVER"], "10")
-        XCTAssertEqual(env["WINE_FORCE_HTTP11"], "1")
+        // These exist in no Wine or WineCX source, so setting them was
+        // decoration; launcher compatibility must not bring them back.
+        XCTAssertNil(env["WINE_ENABLE_SSL"])
+        XCTAssertNil(env["WINE_SSL_VERSION_MIN"])
+        XCTAssertNil(env["WINE_MAX_CONNECTIONS_PER_SERVER"])
+        XCTAssertNil(env["WINE_FORCE_HTTP11"])
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
@@ -199,9 +199,24 @@ final class EnvironmentVariablesTests: XCTestCase {
         XCTAssertEqual(env["D3DM_SUPPORT_DXR"], "1")
     }
 
+    func testSpoofDoesNotOutbidForceD3D11() {
+        var settings = BottleSettings()
+        settings.launcherCompatibilityMode = true
+        settings.gpuSpoofing = true
+        settings.forceD3D11 = true
+
+        var env: [String: String] = [:]
+        settings.environmentVariables(wineEnv: &env)
+
+        // Feature level is one resolved decision: the spoof's launcher layer
+        // must not undo the force-D3D11 pin from the bottle layer.
+        XCTAssertEqual(env["D3DM_FEATURE_LEVEL_12_0"], "0")
+        XCTAssertNil(env["D3DM_FEATURE_LEVEL_12_1"])
+    }
+
     // MARK: - Sequoia Compatibility Mode
 
-    func testEnvironmentVariablesWithSequoiaCompatMode() {
+    func testSequoiaToggleEmitsNothing() {
         var settings = BottleSettings()
         settings.sequoiaCompatMode = true
         settings.metalValidation = false
@@ -209,15 +224,28 @@ final class EnvironmentVariablesTests: XCTestCase {
         var env: [String: String] = [:]
         settings.environmentVariables(wineEnv: &env)
 
-        if MacOSVersion.current.major >= 15 {
-            XCTAssertEqual(env["MTL_DEBUG_LAYER"], "0")
-            XCTAssertEqual(env["D3DM_VALIDATION"], "0")
-            XCTAssertEqual(env["WINEFSYNC"], "0")
-        } else {
-            XCTAssertNil(env["MTL_DEBUG_LAYER"])
-            XCTAssertNil(env["D3DM_VALIDATION"])
-            XCTAssertNil(env["WINEFSYNC"])
-        }
+        // All three values the toggle used to set are platform-layer fixes on
+        // every supported macOS, carried with provenance by
+        // constructWineEnvironment; the bottle-layer duplicates meant the
+        // toggle's off position changed nothing.
+        XCTAssertNil(env["MTL_DEBUG_LAYER"])
+        XCTAssertNil(env["D3DM_VALIDATION"])
+        XCTAssertNil(env["WINEFSYNC"])
+    }
+
+    @MainActor
+    func testPlatformLayerCarriesTheSequoiaFixes() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let bottle = Bottle(bottleUrl: tempDir, inFlight: false, isAvailable: true)
+
+        let env = Wine.constructWineEnvironment(for: bottle)
+
+        // Supported macOS is 15.4+ at minimum, so all three fixes apply.
+        XCTAssertEqual(env["MTL_DEBUG_LAYER"], "0")
+        XCTAssertEqual(env["D3DM_VALIDATION"], "0")
+        XCTAssertEqual(env["WINEFSYNC"], "0")
     }
 
     // MARK: - Performance Preset Environment Variables
@@ -232,7 +260,6 @@ final class EnvironmentVariablesTests: XCTestCase {
         settings.environmentVariables(wineEnv: &env)
 
         // Performance preset - prioritize FPS over visual quality
-        XCTAssertEqual(env["D3DM_FAST_SHADER_COMPILE"], "1")
         XCTAssertEqual(env["D3DM_VALIDATION"], "0")
         XCTAssertEqual(env["MTL_DEBUG_LAYER"], "0")
         XCTAssertEqual(env["DXVK_ASYNC"], "1")
@@ -249,7 +276,6 @@ final class EnvironmentVariablesTests: XCTestCase {
         settings.environmentVariables(wineEnv: &env)
 
         XCTAssertEqual(env["DXVK_SHADER_OPT_LEVEL"], "2")
-        XCTAssertEqual(env["D3DM_FAST_SHADER_COMPILE"], "0")
     }
 
     func testEnvironmentVariablesWithUnityPreset() {
@@ -264,7 +290,6 @@ final class EnvironmentVariablesTests: XCTestCase {
         XCTAssertEqual(env["MONO_THREADS_SUSPEND"], "1")
         XCTAssertEqual(env["WINE_LARGE_ADDRESS_AWARE"], "65536")
         XCTAssertEqual(env["D3DM_FORCE_D3D11"], "1")
-        XCTAssertEqual(env["WINE_HEAP_REUSE"], "0")
         XCTAssertEqual(env["WINE_DISABLE_NTDLL_THREAD_REGS"], "1")
         XCTAssertEqual(env["WINEPRELOADRESERVE"], "1")
     }
@@ -289,8 +314,10 @@ final class EnvironmentVariablesTests: XCTestCase {
         var env: [String: String] = [:]
         settings.environmentVariables(wineEnv: &env)
 
-        XCTAssertEqual(env["DXVK_SHADER_COMPILE_THREADS"], "1")
-        XCTAssertEqual(env["__GL_SHADER_DISK_CACHE"], "0")
+        // The variable DXVK reads, not the NVIDIA GL one the toggle used to set.
+        XCTAssertEqual(env["DXVK_STATE_CACHE"], "0")
+        XCTAssertNil(env["DXVK_SHADER_COMPILE_THREADS"])
+        XCTAssertNil(env["__GL_SHADER_DISK_CACHE"])
     }
 
     // MARK: - EnvironmentBuilder Layer Populator Tests

--- a/WhiskyKit/Tests/WhiskyKitTests/GPUDetectionTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPUDetectionTests.swift
@@ -115,12 +115,12 @@ final class GPUDetectionTests: XCTestCase {
         }
     }
 
-    func testVulkanConfiguration() {
+    func testNoHardcodedVulkanICDPath() {
         let env = GPUDetection.spoofGPU(vendor: .nvidia)
 
-        // Should include MoltenVK ICD path
-        XCTAssertNotNil(env["VK_ICD_FILENAMES"])
-        XCTAssertTrue(env["VK_ICD_FILENAMES"]?.contains("MoltenVK") ?? false)
+        // The old value pointed at /usr/local/share, which exists on no user
+        // machine; the runtime carries its own MoltenVK configuration.
+        XCTAssertNil(env["VK_ICD_FILENAMES"])
     }
 
     func testShaderModelSupport() {

--- a/WhiskyKit/Tests/WhiskyKitTests/GraphicsBackendResolverTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GraphicsBackendResolverTests.swift
@@ -34,8 +34,24 @@ final class GraphicsBackendResolverTests: XCTestCase {
         let runtime = WhiskyWineVersion(version: SemanticVersion(3, 1, 1), dxmtVersion: "0.80")
 
         XCTAssertEqual(
-            GraphicsBackendResolver.resolve(runtimeInfo: runtime, d3dMetalInstalled: false),
+            GraphicsBackendResolver.resolve(
+                runtimeInfo: runtime, d3dMetalInstalled: false, dxmtRuntimeNative: true
+            ),
             .dxmt
+        )
+    }
+
+    /// The version record alone is not the gate the picker applies: a
+    /// builtin-variant or missing DXMT payload fails at launch, so auto must
+    /// not promise a backend the picker would refuse.
+    func testResolvesDXVKWhenDXMTPayloadNotNative() {
+        let runtime = WhiskyWineVersion(version: SemanticVersion(3, 1, 1), dxmtVersion: "0.80")
+
+        XCTAssertEqual(
+            GraphicsBackendResolver.resolve(
+                runtimeInfo: runtime, d3dMetalInstalled: false, dxmtRuntimeNative: false
+            ),
+            .dxvk
         )
     }
 

--- a/WhiskyKit/Tests/WhiskyKitTests/LauncherDiagnosticsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/LauncherDiagnosticsTests.swift
@@ -573,11 +573,12 @@ final class LauncherDiagnosticsTests: XCTestCase {
         var env: [String: String] = [:]
         bottle.settings.environmentVariables(wineEnv: &env)
 
-        // Connection pooling fixes should always be applied when launcher compat is on
-        XCTAssertEqual(env["WINE_MAX_CONNECTIONS_PER_SERVER"], "10")
-        XCTAssertEqual(env["WINE_FORCE_HTTP11"], "1")
-        XCTAssertEqual(env["WINE_ENABLE_SSL"], "1")
-        XCTAssertEqual(env["WINE_SSL_VERSION_MIN"], "TLS1.2")
+        // These variables exist in no Wine or WineCX source; asserting their
+        // absence keeps them from coming back as reassuring decoration.
+        XCTAssertNil(env["WINE_MAX_CONNECTIONS_PER_SERVER"])
+        XCTAssertNil(env["WINE_FORCE_HTTP11"])
+        XCTAssertNil(env["WINE_ENABLE_SSL"])
+        XCTAssertNil(env["WINE_SSL_VERSION_MIN"])
     }
 }
 


### PR DESCRIPTION
two fixes in the same spirit:

- settings that did nothing are wired or removed. the shader cache toggle now controls the cache dxvk actually reads, a dxvk.conf in the bottle is picked up at launch, and the invented network tuning variables and the sequoia compatibility toggle are gone, since the real fixes ship unconditionally
- recommended backend applies exactly the picker's dxmt gate, so auto can no longer promise a backend whose payload is missing or builtin variant and then throw payloadMissing at the launch the picker would have refused

the first commit drops user-visible settings, so that is the behaviour change to weigh in review.