### PR TITLE
fix(graphics): a dxvk bottle must say what happens to d3d12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- DirectX 12 games run again in a bottle set to DXVK or DXMT. Neither ships a
+  d3d12 of its own and neither said so, so that one DLL quietly fell through to
+  D3DMetal while the rest of the stack was not. A DX12 game took its adapter
+  from one translation layer into the other and died before it drew anything,
+  with no error of its own to show for it. Both now turn d3d12 off, so such a
+  game falls back to DirectX 11 rather than half landing on something else, and
+  a bottle or a single program set to D3DMetal gets real DirectX 12 back.
+
 ## [3.6.1] - 2026-08-13 (App)
 
 ### Changed

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/DLLOverride.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/DLLOverride.swift
@@ -146,13 +146,23 @@ public struct DLLOverrideResolver: Sendable {
 
     /// The standard DXVK DLL override preset.
     ///
-    /// Applies `n,b` (native then builtin) to the four core DXVK DLLs.
+    /// Applies `n,b` (native then builtin) to the four core DXVK DLLs, and
+    /// turns `d3d12` off.
+    ///
+    /// DXVK ships no `d3d12`, so leaving it unmentioned let it fall through to
+    /// the builtin, which is D3DMetal. A DX12 game then took its adapter from
+    /// DXVK's DXGI and handed it to D3DMetal's `D3D12CreateDevice`, which
+    /// dereferenced a vtable slot on an object it had not created and jumped to
+    /// null. Disabling it keeps the bottle on one implementation, so such a game
+    /// falls back to D3D11 instead of half-landing on the other one. A bottle or
+    /// program set to D3DMetal resets this to builtin and gets real DX12.
     public static var dxvkPreset: [DLLOverrideEntry] {
         [
             DLLOverrideEntry(dllName: "dxgi", mode: .nativeThenBuiltin),
             DLLOverrideEntry(dllName: "d3d9", mode: .nativeThenBuiltin),
             DLLOverrideEntry(dllName: "d3d10core", mode: .nativeThenBuiltin),
-            DLLOverrideEntry(dllName: "d3d11", mode: .nativeThenBuiltin)
+            DLLOverrideEntry(dllName: "d3d11", mode: .nativeThenBuiltin),
+            DLLOverrideEntry(dllName: "d3d12", mode: .disabled)
         ]
     }
 
@@ -169,7 +179,10 @@ public struct DLLOverrideResolver: Sendable {
             DLLOverrideEntry(dllName: "dxgi", mode: .nativeThenBuiltin),
             DLLOverrideEntry(dllName: "d3d10core", mode: .nativeThenBuiltin),
             DLLOverrideEntry(dllName: "d3d11", mode: .nativeThenBuiltin),
-            DLLOverrideEntry(dllName: "winemetal", mode: .builtin)
+            DLLOverrideEntry(dllName: "winemetal", mode: .builtin),
+            // off for the same reason as DXVK: DXMT has no d3d12 either, and the
+            // builtin behind it belongs to a different translation layer
+            DLLOverrideEntry(dllName: "d3d12", mode: .disabled)
         ]
     }
 

