### PR TITLE
fill the two en-GB rows #204 landed without

### DIFF
--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -36890,12 +36890,24 @@
             "state" : "translated",
             "value" : "DLSS via MetalFX"
           }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DLSS via MetalFX"
+          }
         }
       }
     },
     "config.metalFX.info" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maps a game's DLSS to MetalFX upscaling. Only applies when DLSS is also turned on in the game's own settings."
+          }
+        },
+        "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maps a game's DLSS to MetalFX upscaling. Only applies when DLSS is also turned on in the game's own settings."


### PR DESCRIPTION
`main` fails the Localization job, so every open PR fails it too. It is not any of their doing.

This is the ordering I raised on #208 on the 17th: that PR adds the `--check` gate, #204 was already open with two keys carrying an `en` value and no `en-GB` row, and whichever landed second would need the script run over it. #208 landed first, #204 second, and nothing ran the script in between.

```
$ ./scripts/british-english.py --check
en-GB is out of date, 2 string(s), run scripts/british-english.py:
  config.metalFX
  config.metalFX.info
```

This is `scripts/british-english.py` output with nothing edited. Both strings are spelled the same in en-GB, so the rows are copies, which is what the script does for the 783 other strings that do not differ.

After: `en-GB covers all 796 strings that need it`.

Worth having the gate run on pushes to `main` as well as on PRs, or the next one lands the same way and only shows up on somebody else's branch. Happy to do that in a follow-up if you want it.
