### PR TITLE
fix(graphics): keep the hardware scheduling answer for steam's games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either position (#216).
 
 ### Fixed
+- DLSS frame generation is offered to games Steam launches. Whisky steers Steam
+  itself onto DXVK so its Chromium helper paints, and it was stripping
+  CX_ACTIVE_GRAPHICS_BACKEND along with the rest of the DXVK-versus-D3DMetal
+  environment. That variable selects no backend: the only thing in the runtime
+  that reads it is win32u, and all it does there is answer the hardware
+  scheduling query. Steam's games inherit Steam's environment and run on
+  D3DMetal, since DXVK has no d3d12, so stripping it left every one of them
+  reporting that frame generation needs GPU hardware scheduling turned on. It
+  now survives the DXVK and DXMT overrides, and is still dropped for wined3d,
+  which is the one path with no D3DMetal behind it.
 - Games that decode video themselves no longer fall back to a broken
   half-resolution path under D3DMetal: when the runtime ships the D3D12
   video processor interposer, it is installed automatically alongside the

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
@@ -202,7 +202,14 @@ extension Wine {
                 // Enable DXVK DLLs at program level
                 dllResolver.programCustom.append(contentsOf: DLLOverrideResolver.dxvkPreset)
                 builder.remove("WINED3DMETAL", layer: .programUser)
-                builder.remove("CX_ACTIVE_GRAPHICS_BACKEND", layer: .programUser)
+                // CX_ACTIVE_GRAPHICS_BACKEND deliberately survives. It selects no
+                // backend: win32u is the only thing in the runtime that reads it,
+                // and all it does is answer KMTQAITYPE_WDDM_2_7_CAPS. Stripping it
+                // here starved every child of a DXVK-steered launcher, because
+                // Steam runs its games on D3DMetal (DXVK has no d3d12) while they
+                // inherit Steam's environment, and Streamline then refuses DLSS
+                // frame generation. D3DM_ENABLE_METALFX and D3DM_MTL4 already
+                // survive this branch for the same reason.
 
             case .dxmt:
                 // Reset the full translation-DLL union to builtin first so a DXVK
@@ -215,11 +222,14 @@ extension Wine {
                 builder.remove("DXVK_HUD", layer: .programUser)
                 builder.remove("DXVK_ASYNC", layer: .programUser)
                 builder.remove("WINED3DMETAL", layer: .programUser)
-                builder.remove("CX_ACTIVE_GRAPHICS_BACKEND", layer: .programUser)
+                // Survives for the reason given under .dxvk: DXMT translates d3d11
+                // only, so d3d12 is still D3DMetal here.
 
             case .wined3d:
                 // Force wined3d: disable D3DMetal + undo DXVK/DXMT DLLs
                 builder.set("WINED3DMETAL", "0", layer: .programUser)
+                // The one branch that really has no D3DMetal behind it, so the
+                // capability claim would be a lie.
                 builder.remove("CX_ACTIVE_GRAPHICS_BACKEND", layer: .programUser)
                 dllResolver.programCustom.append(contentsOf: Self.translationDLLResetEntries)
             }

--- a/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
@@ -573,4 +573,62 @@ final class EnvironmentVariablesTests: XCTestCase {
         settings.environmentVariables(wineEnv: &env)
         XCTAssertNil(env["CX_ACTIVE_GRAPHICS_BACKEND"])
     }
+
+    /// Resolves the environment a program launch actually sees: the bottle-managed
+    /// layer with the program override applied on top.
+    private func resolvedEnvironment(
+        bottleSettings: BottleSettings,
+        programOverrides: ProgramOverrides
+    ) -> [String: String] {
+        var settings = bottleSettings
+        var builder = EnvironmentBuilder()
+        var dllResolver = DLLOverrideResolver(managed: [], bottleCustom: [], programCustom: [])
+        let managed = settings.populateBottleManagedLayer(builder: &builder)
+        dllResolver.managed.append(contentsOf: managed)
+
+        Wine.applyProgramOverrides(programOverrides, builder: &builder, dllResolver: &dllResolver)
+
+        let (resolved, _) = builder.resolve()
+        return resolved
+    }
+
+    func testDXVKProgramOverrideKeepsHardwareSchedulingClaim() {
+        // Steam is steered onto DXVK so Chromium paints, and its games inherit that
+        // environment. The variable answers a capability query rather than selecting
+        // a backend, so stripping it here left every Steam-launched game unable to
+        // turn on DLSS frame generation even though it ran on D3DMetal.
+        var settings = BottleSettings()
+        settings.graphicsBackend = .d3dMetal
+
+        var overrides = ProgramOverrides()
+        overrides.graphicsBackend = .dxvk
+
+        let env = resolvedEnvironment(bottleSettings: settings, programOverrides: overrides)
+        XCTAssertEqual(env["CX_ACTIVE_GRAPHICS_BACKEND"], "d3dmetal")
+    }
+
+    func testDXMTProgramOverrideKeepsHardwareSchedulingClaim() {
+        // DXMT translates d3d11 only, so d3d12 is still D3DMetal underneath.
+        var settings = BottleSettings()
+        settings.graphicsBackend = .d3dMetal
+
+        var overrides = ProgramOverrides()
+        overrides.graphicsBackend = .dxmt
+
+        let env = resolvedEnvironment(bottleSettings: settings, programOverrides: overrides)
+        XCTAssertEqual(env["CX_ACTIVE_GRAPHICS_BACKEND"], "d3dmetal")
+    }
+
+    func testWineD3DProgramOverrideDropsHardwareSchedulingClaim() {
+        // wined3d is the one override that switches D3DMetal off outright, so
+        // there is nothing behind the claim.
+        var settings = BottleSettings()
+        settings.graphicsBackend = .d3dMetal
+
+        var overrides = ProgramOverrides()
+        overrides.graphicsBackend = .wined3d
+
+        let env = resolvedEnvironment(bottleSettings: settings, programOverrides: overrides)
+        XCTAssertNil(env["CX_ACTIVE_GRAPHICS_BACKEND"])
+    }
 }