--- a/WhiskyKit/Tests/WhiskyKitTests/BottleLauncherConfigTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BottleLauncherConfigTests.swift
@@ -159,7 +159,7 @@ final class BottleLauncherConfigTests: XCTestCase {
 
         // Should still enable DXVK overrides because Rockstar requires it
         // DLL overrides are now composed per-DLL via DLLOverrideResolver (sorted alphabetically)
-        XCTAssertEqual(env["WINEDLLOVERRIDES"], "d3d10core=n,b;d3d11=n,b;d3d9=n,b;dxgi=n,b")
+        XCTAssertEqual(env["WINEDLLOVERRIDES"], "d3d10core=n,b;d3d11=n,b;d3d12=;d3d9=n,b;dxgi=n,b")
     }
 
     func testSSLTLSConfiguration() {

--- a/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/DLLOverrideTests.swift
@@ -140,11 +140,15 @@ final class DLLOverrideTests: XCTestCase {
 
     func testDXVKPresetReturnsCorrectEntries() {
         let preset = DLLOverrideResolver.dxvkPreset
-        let names = Set(preset.map(\.dllName))
-        XCTAssertEqual(names, Set(["dxgi", "d3d9", "d3d10core", "d3d11"]))
-        for entry in preset {
-            XCTAssertEqual(entry.mode, .nativeThenBuiltin)
-        }
+        let modesByName = Dictionary(uniqueKeysWithValues: preset.map { ($0.dllName, $0.mode) })
+        XCTAssertEqual(modesByName, [
+            "dxgi": .nativeThenBuiltin,
+            "d3d9": .nativeThenBuiltin,
+            "d3d10core": .nativeThenBuiltin,
+            "d3d11": .nativeThenBuiltin,
+            // DXVK has no d3d12; off rather than falling through to D3DMetal
+            "d3d12": .disabled
+        ])
     }
 
     // MARK: - DXMT Preset
@@ -158,7 +162,8 @@ final class DLLOverrideTests: XCTestCase {
             "dxgi": .nativeThenBuiltin,
             "d3d10core": .nativeThenBuiltin,
             "d3d11": .nativeThenBuiltin,
-            "winemetal": .builtin
+            "winemetal": .builtin,
+            "d3d12": .disabled
         ])
     }
 
@@ -169,7 +174,7 @@ final class DLLOverrideTests: XCTestCase {
             programCustom: []
         )
         let result = resolver.resolve()
