### PR TITLE
fix(graphics): tell wine we are on d3dmetal so it answers the gpu scheduling query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- A D3DMetal bottle answers when a game asks whether hardware accelerated GPU
+  scheduling is available. Wine only answers that query for a caller that says
+  it is running on D3DMetal, and nothing said so, so the answer was always that
+  the feature is not implemented.
+
 ## [3.6.1] - 2026-08-13 (App)
 
 ### Changed

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -811,8 +811,13 @@ public struct BottleSettings: Codable, Equatable {
         // Backend-conditional env vars and DLL overrides
         switch resolvedBackend {
         case .d3dMetal, .recommended:
-            // D3DMetal is Wine's default on macOS -- no special env vars needed
-            break
+            // Wine answers KMTQAITYPE_WDDM_2_7_CAPS, the query behind "hardware
+            // accelerated GPU scheduling", only when this says d3dmetal, and
+            // returns STATUS_NOT_IMPLEMENTED otherwise. Nothing set it, so a
+            // game asking whether scheduling is available was told it is not.
+            // The only other reader wants the value "wined3d" alongside
+            // CX_LIBVULKAN, so this is inert for it.
+            builder.set("CX_ACTIVE_GRAPHICS_BACKEND", "d3dmetal", layer: .bottleManaged)
 
         case .dxvk:
             // DXVK: DLL overrides + env vars

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
@@ -181,11 +181,15 @@ extension Wine {
                 builder.remove("DXVK_HUD", layer: .programUser)
                 builder.remove("DXVK_ASYNC", layer: .programUser)
                 builder.remove("WINED3DMETAL", layer: .programUser)
+                // One program on D3DMetal inside a bottle running something else
+                // still has to be told scheduling exists; see the bottle layer.
+                builder.set("CX_ACTIVE_GRAPHICS_BACKEND", "d3dmetal", layer: .programUser)
 
             case .dxvk:
                 // Enable DXVK DLLs at program level
                 dllResolver.programCustom.append(contentsOf: DLLOverrideResolver.dxvkPreset)
                 builder.remove("WINED3DMETAL", layer: .programUser)
+                builder.remove("CX_ACTIVE_GRAPHICS_BACKEND", layer: .programUser)
 
             case .dxmt:
                 // Reset the full translation-DLL union to builtin first so a DXVK
@@ -198,10 +202,12 @@ extension Wine {
                 builder.remove("DXVK_HUD", layer: .programUser)
                 builder.remove("DXVK_ASYNC", layer: .programUser)
                 builder.remove("WINED3DMETAL", layer: .programUser)
+                builder.remove("CX_ACTIVE_GRAPHICS_BACKEND", layer: .programUser)
 
             case .wined3d:
                 // Force wined3d: disable D3DMetal + undo DXVK/DXMT DLLs
                 builder.set("WINED3DMETAL", "0", layer: .programUser)
+                builder.remove("CX_ACTIVE_GRAPHICS_BACKEND", layer: .programUser)
                 dllResolver.programCustom.append(contentsOf: Self.translationDLLResetEntries)
             }
         }

--- a/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
@@ -525,4 +525,25 @@ final class EnvironmentVariablesTests: XCTestCase {
         // programUser wins over bottleManaged
         XCTAssertEqual(resolved["DXVK_ASYNC"], "0")
     }
+
+    // MARK: - hardware scheduling is claimed only where it applies
+
+    func testD3DMetalBottleClaimsHardwareScheduling() {
+        // Wine answers the WDDM 2.7 caps query only for a caller that says it is
+        // on D3DMetal; without it, a game asking about GPU scheduling is told
+        // the feature is not implemented.
+        var settings = BottleSettings()
+        settings.graphicsBackend = .d3dMetal
+        var env: [String: String] = [:]
+        settings.environmentVariables(wineEnv: &env)
+        XCTAssertEqual(env["CX_ACTIVE_GRAPHICS_BACKEND"], "d3dmetal")
+    }
+
+    func testDXVKBottleDoesNotClaimHardwareScheduling() {
+        var settings = BottleSettings()
+        settings.graphicsBackend = .dxvk
+        var env: [String: String] = [:]
+        settings.environmentVariables(wineEnv: &env)
+        XCTAssertNil(env["CX_ACTIVE_GRAPHICS_BACKEND"])
+    }
 }


### PR DESCRIPTION
wine answers `KMTQAITYPE_WDDM_2_7_CAPS`, the query behind hardware accelerated
gpu scheduling, only when `CX_ACTIVE_GRAPHICS_BACKEND` says `d3dmetal`:

```c
/* CW HACK 24905 */
case KMTQAITYPE_WDDM_2_7_CAPS:
    char *active_gfx_backend = getenv("CX_ACTIVE_GRAPHICS_BACKEND");
    if (active_gfx_backend && !strcmp(active_gfx_backend, "d3dmetal"))
    {
        caps->HwSchEnabled = 1;
        ...
    }
    /* fallthrough */   ->  STATUS_NOT_IMPLEMENTED
```

nothing sets that variable, so a game asking whether scheduling is available is
always told the feature does not exist.

a d3dmetal bottle now sets it, and so does a single program overridden to
d3dmetal inside a bottle running something else. the other three program
backends clear it, so the claim cannot leak to a program that is not on
d3dmetal. the only other reader in the tree wants the value `wined3d` together
with `CX_LIBVULKAN`, which whisky never sets, so this is inert for it.

## where i found it

on my fork, which carries a metalfx bridge that exposes dlss. nvidia streamline
checks scheduling before it will enable frame generation, gets the
not-implemented answer, and refuses:

```
LogStreamlineAPI: Error: Feature 'kFeatureDLSS_G' requires GPU hardware
scheduling to be enabled in the OS
```

with the variable set, deep rock galactic reaches the menu and runs instead of
dying during plugin mounting.

worth saying plainly: that payoff needs the metalfx bridge, which is not in this
tree, so nobody here will see the dlss half. what this changes upstream is
narrower, that a d3dmetal bottle stops answering "not implemented" to a
capability it does in fact have. i have no upstream-visible repro to point at,
so treat it on the merits of the code path rather than on my measurement.

1258 tests pass, swiftformat 0/358, swiftlint 0 violations.