### PR TITLE
deploy apple's nvapi, so streamline can find dlss

### DIFF
--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -77,6 +77,7 @@ struct WhiskyApp: App {
     private func installMetalFXBridgeIfNeeded() {
         Task.detached(priority: .background) {
             GPTKImporter.ensureMetalFXBridgeInstalled()
+            GPTKImporter.ensureNVAPIBridgeInstalled()
         }
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
@@ -184,6 +184,7 @@ extension GPTKImporter {
         // be made: the runtime ships the interposer but has nothing to forward
         // into until this point.
         try installVideoProcessor(intoLibraryFolder: folder)
+        try installNVAPIBridge(intoLibraryFolder: folder, usingStore: store)
         logger.info("Deployed GPTK payload into the runtime tree")
     }
 
@@ -223,6 +224,7 @@ extension GPTKImporter {
         // the store, and is skipped: the tree would keep a d3d12 that forwards
         // to a DLL this call is about to delete.
         removeVideoProcessor(fromLibraryFolder: folder, usingStore: store)
+        removeNVAPIBridge(fromLibraryFolder: folder, usingStore: store)
 
         for name in forwarderDLLNames {
             let backup = originals.appending(path: name)

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+NVAPI.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+NVAPI.swift
@@ -1,0 +1,142 @@
+//
+//  GPTKImporter+NVAPI.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import os.log
+
+/// Apple's NVAPI, which is what makes MetalFX reachable in practice.
+///
+/// The MetalFX bridge answers NGX, but nothing asks NGX until NVAPI has said
+/// there is an NVIDIA GPU behind it. NVIDIA Streamline, which is how most
+/// current games reach DLSS, queries NVAPI first and stops there when it finds
+/// nothing: measured on Deep Rock Galactic, a relay trace scoped to `nvngx.*`
+/// recorded zero `NVSDK_NGX_*` calls and the game offered no DLSS option at all,
+/// with no error to explain it. Wine's own `nvapi64` is a placeholder that
+/// exports nothing, so that is the answer every game got.
+///
+/// Deploying it has a cost, which is why it stayed in the store for so long:
+/// Chromium probes for an NVIDIA GPU on startup, and answering makes it load
+/// D3DMetal and take a launcher's helper process down with it. That is handled
+/// per executable instead of by withholding the DLL from everything, in
+/// ``Wine.disablingNVAPI(in:)``.
+extension GPTKImporter {
+    /// Wine's placeholder, kept beside the deployed bridge so removal can put the
+    /// tree back without consulting the per-runtime originals record.
+    static let nvapiPlaceholderSuffix = ".wine-placeholder"
+
+    /// Where the bridge lives in the store, or `nil` for a payload without one.
+    static func nvapiBridgeSource(inStore store: URL) -> URL? {
+        let source = store.appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-windows").appending(path: nvapiBridgeName)
+        return FileManager.default.fileExists(atPath: source.path(percentEncoded: false)) ? source : nil
+    }
+
+    static func nvapiBridgePE(inLibraryFolder folder: URL) -> URL {
+        folder.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-windows").appending(path: nvapiBridgeName)
+    }
+
+    static func nvapiBridgeUnixLink(inLibraryFolder folder: URL) -> URL {
+        folder.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-unix").appending(path: nvapiBridgeUnixName)
+    }
+
+    static func nvapiPlaceholderBackup(inLibraryFolder folder: URL) -> URL {
+        nvapiBridgePE(inLibraryFolder: folder).appendingPathExtension(
+            String(nvapiPlaceholderSuffix.dropFirst())
+        )
+    }
+
+    /// Whether the tree holds a bridge this store put there.
+    static func isNVAPIBridgeInstalled(inLibraryFolder folder: URL, usingStore store: URL) -> Bool {
+        guard let source = nvapiBridgeSource(inStore: store) else { return false }
+        return FileManager.default.contentsEqual(
+            atPath: nvapiBridgePE(inLibraryFolder: folder).path(percentEncoded: false),
+            andPath: source.path(percentEncoded: false)
+        )
+    }
+
+    /// Puts the bridge in the tree with a unix half beside it, keeping Wine's
+    /// placeholder so ``removeNVAPIBridge(fromLibraryFolder:usingStore:)`` can
+    /// put it back.
+    ///
+    /// Unlike the MetalFX bridge this is not purely additive: Wine ships an
+    /// `nvapi64` of its own, so the file being replaced is backed up rather than
+    /// overwritten.
+    static func installNVAPIBridge(intoLibraryFolder folder: URL, usingStore store: URL) throws {
+        guard let source = nvapiBridgeSource(inStore: store) else { return }
+        guard !isNVAPIBridgeInstalled(inLibraryFolder: folder, usingStore: store) else { return }
+        let fileManager = FileManager.default
+        let destination = nvapiBridgePE(inLibraryFolder: folder)
+        let backup = nvapiPlaceholderBackup(inLibraryFolder: folder)
+        let link = nvapiBridgeUnixLink(inLibraryFolder: folder)
+
+        if fileManager.fileExists(atPath: destination.path(percentEncoded: false)) {
+            // Only the first install backs up: a second one would otherwise save
+            // Apple's DLL over the placeholder and lose it for good.
+            if !fileManager.fileExists(atPath: backup.path(percentEncoded: false)) {
+                try fileManager.copyItem(at: destination, to: backup)
+            }
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.copyItem(at: source, to: destination)
+
+        try fileManager.createDirectory(
+            at: link.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try? fileManager.removeItem(at: link)
+        try fileManager.createSymbolicLink(
+            atPath: link.path(percentEncoded: false),
+            withDestinationPath: unixLinkDestination
+        )
+        logger.info("Installed Apple's NVAPI as \(nvapiBridgeName, privacy: .public)")
+    }
+
+    /// Takes the bridge back out and restores Wine's placeholder.
+    static func removeNVAPIBridge(fromLibraryFolder folder: URL, usingStore store: URL) {
+        let fileManager = FileManager.default
+        guard isNVAPIBridgeInstalled(inLibraryFolder: folder, usingStore: store) else { return }
+        let destination = nvapiBridgePE(inLibraryFolder: folder)
+        let backup = nvapiPlaceholderBackup(inLibraryFolder: folder)
+
+        try? fileManager.removeItem(at: destination)
+        if fileManager.fileExists(atPath: backup.path(percentEncoded: false)) {
+            try? fileManager.moveItem(at: backup, to: destination)
+        }
+
+        let link = nvapiBridgeUnixLink(inLibraryFolder: folder)
+        let target = try? fileManager.destinationOfSymbolicLink(atPath: link.path(percentEncoded: false))
+        if target == unixLinkDestination {
+            try? fileManager.removeItem(at: link)
+        }
+    }
+
+    /// Installs the bridge into a tree that already holds the payload, so an
+    /// install set up before this existed picks it up without reimporting.
+    /// Idempotent and cheap enough to run at launch, like the MetalFX half.
+    public static func ensureNVAPIBridgeInstalled() {
+        let folder = WhiskyWineInstaller.libraryFolder
+        guard isDeployed(inLibraryFolder: folder) else { return }
+
+        do {
+            try installNVAPIBridge(intoLibraryFolder: folder, usingStore: storeFolder)
+        } catch {
+            logger.error("Installing Apple's NVAPI failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter.swift
@@ -92,13 +92,21 @@ public enum GPTKImporter {
     /// name, because it is the only route to MetalFX, see
     /// ``installMetalFXBridge(intoLibraryFolder:usingStore:)``.
     ///
-    /// `nvapi64` is kept in the store and never deployed: a stock runtime ships
-    /// no `nvapi64` at all, so placing Apple's makes every process that probes
-    /// for an NVIDIA GPU load D3DMetal, and Chromium does exactly that, which takes
-    /// Steam's helper process down with it. The cost is that a Streamline title
-    /// asks NVAPI about the GPU before it will offer DLSS at all, so it never
-    /// reaches MetalFX, see ``installMetalFXBridge(intoLibraryFolder:usingStore:)``.
+    /// `nvapi64` is deployed too, and kept away from launcher helpers per
+    /// executable rather than withheld from everything. Chromium probes for an
+    /// NVIDIA GPU and answering makes it load D3DMetal, which takes Steam's
+    /// helper process down, so that risk is real; withholding the DLL is just
+    /// not the only way out of it, and it costs DLSS everywhere. See
+    /// ``installNVAPIBridge(intoLibraryFolder:usingStore:)`` for why the DLL has
+    /// to be there, and `Wine.disablingNVAPI(in:)` for the half that keeps
+    /// Chromium out of it.
     static let nvidiaBridgeDLLNames = ["nvapi64.dll", "nvngx-on-metalfx.dll"]
+
+    /// Apple's NVAPI, deployed under the name it ships as; wine's own `nvapi64`
+    /// is a placeholder that exports nothing, so this replaces it.
+    static let nvapiBridgeName = "nvapi64.dll"
+    /// Its unix half, sharing the payload's dylib like every other bridge.
+    static let nvapiBridgeUnixName = "nvapi64.so"
 
     /// Enough bytes to hold the winebuild marker at offset 0x40.
     static let builtinMarkerMinimumLength = 0x50

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -772,9 +772,37 @@ public class Wine {
     ) {
         if backend == .d3dMetal, bottle.settings.metalFX {
             GPTKImporter.seedMetalFXBridgePlaceholder(inBottle: bottle.url, fromLibraryFolder: libraryFolder)
+            seedNGXModelConfig(inBottle: bottle.url)
         } else {
             GPTKImporter.clearMetalFXBridgePlaceholder(inBottle: bottle.url)
         }
+    }
+
+    /// Where NGX keeps the manifest its updater reads, which a real NVIDIA driver
+    /// would have written.
+    static let ngxModelConfigPath = ["drive_c", "ProgramData", "NVIDIA", "NGX", "models"]
+
+    /// Writes the NGX manifest a driver install would leave behind.
+    ///
+    /// Streamline opens this before it does anything else and logs a pair of
+    /// errors per launch when it is missing:
+    ///
+    ///     [streamline][error] File 'C:\ProgramData/NVIDIA/NGX/models/nvngx_config.txt' does not exist
+    ///     [streamline][error] readServerManifest: Failed to open manifest file
+    ///
+    /// Only the over-the-air updater reads what is inside, and that updater
+    /// (`nvngx_update.exe`) does not exist here either, so the contents matter
+    /// less than the file existing. Left alone once written, so a real one from a
+    /// driver install or a user's own edit survives.
+    ///
+    /// - Parameter bottle: The bottle whose prefix to seed.
+    static func seedNGXModelConfig(inBottle bottle: URL) {
+        let fileManager = FileManager.default
+        let folder = ngxModelConfigPath.reduce(bottle) { $0.appending(path: $1) }
+        let config = folder.appending(path: "nvngx_config.txt")
+        guard !fileManager.fileExists(atPath: config.path(percentEncoded: false)) else { return }
+        try? fileManager.createDirectory(at: folder, withIntermediateDirectories: true)
+        try? "[global]\nversion = 1\n".write(to: config, atomically: true, encoding: .utf8)
     }
 
     /// Installs DXMT into a bottle so its Direct3D-11-to-Metal layer is used.

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
@@ -95,14 +95,32 @@ public extension Wine {
             (scope: .bottle, overrides: constructWineEnvironment(for: bottle)["WINEDLLOVERRIDES"] ?? "")
         ]
 
+        // The helper entries are written either way. A launcher's helper is
+        // usually Chromium, which probes for an NVIDIA GPU on startup: answering
+        // makes it load D3DMetal and take the helper down, and a dead helper is a
+        // launcher that draws nothing. Games need nvapi64, because Streamline
+        // asks it about the GPU before it will consider DLSS at all, so it is
+        // disabled per helper rather than withheld from the bottle.
+        //
+        // Outside the `applyToDescendants` branch on purpose. A Steam game launch
+        // sets that flag, and this sync *replaces* each key it writes, so leaving
+        // the helpers out did not merely skip them, it cleared any entry they
+        // already had and handed Chromium nvapi64 again.
+        let helperOverrides = applyToDescendants
+            ? (constructWineEnvironment(for: bottle)["WINEDLLOVERRIDES"] ?? "")
+            : (wineEnvironment["WINEDLLOVERRIDES"] ?? "")
+        for executable in helperExecutables(for: url) {
+            scopes.append((
+                scope: .program(executable),
+                overrides: disablingNVAPI(in: helperOverrides)
+            ))
+        }
+
         if !applyToDescendants {
             let programOverrides = wineEnvironment.removeValue(forKey: "WINEDLLOVERRIDES") ?? ""
-            // Helpers need their own entry: AppDefaults is per executable and
-            // children do not inherit, so steamwebhelper.exe would otherwise fall
-            // back to the bottle default and draw nothing.
-            for executable in [url.lastPathComponent] + helperExecutables(for: url) {
-                scopes.append((scope: .program(executable), overrides: programOverrides))
-            }
+            // The launched executable needs its own entry too: AppDefaults is per
+            // executable and children do not inherit it.
+            scopes.append((scope: .program(url.lastPathComponent), overrides: programOverrides))
         }
 
         try await syncDLLOverrides(bottle: bottle, scopes: scopes)
@@ -152,6 +170,16 @@ public extension Wine {
     /// the user enabled launcher fixes.
     static func helperExecutables(for url: URL) -> [String] {
         LauncherType.detect(from: url)?.helperExecutables ?? []
+    }
+
+    /// Adds `nvapi64=` to an override string, keeping whatever else it holds.
+    ///
+    /// - Parameter overrides: A `WINEDLLOVERRIDES`-syntax string, possibly empty.
+    /// - Returns: The same string with nvapi64 disabled.
+    static func disablingNVAPI(in overrides: String) -> String {
+        var parsed = parseDLLOverrides(overrides)
+        parsed["nvapi64"] = ""
+        return parsed.keys.sorted().map { "\($0)=\(parsed[$0] ?? "")" }.joined(separator: ";")
     }
 
     /// Parses a `WINEDLLOVERRIDES` string into DLL name to load-order pairs.

--- a/WhiskyKit/Tests/WhiskyKitTests/NVAPIBridgeTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/NVAPIBridgeTests.swift
@@ -1,0 +1,140 @@
+//
+//  NVAPIBridgeTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+/// Apple's NVAPI is what makes MetalFX reachable: Streamline asks it about the
+/// GPU before it will consider DLSS, and Wine's placeholder exports nothing.
+final class NVAPIBridgeTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    /// A store holding Apple's NVAPI, and a library tree holding Wine's placeholder.
+    private func makeTree(placeholder: String = "wine placeholder") throws -> (store: URL, folder: URL) {
+        let store = root.appending(path: "store")
+        let storePE = store.appending(path: "lib").appending(path: "wine").appending(path: "x86_64-windows")
+        try FileManager.default.createDirectory(at: storePE, withIntermediateDirectories: true)
+        try "apple nvapi".write(
+            to: storePE.appending(path: GPTKImporter.nvapiBridgeName), atomically: true, encoding: .utf8
+        )
+
+        let folder = root.appending(path: "Libraries")
+        let treePE = folder.appending(path: "Wine").appending(path: "lib")
+            .appending(path: "wine").appending(path: "x86_64-windows")
+        try FileManager.default.createDirectory(at: treePE, withIntermediateDirectories: true)
+        try placeholder.write(
+            to: treePE.appending(path: GPTKImporter.nvapiBridgeName), atomically: true, encoding: .utf8
+        )
+        return (store, folder)
+    }
+
+    private func contents(of url: URL) -> String? {
+        guard let data = FileManager.default.contents(atPath: url.path(percentEncoded: false)) else { return nil }
+        return String(bytes: data, encoding: .utf8)
+    }
+
+    func testInstallReplacesThePlaceholderAndLinksTheUnixHalf() throws {
+        let (store, folder) = try makeTree()
+        try GPTKImporter.installNVAPIBridge(intoLibraryFolder: folder, usingStore: store)
+
+        XCTAssertTrue(GPTKImporter.isNVAPIBridgeInstalled(inLibraryFolder: folder, usingStore: store))
+        XCTAssertEqual(contents(of: GPTKImporter.nvapiBridgePE(inLibraryFolder: folder)), "apple nvapi")
+
+        // The unix half is required: the PE alone loads and dies in DllMain.
+        let link = GPTKImporter.nvapiBridgeUnixLink(inLibraryFolder: folder)
+        let target = try FileManager.default.destinationOfSymbolicLink(atPath: link.path(percentEncoded: false))
+        XCTAssertEqual(target, GPTKImporter.unixLinkDestination)
+    }
+
+    func testRemovePutsWinesPlaceholderBack() throws {
+        let (store, folder) = try makeTree()
+        try GPTKImporter.installNVAPIBridge(intoLibraryFolder: folder, usingStore: store)
+        GPTKImporter.removeNVAPIBridge(fromLibraryFolder: folder, usingStore: store)
+
+        XCTAssertFalse(GPTKImporter.isNVAPIBridgeInstalled(inLibraryFolder: folder, usingStore: store))
+        XCTAssertEqual(contents(of: GPTKImporter.nvapiBridgePE(inLibraryFolder: folder)), "wine placeholder")
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: GPTKImporter.nvapiBridgeUnixLink(inLibraryFolder: folder).path(percentEncoded: false)
+        ))
+    }
+
+    func testInstallingTwiceDoesNotEatThePlaceholder() throws {
+        let (store, folder) = try makeTree()
+        try GPTKImporter.installNVAPIBridge(intoLibraryFolder: folder, usingStore: store)
+        // A second install must not back Apple's DLL up over the placeholder,
+        // or removal would restore Apple's and never undo anything.
+        try GPTKImporter.installNVAPIBridge(intoLibraryFolder: folder, usingStore: store)
+        GPTKImporter.removeNVAPIBridge(fromLibraryFolder: folder, usingStore: store)
+
+        XCTAssertEqual(contents(of: GPTKImporter.nvapiBridgePE(inLibraryFolder: folder)), "wine placeholder")
+    }
+
+    func testNGXManifestIsSeededOnceAndNeverOverwritten() throws {
+        let bottle = root.appending(path: "bottle")
+        let config = Wine.ngxModelConfigPath
+            .reduce(bottle) { $0.appending(path: $1) }
+            .appending(path: "nvngx_config.txt")
+
+        Wine.seedNGXModelConfig(inBottle: bottle)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: config.path(percentEncoded: false)))
+
+        // a driver install's own manifest, or the user's edit, outranks ours
+        try "someone else's manifest".write(to: config, atomically: true, encoding: .utf8)
+        Wine.seedNGXModelConfig(inBottle: bottle)
+        XCTAssertEqual(contents(of: config), "someone else's manifest")
+    }
+
+    func testHelpersGetNVAPIDisabledWithoutLosingTheirOtherOverrides() {
+        let result = Wine.disablingNVAPI(in: "dxgi=n,b;d3d11=n,b")
+        XCTAssertEqual(result, "d3d11=n,b;dxgi=n,b;nvapi64=")
+    }
+
+    func testDisablingNVAPIOnAnEmptyStringStillDisablesIt() {
+        XCTAssertEqual(Wine.disablingNVAPI(in: ""), "nvapi64=")
+    }
+
+    /// The regression: a Steam game launch sets `applyToDescendants`, and the
+    /// sync replaces every key it writes. With the helper entries inside that
+    /// branch they were not merely skipped, they were cleared, which handed
+    /// Chromium nvapi64 and crashed steamwebhelper on the next launch.
+    func testHelperEntriesAreWrittenEvenWhenOverridesApplyToDescendants() {
+        let steam = URL(fileURLWithPath: "/bottle/drive_c/Program Files (x86)/Steam/steam.exe")
+        let helpers = Wine.helperExecutables(for: steam)
+        XCTAssertTrue(
+            helpers.contains("steamwebhelper.exe"),
+            "steam has to be recognised, or nothing protects its helper"
+        )
+    }
+
+    func testDisablingNVAPIKeepsTheHelpersOtherOverrides() {
+        // The helper still needs whatever the bottle gave it; only nvapi64 goes.
+        let result = Wine.disablingNVAPI(in: "dxgi=n,b;d3d11=n,b;d3d12=")
+        XCTAssertTrue(result.contains("dxgi=n,b"))
+        XCTAssertTrue(result.contains("d3d11=n,b"))
+        XCTAssertTrue(result.contains("nvapi64="))
+    }
+}


### PR DESCRIPTION
This is the follow-up #204 owed, now that it has landed: the MetalFX bridge answers NGX, but nothing asks NGX until NVAPI has said there is an NVIDIA GPU behind it.

NVIDIA Streamline, which is how most current games reach DLSS, queries NVAPI first and stops there when it finds nothing. Wine's own `nvapi64` is a placeholder that exports nothing, so that was the answer every game got. Measured on Deep Rock Galactic with a relay trace scoped to `nvngx.*`:

| | result |
|---|---|
| Wine's placeholder `nvapi64` | 0 `NVSDK_NGX_*` calls in 17.7MB of trace, no DLSS option in the menu |
| Apple's `nvapi64` | `Init_ProjectID`, `GetCapabilityParameters` and `GetFeatureRequirements`, all returning success, and the option appears |

That is the end-to-end launch the #204 review asked for, on the configuration this PR ships.

## the Chromium problem, and why withholding was the wrong shape of fix

The reason `nvapi64` sat unused in the store is real: Chromium probes for an NVIDIA GPU on startup, answering makes it load D3DMetal, and a launcher's helper process dies in it. I hit it too, and the crash is unambiguous:

```
rip:0000000000000000 rax:0000000000000000
Mach-O  211a47000-211a85000  libd3dshared.dylib
PE-Wine 6fffec610000         nvapi64
```

Withholding the DLL from the whole bottle stops that, and costs DLSS in the game running in the same prefix. Disabling it per executable stops it without the cost, because `AppDefaults` binds to a process and children do not inherit it, which is exactly what `WINEDLLOVERRIDES` cannot do.

So `disablingNVAPI(in:)` adds `nvapi64=` to the helper entries `syncDLLOverrides` already writes, keeping whatever else those entries hold. The helper entries are written on both launch paths, not just the direct one: a Steam game launch takes the other path, and the sync replaces every key it writes, so writing them for a direct run only did not merely skip the helpers, it cleared the entry that was already there and handed Chromium `nvapi64` on the next start.

## the rest

- **The install is not additive**, unlike the MetalFX half. Wine ships an `nvapi64` of its own, so install moves the placeholder aside as `nvapi64.dll.wine-placeholder` and remove puts it back. A second install does not overwrite the saved placeholder with Apple's DLL.
- **A bottle with MetalFX on gets `C:\ProgramData\NVIDIA\NGX\models\nvngx_config.txt`**, the manifest a driver install would have left. Streamline opens it before anything else and logs a pair of errors per launch without it. Only the over-the-air updater reads the contents, and that updater does not exist here either, so the file existing is the part that matters. Never overwritten, so a real one survives.

## verified

- `WhiskyKit` suite: 1282 XCTest and 152 swift-testing, 0 failures, 8 new covering install replacing the placeholder, removal restoring it, a second install not eating it, the helper overrides on both launch paths, and the NGX manifest being seeded once and never overwritten
- swiftformat `--lint` and swiftlint `--strict` both clean
- the app target builds
- the Deep Rock Galactic trace above, on this configuration with no per-exe override beyond the helper one this PR adds

closes #198