-        XCTAssertEqual(result.overrides, "d3d10core=n,b;d3d11=n,b;dxgi=n,b;winemetal=b")
+        XCTAssertEqual(result.overrides, "d3d10core=n,b;d3d11=n,b;d3d12=;dxgi=n,b;winemetal=b")
     }
 
     func testDXMTWarningWhenManagedOverridden() {
@@ -186,5 +191,38 @@ final class DLLOverrideTests: XCTestCase {
         XCTAssertEqual(result.warnings.count, 1)
         XCTAssertEqual(result.warnings.first?.overriddenSource, .dxmt)
         XCTAssertTrue(result.warnings.first?.message.contains("DXMT") == true)
+    }
+
+    // MARK: - d3d12 is never left to fall through
+
+    func testTranslationPresetsTurnD3D12Off() {
+        // Neither DXVK nor DXMT ships a d3d12. Leaving the name unmentioned let
+        // it resolve to the builtin, which is D3DMetal, and a DX12 game took its
+        // adapter from one implementation into the other and jumped to null.
+        for (name, preset) in [
+            ("DXVK", DLLOverrideResolver.dxvkPreset),
+            ("DXMT", DLLOverrideResolver.dxmtPreset)
+        ] {
+            let entry = preset.first { $0.dllName == "d3d12" }
+            XCTAssertNotNil(entry, "\(name) preset must say what happens to d3d12")
+            XCTAssertEqual(entry?.mode, .disabled, "\(name) must turn d3d12 off, not leave it builtin")
+        }
+    }
+
+    func testD3DMetalResetRestoresD3D12() {
+        // A program that overrides a DXVK bottle back to D3DMetal has to get
+        // real DX12, so the reset union must put d3d12 back to builtin.
+        let reset = Wine.translationDLLResetEntries
+        let entry = reset.first { $0.dllName == "d3d12" }
+        XCTAssertEqual(entry?.mode, .builtin, "resetting to a builtin backend must re-enable d3d12")
+    }
+
+    func testDXVKBottleRendersD3D12Disabled() {
+        let resolver = DLLOverrideResolver(
+            managed: DLLOverrideResolver.dxvkPreset.map { ($0, DLLOverrideSource.dxvk) },
+            bottleCustom: [],
+            programCustom: []
+        )
+        XCTAssertTrue(resolver.resolve().overrides.contains("d3d12="))
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
@@ -33,7 +33,7 @@ final class EnvironmentVariablesTests: XCTestCase {
         settings.environmentVariables(wineEnv: &env)
 
         // DLL overrides are now composed per-DLL via DLLOverrideResolver (sorted alphabetically)
-        XCTAssertEqual(env["WINEDLLOVERRIDES"], "d3d10core=n,b;d3d11=n,b;d3d9=n,b;dxgi=n,b")
+        XCTAssertEqual(env["WINEDLLOVERRIDES"], "d3d10core=n,b;d3d11=n,b;d3d12=;d3d9=n,b;dxgi=n,b")
         XCTAssertEqual(env["DXVK_HUD"], "full")
     }
 
@@ -47,7 +47,7 @@ final class EnvironmentVariablesTests: XCTestCase {
         settings.environmentVariables(wineEnv: &env)
 
         // The trio is native-then-builtin; winemetal pinned builtin for unixlib binding.
-        XCTAssertEqual(env["WINEDLLOVERRIDES"], "d3d10core=n,b;d3d11=n,b;dxgi=n,b;winemetal=b")
+        XCTAssertEqual(env["WINEDLLOVERRIDES"], "d3d10core=n,b;d3d11=n,b;d3d12=;dxgi=n,b;winemetal=b")
         // DXMT is not DXVK and not wined3d: none of their env vars may leak.
         XCTAssertNil(env["DXVK_HUD"])
         XCTAssertNil(env["DXVK_ASYNC"])
@@ -303,7 +303,7 @@ final class EnvironmentVariablesTests: XCTestCase {
         let managedOverrides = settings.populateBottleManagedLayer(builder: &builder)
 
         // DXVK managed overrides should be returned, not set via builder
-        XCTAssertEqual(managedOverrides.count, 4) // dxgi, d3d9, d3d10core, d3d11
+        XCTAssertEqual(managedOverrides.count, 5) // dxgi, d3d9, d3d10core, d3d11, d3d12
         XCTAssertTrue(managedOverrides.allSatisfy { $0.source == .dxvk })
 
         // WINEDLLOVERRIDES should NOT be in the resolved environment (handled by DLLOverrideResolver)
@@ -343,7 +343,7 @@ final class EnvironmentVariablesTests: XCTestCase {
             builder: &builder, resolvedBackend: resolved
         )
 
-        XCTAssertEqual(managedOverrides.count, 4) // dxgi, d3d9, d3d10core, d3d11
+        XCTAssertEqual(managedOverrides.count, 5) // dxgi, d3d9, d3d10core, d3d11, d3d12
         XCTAssertTrue(managedOverrides.allSatisfy { $0.source == .dxvk })
     }
 
@@ -391,7 +391,7 @@ final class EnvironmentVariablesTests: XCTestCase {
         overrides.graphicsBackend = .dxmt
 
         let resolved = resolvedOverrides(bottleSettings: settings, programOverrides: overrides)
-        XCTAssertEqual(resolved, "d3d10core=n,b;d3d11=n,b;d3d9=b;dxgi=n,b;winemetal=b")
+        XCTAssertEqual(resolved, "d3d10core=n,b;d3d11=n,b;d3d12=;d3d9=b;dxgi=n,b;winemetal=b")
     }
 
     func testProgramBackendOverrideDXMTNeutralizesLeakedDXVKd3d9() {
@@ -406,7 +406,7 @@ final class EnvironmentVariablesTests: XCTestCase {
         overrides.graphicsBackend = .dxmt
 
         let resolved = resolvedOverrides(bottleSettings: settings, programOverrides: overrides)
-        XCTAssertEqual(resolved, "d3d10core=n,b;d3d11=n,b;d3d9=b;dxgi=n,b;winemetal=b")
+        XCTAssertEqual(resolved, "d3d10core=n,b;d3d11=n,b;d3d12=;d3d9=b;dxgi=n,b;winemetal=b")
         XCTAssertFalse(resolved.contains("d3d9=n,b"), "Leaked DXVK d3d9 must be reset to builtin")
     }
 
@@ -438,7 +438,7 @@ final class EnvironmentVariablesTests: XCTestCase {
         overrides.dxvk = false
 
         let resolved = resolvedOverrides(bottleSettings: settings, programOverrides: overrides)
-        XCTAssertEqual(resolved, "d3d10core=n,b;d3d11=n,b;d3d9=b;dxgi=n,b;winemetal=b")
+        XCTAssertEqual(resolved, "d3d10core=n,b;d3d11=n,b;d3d12=;d3d9=b;dxgi=n,b;winemetal=b")
     }
 
     func testLegacyDXVKTrueDoesNotResurrectDXVKUnderD3DMetalOverride() {

--- a/WhiskyKit/Tests/WhiskyKitTests/LauncherDiagnosticsTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/LauncherDiagnosticsTests.swift
@@ -392,7 +392,7 @@ final class LauncherDiagnosticsTests: XCTestCase {
 
         // DXVK should be auto-enabled because Rockstar requires it
         // DLL overrides are now composed per-DLL via DLLOverrideResolver (sorted alphabetically)
-        XCTAssertEqual(env["WINEDLLOVERRIDES"], "d3d10core=n,b;d3d11=n,b;d3d9=n,b;dxgi=n,b")
+        XCTAssertEqual(env["WINEDLLOVERRIDES"], "d3d10core=n,b;d3d11=n,b;d3d12=;d3d9=n,b;dxgi=n,b")
     }
 
     func testAutoEnableDXVKNotTriggeredForSteam() throws {

--- a/WhiskyKit/Tests/WhiskyKitTests/ManagedPresetTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ManagedPresetTests.swift
@@ -22,14 +22,14 @@ import XCTest
 final class ManagedPresetTests: XCTestCase {
     func testDXVKBackendContributesTheDXVKPreset() {
         let preset = DLLOverrideResolver.managedPreset(for: .dxvk)
-        XCTAssertEqual(preset.map(\.dllName).sorted(), ["d3d10core", "d3d11", "d3d9", "dxgi"])
+        XCTAssertEqual(preset.map(\.dllName).sorted(), ["d3d10core", "d3d11", "d3d12", "d3d9", "dxgi"])
     }
 
     /// The case the config section used to miss entirely: a DXMT bottle applies
-    /// four overrides at launch and the UI listed none of them.
+    /// five overrides at launch and the UI listed none of them.
     func testDXMTBackendContributesTheDXMTPreset() {
         let preset = DLLOverrideResolver.managedPreset(for: .dxmt)
-        XCTAssertEqual(preset.map(\.dllName).sorted(), ["d3d10core", "d3d11", "dxgi", "winemetal"])
+        XCTAssertEqual(preset.map(\.dllName).sorted(), ["d3d10core", "d3d11", "d3d12", "dxgi", "winemetal"])
     }
 
     /// D3DMetal and WineD3D both run on Wine's builtin D3D and pick between


### PR DESCRIPTION
neither dxvk nor dxmt ships a d3d12, and neither preset mentions the name, so it
resolves to the builtin behind them: d3dmetal. a dx12 game in a dxvk bottle takes
its adapter from dxvk's dxgi and hands it to d3dmetal's `D3D12CreateDevice`,
which dereferences a vtable slot on an object it did not create and jumps to
null.

deep rock galactic hits it on every launch. what you get is a game that dies
before it draws anything, with nothing in its own log past mounting plugins:

```
rip=0x0  rax=0x0  rcx=0x0        a call through a null function pointer
rsp=0x00c9d508                    identical on every run
return address 0x2144ede64        in no PE module at all
```

that return address is in a mach-o loaded by dyld, which is why the game's
minidump cannot name the caller and the crash looks like it comes from nowhere.

## what this changes

both presets now turn `d3d12` off, so a bottle stays on one implementation and a
dx12 game falls back to d3d11 on the same translation layer instead of half
landing on the other one. `translationDLLResetEntries` is the union of the two
presets, so a bottle or a single program set to d3dmetal picks the name up and
gets real dx12 back.

## how i checked

controls, on runtime 4.5.112, bottle set to dxvk:

| d3d12 slot | result |
|---|---|
| the gptk video shim | crash |
| apple's unshimmed d3d12 | crash |
| d3d12 disabled | game runs |
| program overridden to d3dmetal | game runs on dx12 |

so neither dll is at fault, the pairing is. it also reproduces on an older
runtime, so it is not a runtime regression.

1259 tests pass, swiftformat 0/358, swiftlint 0 violations. the updated
expectations are all preset contents and rendered override strings; the parser
test in DLLOverrideRegistryTests keeps its literal input, since that one is
about parsing rather than about what a backend contributes.