### PR TITLE
fix(gptk): close the crash window in the video processor install

### DIFF
--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+VideoProcessor.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+VideoProcessor.swift
@@ -98,8 +98,13 @@ extension GPTKImporter {
             withDestinationPath: unixLinkDestination
         )
 
-        try fileManager.removeItem(at: slot)
-        try fileManager.copyItem(at: shim, to: slot)
+        // Stage the shim beside the slot and swap by rename. Removing the slot
+        // before copying left a window where a crash strands the tree with no
+        // d3d12.dll at all, a state the guard above then refuses to repair.
+        let staged = peDir.appending(path: videoProcessorSlotName + ".staging")
+        try? fileManager.removeItem(at: staged)
+        try fileManager.copyItem(at: shim, to: staged)
+        _ = try fileManager.replaceItemAt(slot, withItemAt: staged)
         logger.info("Installed the D3D12 video processor, Apple's D3D12 is now \(videoDeviceDLLName)")
     }
 

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKVideoProcessorTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKVideoProcessorTests.swift
@@ -125,6 +125,19 @@ struct GPTKVideoProcessorTests {
         #expect(try exportName(of: renamed) == "d3dmt.dll")
     }
 
+    @Test("A staging file left by an interrupted install is replaced, not tripped over")
+    func installReplacesStaleStagingFile() throws {
+        let (store, runtime) = try makeDeployableRuntime()
+        let staging = peDir(of: runtime).appending(path: "d3d12.dll.staging")
+        try Data("half-written".utf8).write(to: staging)
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        #expect(GPTKImporter.isVideoProcessorInstalled(inLibraryFolder: runtime))
+        // the swap consumes the staged copy; nothing is left behind
+        #expect(!FileManager.default.fileExists(atPath: staging.path(percentEncoded: false)))
+    }
+
     @Test("A runtime that ships no interposer is left alone")
     func installSkipsRuntimeWithoutShim() throws {
         let store = try makeImportedStore(in: tempDir)


### PR DESCRIPTION
installVideoProcessor removed the d3d12 slot before copying the shim in, so a crash or kill between the two operations stranded the tree with no d3d12.dll at all. The state was also unrecoverable without a reimport: the launch-time ensure path guards on the slot existing, so it refused to repair exactly the state the interruption created.

The shim is now staged beside the slot as d3d12.dll.staging and swapped in with replaceItemAt, so the slot always holds either Apple's DLL or the interposer, never nothing. A stale staging file left by an interrupted attempt is replaced on the next install, covered by a new test.

Follow-up to the note in #197's review.