### PR TITLE
classify crashes when the session ends, not seconds after launch

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/Extensions/Program+Extensions.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Extensions/Program+Extensions.swift
@@ -40,7 +40,10 @@ private let crashSignatures: Set<String> = [
     "device lost",
     "DEVICE_REMOVED",
     "DEVICE_HUNG",
-    "Fatal error"
+    "Fatal error",
+    // The head-of-log event behind "the game does nothing": a DLL the exe
+    // imports could not be loaded.
+    "import_dll"
 ]
 
 public extension Program {
@@ -105,17 +108,47 @@ public extension Program {
             // Track the log file URL for diagnostics
             settings.lastLogFileURL = result.logFileURL
 
-            // Trigger classification if non-zero exit or crash signatures detected in log
+            // The exit code and the log this instant belong to the `start
+            // /unix` stub, which returns seconds after launch, so this check
+            // only sees failures that happen immediately. Anything later is
+            // the watcher's job below.
             if result.exitCode != 0 || logContainsCrashSignatures(result.logFileURL) {
                 triggerCrashClassification(
                     logFileURL: result.logFileURL,
                     exitCode: result.exitCode
                 )
+            } else {
+                watchForLateCrash(logFileURL: result.logFileURL)
             }
 
             return .launchedSuccessfully(programName: self.name)
         } catch {
             return .launchFailed(programName: self.name, errorDescription: error.localizedDescription)
+        }
+    }
+
+    /// Watches for the session actually ending, then classifies its log.
+    ///
+    /// The bottle's wineserver going idle is the end-of-session signal, the
+    /// same one Discord presence uses, and this run's log keeps growing until
+    /// then because Wine's children inherit its file descriptor. Each launch
+    /// has its own log file, so concurrent watchers never double-report one
+    /// run. The probe is deliberately one interval late; the wineserver may
+    /// not be up yet at the moment of launch.
+    private func watchForLateCrash(logFileURL: URL) {
+        let bottle = self.bottle
+        Task {
+            while true {
+                try? await Task.sleep(for: .seconds(30))
+                if logContainsCrashSignatures(logFileURL) {
+                    triggerCrashClassification(logFileURL: logFileURL, exitCode: 1)
+                    return
+                }
+                // Checked after the scan, so a crash written between the last
+                // scan and the wineserver going down still gets one look.
+                let running = await Wine.isWineserverRunning(for: bottle)
+                if !running { return }
+            }
         }
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -986,8 +986,10 @@ public extension Wine {
 
     /// Classifies the output from a Wine process run for crash patterns.
     ///
-    /// Reads the tail of the log file (up to 500 lines / 256 KiB) and runs
-    /// classification on a background task to avoid blocking the UI.
+    /// Reads the head and the tail of the log, not the tail alone: missing-DLL
+    /// (`import_dll`) and backend-init failures are head-of-log events, and a
+    /// long session buries them under hours of output a tail-only window never
+    /// sees. Runs on a background task to avoid blocking the UI.
     ///
     /// - Parameters:
     ///   - logFileURL: URL to the Wine log file to analyze.
@@ -1001,41 +1003,59 @@ public extension Wine {
         classifier: CrashClassifier? = nil
     ) async -> CrashDiagnosis? {
         await Task.detached(priority: .utility) {
-            let maxBytesToRead = 256 * 1_024
-            let maxLines = 500
-
-            do {
-                let handle = try FileHandle(forReadingFrom: logFileURL)
-                defer { try? handle.close() }
-
-                let end = try handle.seekToEnd()
-                let start = end > UInt64(maxBytesToRead) ? end - UInt64(maxBytesToRead) : 0
-                try handle.seek(toOffset: start)
-
-                let data = try handle.readToEnd() ?? Data()
-                guard var text = String(data: data, encoding: .utf8), !text.isEmpty else {
-                    return nil
-                }
-
-                // Drop first partial line if reading from the middle
-                if start != 0, let firstNewline = text.firstIndex(of: "\n") {
-                    text = String(text[text.index(after: firstNewline)...])
-                }
-
-                // Limit to last N lines
-                let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-                let logText: String = if lines.count > maxLines {
-                    lines.suffix(maxLines).joined(separator: "\n")
-                } else {
-                    lines.joined(separator: "\n")
-                }
-
-                let resolvedClassifier = classifier ?? CrashClassifier()
-                return resolvedClassifier.classify(log: logText, exitCode: exitCode)
-            } catch {
+            guard let logText = try? classificationWindow(of: logFileURL), !logText.isEmpty else {
                 return nil
             }
+            let resolvedClassifier = classifier ?? CrashClassifier()
+            return resolvedClassifier.classify(log: logText, exitCode: exitCode)
         }.value
+    }
+
+    /// The head and tail of a log, joined into the window classification reads.
+    private nonisolated static func classificationWindow(of logFileURL: URL) throws -> String? {
+        let maxTailBytes = 256 * 1_024
+        let maxHeadBytes = 64 * 1_024
+        let maxTailLines = 500
+        let maxHeadLines = 200
+
+        let handle = try FileHandle(forReadingFrom: logFileURL)
+        defer { try? handle.close() }
+        let end = try handle.seekToEnd()
+
+        if end <= UInt64(maxHeadBytes + maxTailBytes) {
+            try handle.seek(toOffset: 0)
+            let data = try handle.readToEnd() ?? Data()
+            guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return nil }
+            let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+            if lines.count <= maxHeadLines + maxTailLines {
+                return text
+            }
+            return (lines.prefix(maxHeadLines) + lines.suffix(maxTailLines)).joined(separator: "\n")
+        }
+
+        try handle.seek(toOffset: 0)
+        let headData = try handle.read(upToCount: maxHeadBytes) ?? Data()
+        var head = String(data: headData, encoding: .utf8) ?? ""
+        // Drop the trailing partial line of the head window.
+        if let lastNewline = head.lastIndex(of: "\n") {
+            head = String(head[..<lastNewline])
+        }
+        let headLines = head
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .prefix(maxHeadLines)
+
+        try handle.seek(toOffset: end - UInt64(maxTailBytes))
+        let tailData = try handle.readToEnd() ?? Data()
+        var tail = String(data: tailData, encoding: .utf8) ?? ""
+        // Drop the leading partial line of the tail window.
+        if let firstNewline = tail.firstIndex(of: "\n") {
+            tail = String(tail[tail.index(after: firstNewline)...])
+        }
+        let tailLines = tail
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .suffix(maxTailLines)
+
+        return (headLines + tailLines).joined(separator: "\n")
     }
 }
 

--- a/WhiskyKit/Tests/WhiskyKitTests/CrashClassifierTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/CrashClassifierTests.swift
@@ -307,4 +307,27 @@ final class CrashClassifierTests: XCTestCase {
         XCTAssertTrue(types.contains(.switchBackend))
         XCTAssertTrue(types.contains(.changeSetting))
     }
+
+    /// A missing-DLL failure is a head-of-log event. A session that then runs
+    /// for hours buries it megabytes above the tail, which is exactly the log
+    /// a tail-only window used to read and classify as clean.
+    func testClassifyLastRunSeesHeadOfLogEvents() async throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let logURL = tempDir.appendingPathComponent("run.log")
+        let crash = "0024:err:module:import_dll Library MSVCR100.dll (which is needed by L\"game.exe\") not found\n"
+        let padding = String(
+            repeating: "0032:fixme:dxgi:swapchain_present partial stub, routine frame output line\n",
+            count: 8_000
+        )
+        try (crash + padding).write(to: logURL, atomically: true, encoding: .utf8)
+
+        let diagnosis = await Wine.classifyLastRun(logFileURL: logURL, exitCode: 0)
+
+        let unwrapped = try XCTUnwrap(diagnosis)
+        XCTAssertFalse(unwrapped.isEmpty)
+        XCTAssertEqual(unwrapped.primaryCategory, .dependenciesLoading)
+    }
 }


### PR DESCRIPTION
the classifier ran on a timer a few seconds after launch, so a game that died later was never classified at all, and it read the tail of the log, where a long session has pushed the loader errors out of view. classification now runs when the wine session actually ends, and the classifier reads the head of the log, which is where loader errors appear.