### PR DESCRIPTION
`CX_ACTIVE_GRAPHICS_BACKEND` does not select a backend. `lib/wine/x86_64-unix/win32u.so` is the only file in the whole runtime that contains the string (checked by sweeping every binary in the tree), and all it does there is answer `KMTQAITYPE_WDDM_2_7_CAPS`, the query behind "hardware accelerated GPU scheduling". The one other reader in wine's source wants the value `wined3d` alongside `CX_LIBVULKAN`, so it is inert for that.

We strip it in `applyProgramOverrides`' dxvk branch alongside the real DXVK env, which is wrong. Steam is steered onto dxvk so its Chromium helper paints, its games inherit its environment, and those games run on D3DMetal because dxvk has no d3d12. So every Steam-launched game was told scheduling is unavailable, and NVIDIA Streamline refused DLSS frame generation with "requires GPU hardware scheduling to be enabled". `D3DM_ENABLE_METALFX` and `D3DM_MTL4` already survived that branch, so the removal was the odd one out.

## measured

Ready Or Not, same bottle, same runtime, comparing the `Environment (keys only)` line of two run logs:

```
only in GAME (launched from whisky) : ['CX_ACTIVE_GRAPHICS_BACKEND']
only in STEAM                       : []
```

Launched directly from Whisky, the DLSS frame generation option is offered. Launched from Steam it was not. With this change the Steam launch carries the key and offers it too.

## scope

Kept for dxvk and dxmt, both of which still leave d3d12 on D3DMetal. Still dropped for wined3d, which is the one override that switches D3DMetal off outright, so the claim would be false there.

Three regression tests cover all three branches. 1285 tests pass, swiftformat and swiftlint --strict are both clean.