### PR TITLE
ways in from outside the window

### DIFF
--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		FBD19F7BAD838BE3ABB2CCC2 /* LaunchResult+Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2516958D60EC8937A2AF71 /* LaunchResult+Toast.swift */; };
 		G1A2B3C4E5F60901A9B0C1D0 /* DependencyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = G1A2B3C4E5F60901A9B0C1D1 /* DependencyManager.swift */; };
 		AB5DECAF20260818000000D4 /* RemediationExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5DECAF20260818000000D5 /* RemediationExecutor.swift */; };
+		AB5DECAF20260818000000D0 /* QuickLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5DECAF20260818000000D1 /* QuickLaunch.swift */; };
 		G1A2B3C4E5F60901A9B0C1D2 /* Winetricks+Install.swift in Sources */ = {isa = PBXBuildFile; fileRef = G1A2B3C4E5F60901A9B0C1D3 /* Winetricks+Install.swift */; };
 		H1A2B3C4E5F61001A9B0C1D0 /* LaunchTimeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = H1A2B3C4E5F61001A9B0C1D1 /* LaunchTimeBanner.swift */; };
 		H1A2B3C4E5F61101A9B0C1D0 /* DependencyConfigSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = H1A2B3C4E5F61101A9B0C1D1 /* DependencyConfigSection.swift */; };
@@ -322,6 +323,7 @@
 		F1A2B3C4E5F60801A9B0C1D0 /* ControllerMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControllerMonitor.swift; sourceTree = "<group>"; };
 		G1A2B3C4E5F60901A9B0C1D1 /* DependencyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyManager.swift; sourceTree = "<group>"; };
 		AB5DECAF20260818000000D5 /* RemediationExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemediationExecutor.swift; sourceTree = "<group>"; };
+		AB5DECAF20260818000000D1 /* QuickLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunch.swift; sourceTree = "<group>"; };
 		G1A2B3C4E5F60901A9B0C1D3 /* Winetricks+Install.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Winetricks+Install.swift"; sourceTree = "<group>"; };
 		H1A2B3C4E5F61001A9B0C1D1 /* LaunchTimeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Whisky/Views/Common/LaunchTimeBanner.swift; sourceTree = SOURCE_ROOT; };
 		H1A2B3C4E5F61101A9B0C1D1 /* DependencyConfigSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyConfigSection.swift; sourceTree = "<group>"; };
@@ -594,6 +596,7 @@
 				AA88CFEB38031323229CD377 /* LauncherDiagnostics.swift */,
 				G1A2B3C4E5F60901A9B0C1D1 /* DependencyManager.swift */,
 				AB5DECAF20260818000000D5 /* RemediationExecutor.swift */,
+				AB5DECAF20260818000000D1 /* QuickLaunch.swift */,
 				F1A2B3C4E5F60801A9B0C1D0 /* ControllerMonitor.swift */,
 				I1A2B3C4E5F61201A9B0C1D1 /* SteamDownloadMonitor.swift */,
 				2B94A3D15B907CF55C906C9A /* SteamClientOrchestrator.swift */,
@@ -1062,6 +1065,7 @@
 				F1A2B3C4E5F60801A9B0C1D1 /* ControllerMonitor.swift in Sources */,
 				G1A2B3C4E5F60901A9B0C1D0 /* DependencyManager.swift in Sources */,
 				AB5DECAF20260818000000D4 /* RemediationExecutor.swift in Sources */,
+				AB5DECAF20260818000000D0 /* QuickLaunch.swift in Sources */,
 				G1A2B3C4E5F60901A9B0C1D2 /* Winetricks+Install.swift in Sources */,
 				H1A2B3C4E5F61101A9B0C1D0 /* DependencyConfigSection.swift in Sources */,
 				H1A2B3C4E5F61101A9B0C1D2 /* DependencyInstallSheet.swift in Sources */,

--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -97,6 +97,50 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         !UserDefaults.standard.bool(forKey: "showMenuBarExtra")
     }
 
+    // MARK: - Dock Menu
+
+    /// The pin behind a Dock menu item.
+    private final class DockPin: NSObject {
+        let bottleURL: URL
+        let pinURL: URL
+
+        init(bottleURL: URL, pinURL: URL) {
+            self.bottleURL = bottleURL
+            self.pinURL = pinURL
+        }
+    }
+
+    /// Right-clicking Whisky in the Dock lists the pinned games, launchable
+    /// without the main window.
+    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        let entries = QuickLaunch.availablePins()
+        guard !entries.isEmpty else { return nil }
+
+        let menu = NSMenu()
+        let bottleCount = Set(entries.map(\.bottle.url)).count
+        for entry in entries.prefix(10) {
+            guard let pinURL = entry.pin.url else { continue }
+            let title = bottleCount > 1
+                ? "\(entry.pin.name) (\(entry.bottle.settings.name))"
+                : entry.pin.name
+            let item = NSMenuItem(
+                title: title, action: #selector(launchDockPin(_:)), keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = DockPin(bottleURL: entry.bottle.url, pinURL: pinURL)
+            menu.addItem(item)
+        }
+        return menu
+    }
+
+    @MainActor @objc private func launchDockPin(_ sender: NSMenuItem) {
+        guard let ref = sender.representedObject as? DockPin,
+              let bottle = BottleVM.shared.bottles.first(where: { $0.url == ref.bottleURL }),
+              let pin = bottle.settings.pins.first(where: { $0.url == ref.pinURL })
+        else { return }
+        QuickLaunch.launch(pin: pin, in: bottle)
+    }
+
     private static var appUrl: URL? {
         Bundle.main.resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
     }

--- a/Whisky/Info.plist
+++ b/Whisky/Info.plist
@@ -53,6 +53,17 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.franke.Whisky</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>whisky</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSDesktopFolderUsageDescription</key>
 	<string>Whisky needs access to Desktop to create shortcuts for Windows programs.</string>
 	<key>NSDocumentsFolderUsageDescription</key>

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -95705,6 +95705,102 @@
         }
       }
     },
+    "url.confirm.info" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This launch was requested by a link from outside Whisky. Whisky can only launch games and pins you already have, never an arbitrary program, but you should still recognize this one."
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This launch was requested by a link from outside Whisky. Whisky can only launch games and pins you already have, never an arbitrary program, but you should still recognise this one."
+          }
+        }
+      }
+    },
+    "url.confirm.launch" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Launch"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Launch"
+          }
+        }
+      }
+    },
+    "url.confirm.msg %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Launch %@?"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Launch %@?"
+          }
+        }
+      }
+    },
+    "url.confirm.remember" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Always allow this from links"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Always allow this from links"
+          }
+        }
+      }
+    },
+    "url.error.noBottle %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No bottle named %@."
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No bottle named %@."
+          }
+        }
+      }
+    },
+    "url.error.noPin" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing pinned under that name."
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing pinned under that name."
+          }
+        }
+      }
+    },
     "wine.clearShaderCaches" : {
       "localizations" : {
         "ar" : {

--- a/Whisky/Utils/QuickLaunch.swift
+++ b/Whisky/Utils/QuickLaunch.swift
@@ -1,0 +1,247 @@
+//
+//  QuickLaunch.swift
+//  Whisky
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import AppKit
+import os.log
+import WhiskyKit
+
+/// Launching from surfaces that live outside the main window: the Dock menu,
+/// the menu-bar extra, and `whisky://` URLs.
+///
+/// The URL scheme is the identity layer for all of them. Every surface here
+/// names a target the same way a URL does, an installed Steam app ID or a pin
+/// the user made, and resolves it at launch time rather than baking a path. A
+/// shortcut therefore survives its bottle being moved or renamed, and picks up
+/// current settings, DLL deployment and crash classification, because it goes
+/// through the same door as a launch from the window. Anything added later that
+/// starts a program from outside the window belongs here, resolving the same
+/// two identifiers, rather than growing its own path handling. Why a URL may
+/// only ever name those two things is ``WhiskyKit/WhiskyURL``.
+@MainActor
+enum QuickLaunch {
+    private static let logger = Logger(
+        subsystem: Bundle.whiskyBundleIdentifier, category: "QuickLaunch"
+    )
+
+    /// Every pin whose file still exists, across all available bottles.
+    ///
+    /// Reads `settings.pins` rather than `bottle.pinnedPrograms`: the latter
+    /// resolves against `bottle.programs`, which stays empty until a bottle
+    /// view scans it. Pins live in settings and are always loaded.
+    static func availablePins() -> [(bottle: Bottle, pin: PinnedProgram)] {
+        BottleVM.shared.bottles.filter(\.isAvailable).flatMap { bottle in
+            bottle.settings.pins.compactMap { pin -> (bottle: Bottle, pin: PinnedProgram)? in
+                guard let path = pin.url?.path(percentEncoded: false),
+                      FileManager.default.fileExists(atPath: path)
+                else { return nil }
+                return (bottle, pin)
+            }
+        }
+    }
+
+    /// Launches a pinned program without a prior bottle scan.
+    ///
+    /// The `Program` is built from the pin so this doesn't depend on a bottle
+    /// view having scanned. Failures are reported via an `NSAlert` rather than
+    /// a view toast because these surfaces can be the app's only one (the main
+    /// window may be closed), so there's no toast presenter to reach.
+    static func launch(pin: PinnedProgram, in bottle: Bottle) {
+        guard let url = pin.url else { return }
+        let program = Program(url: url, bottle: bottle)
+        Task {
+            let result = await program.launchWithUserMode(useTerminal: false)
+            guard case let .launchFailed(_, errorDescription) = result else { return }
+            logger.error(
+                "Quick launch failed for \(pin.name, privacy: .public): \(errorDescription, privacy: .public)"
+            )
+            presentLaunchFailure(programName: pin.name, error: errorDescription)
+        }
+    }
+
+    private static func presentLaunchFailure(programName: String, error: String) {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "menubar.launchFailed \(programName)")
+        alert.informativeText = error
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: String(localized: "button.ok"))
+        NSApp.activate(ignoringOtherApps: true)
+        alert.runModal()
+    }
+
+    // MARK: - whisky:// URLs
+
+    /// A target a `whisky://` URL named, already resolved against real state.
+    ///
+    /// Resolution happens before the confirmation, not after, so the dialog can
+    /// name what will actually run rather than echoing back the app ID the page
+    /// supplied.
+    ///
+    /// `@MainActor` for ``consentKey``: a nested type does not inherit the
+    /// enclosing type's isolation.
+    @MainActor
+    enum Target {
+        case steam(SteamGame, bottle: Bottle)
+        case pin(PinnedProgram, bottle: Bottle)
+
+        /// What the user sees in the confirmation.
+        var displayName: String {
+            switch self {
+            case let .steam(game, _): game.name
+            case let .pin(pin, _): pin.name
+            }
+        }
+
+        /// Identifies the target across launches, so "always allow" outlives a
+        /// restart. Scoped by bottle, since the same app ID in a different
+        /// bottle is a different thing to approve.
+        var consentKey: String {
+            switch self {
+            case let .steam(game, bottle): "steam:\(bottle.settings.name):\(game.appId)"
+            case let .pin(pin, bottle): "pin:\(bottle.settings.name):\(pin.name)"
+            }
+        }
+    }
+
+    /// Targets the user chose to stop being asked about. Written only through
+    /// ``rememberApproval(of:)``.
+    static let approvedURLTargetsKey = "urlLaunchApprovedTargets"
+
+    /// Handles a `whisky://` URL. Returns `false` for any other scheme so
+    /// file opens keep flowing to `FileOpenView`.
+    ///
+    /// What a URL may say, and why there are only two forms, is
+    /// ``WhiskyKit/WhiskyURL``. This handles what a well-formed one does.
+    ///
+    /// A URL cannot name an executable, so nothing arbitrary runs, but a page
+    /// the user did not mean to visit can still start a game they own. So a URL
+    /// arrival confirms once per target before launching, and the dialog offers
+    /// to remember that target, which keeps a shortcut at one click after its
+    /// first use. The Dock menu and the menu-bar extra do not confirm: the user
+    /// is already in the app and already clicked the thing.
+    static func handle(_ url: URL) -> Bool {
+        guard url.scheme?.lowercased() == WhiskyURL.scheme else { return false }
+        guard let request = WhiskyURL.parse(url) else {
+            logger.error("Unrecognized whisky URL: \(url.absoluteString, privacy: .public)")
+            return true
+        }
+
+        // A URL that launches the app can arrive before the window's task has
+        // loaded the bottle list, and resolution below reads it.
+        if BottleVM.shared.bottles.isEmpty {
+            BottleVM.shared.loadBottles()
+        }
+
+        let resolved: Result<Target, String> = switch request {
+        case let .steam(appId, bottle):
+            resolveSteam(appId: appId, bottleName: bottle)
+        case let .pin(name, bottle):
+            resolvePin(named: name, bottleName: bottle)
+        }
+
+        switch resolved {
+        case let .failure(reason):
+            presentLaunchFailure(programName: url.absoluteString, error: reason)
+        case let .success(target):
+            guard confirmURLLaunch(of: target) else { return true }
+            launch(target)
+        }
+        return true
+    }
+
+    /// Whether this target may run without asking, either because the user
+    /// approved it before or because they approve it now.
+    private static func confirmURLLaunch(of target: Target) -> Bool {
+        let approved = UserDefaults.standard.stringArray(forKey: approvedURLTargetsKey) ?? []
+        guard !approved.contains(target.consentKey) else { return true }
+
+        let alert = NSAlert()
+        alert.messageText = String(localized: "url.confirm.msg \(target.displayName)")
+        alert.informativeText = String(localized: "url.confirm.info")
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: String(localized: "url.confirm.launch"))
+        alert.addButton(withTitle: String(localized: "button.cancel"))
+        alert.showsSuppressionButton = true
+        alert.suppressionButton?.title = String(localized: "url.confirm.remember")
+
+        NSApp.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            logger.info("URL launch declined for \(target.consentKey, privacy: .public)")
+            return false
+        }
+        if alert.suppressionButton?.state == .on {
+            rememberApproval(of: target)
+        }
+        return true
+    }
+
+    private static func rememberApproval(of target: Target) {
+        var approved = UserDefaults.standard.stringArray(forKey: approvedURLTargetsKey) ?? []
+        guard !approved.contains(target.consentKey) else { return }
+        approved.append(target.consentKey)
+        UserDefaults.standard.set(approved, forKey: approvedURLTargetsKey)
+    }
+
+    private static func launch(_ target: Target) {
+        switch target {
+        case let .steam(game, bottle):
+            do {
+                _ = try SteamLauncher.launch(
+                    appId: game.appId, bottle: bottle, installURL: game.installURL
+                )
+            } catch {
+                presentLaunchFailure(
+                    programName: target.displayName, error: error.localizedDescription
+                )
+            }
+        case let .pin(pin, bottle):
+            launch(pin: pin, in: bottle)
+        }
+    }
+
+    /// Resolves the Steam form of a URL against what is actually installed.
+    ///
+    /// A named bottle narrows the candidates rather than replacing the check,
+    /// so ``WhiskyKit/SteamLauncher/resolveGame(appId:in:routing:)`` runs
+    /// either way.
+    private static func resolveSteam(appId: Int, bottleName: String?) -> Result<Target, String> {
+        var bottles = BottleVM.shared.bottles.filter(\.isAvailable)
+        if let bottleName {
+            guard let named = bottles.first(where: { $0.settings.name == bottleName }) else {
+                return .failure(String(localized: "url.error.noBottle \(bottleName)"))
+            }
+            bottles = [named]
+        }
+        do {
+            let hit = try SteamLauncher.resolveGame(appId: appId, in: bottles)
+            return .success(.steam(hit.game, bottle: hit.bottle))
+        } catch {
+            return .failure(error.localizedDescription)
+        }
+    }
+
+    private static func resolvePin(named pinName: String, bottleName: String?) -> Result<Target, String> {
+        let matches = availablePins().filter { entry in
+            entry.pin.name.localizedCaseInsensitiveCompare(pinName) == .orderedSame
+                && (bottleName == nil || entry.bottle.settings.name == bottleName)
+        }
+        guard let hit = matches.first else {
+            return .failure(String(localized: "url.error.noPin"))
+        }
+        return .success(.pin(hit.pin, bottle: hit.bottle))
+    }
+}

--- a/Whisky/Views/ContentView.swift
+++ b/Whisky/Views/ContentView.swift
@@ -178,7 +178,17 @@ struct ContentView: View {
         }
         .handlesExternalEvents(preferring: [], allowing: ["*"])
         .onOpenURL { url in
+            if QuickLaunch.handle(url) { return }
             openedFileURL = url
+        }
+        .dropDestination(for: URL.self) { urls, _ in
+            // A Finder drop of anything the Run panel would accept opens the
+            // same run-this-file flow, wherever on the window it lands.
+            let runnable = ["exe", "msi", "bat", "msix", "appx", "url"]
+            guard let url = urls.first(where: { runnable.contains($0.pathExtension.lowercased()) })
+            else { return false }
+            openedFileURL = url
+            return true
         }
         .task {
             bottleVM.loadBottles()

--- a/Whisky/Views/MenuBar/WhiskyMenuBarView.swift
+++ b/Whisky/Views/MenuBar/WhiskyMenuBarView.swift
@@ -16,7 +16,6 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
-import os.log
 import SwiftUI
 import WhiskyKit
 
@@ -71,42 +70,10 @@ struct WhiskyMenuBarView: View {
                 Text("menubar.bottle.noPins")
             } else {
                 ForEach(pins, id: \.url) { pin in
-                    Button(pin.name) { launch(pin, in: bottle) }
+                    Button(pin.name) { QuickLaunch.launch(pin: pin, in: bottle) }
                 }
             }
         }
-    }
-
-    /// Launches a pinned program, surfacing failures the user would otherwise
-    /// never see.
-    ///
-    /// The `Program` is built from the pin so this doesn't depend on a prior
-    /// bottle scan. Failures are reported via an `NSAlert` rather than a view
-    /// toast because the menu-bar extra can be the app's only surface (the main
-    /// window may be closed), so there's no toast presenter to reach.
-    @MainActor
-    private func launch(_ pin: PinnedProgram, in bottle: Bottle) {
-        guard let url = pin.url else { return }
-        let program = Program(url: url, bottle: bottle)
-        Task {
-            let result = await program.launchWithUserMode(useTerminal: false)
-            guard case let .launchFailed(_, errorDescription) = result else { return }
-            Logger.wineKit.error(
-                "Menu-bar launch failed for \(pin.name, privacy: .public): \(errorDescription, privacy: .public)"
-            )
-            presentLaunchFailure(programName: pin.name, error: errorDescription)
-        }
-    }
-
-    @MainActor
-    private func presentLaunchFailure(programName: String, error: String) {
-        let alert = NSAlert()
-        alert.messageText = String(localized: "menubar.launchFailed \(programName)")
-        alert.informativeText = error
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: String(localized: "button.ok"))
-        NSApp.activate(ignoringOtherApps: true)
-        alert.runModal()
     }
 
     /// Brings an existing Whisky window forward, or opens a fresh one when the

--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -166,8 +166,7 @@ struct WhiskyApp: App {
                 }
                 .toast($audioDeviceToast)
         }
-        // Don't ask me how this works, it just does
-        .handlesExternalEvents(matching: ["{same path of URL?}"])
+        .handlesExternalEvents(matching: ["*"])
         .commands {
             CommandGroup(after: .appInfo) {
                 SparkleView(updater: updaterController.updater)

--- a/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Steam/SteamLauncher.swift
@@ -111,6 +111,32 @@ public enum SteamLauncher {
         return SteamLibrary.preferredOverrides(among: candidates)
     }
 
+    /// Finds the installed game an App ID names, and the bottle holding it.
+    ///
+    /// Narrowing `bottles` to a single bottle chooses where to look, never
+    /// whether to look: an App ID that arrives from outside the app may only
+    /// ever reach a game the user actually has. The library entry is also what
+    /// lets a caller name the game rather than echo the App ID back.
+    ///
+    /// - Parameters:
+    ///   - appId: The Steam App ID to locate.
+    ///   - bottles: The bottles to search.
+    ///   - routing: The route store to consult.
+    /// - Returns: The library entry and the bottle it was found in.
+    /// - Throws: ``SteamLaunchError/gameNotFound(appId:)`` when no bottle has it.
+    @MainActor
+    public static func resolveGame(
+        appId: Int, in bottles: [Bottle], routing: GameRouting = GameRouting()
+    ) throws -> (game: SteamGame, bottle: Bottle) {
+        let bottle = try resolveBottle(appId: appId, in: bottles, routing: routing)
+        guard let game = SteamLibrary.enumerate(bottleURL: bottle.url)
+            .first(where: { $0.appId == appId })
+        else {
+            throw SteamLaunchError.gameNotFound(appId: appId)
+        }
+        return (game, bottle)
+    }
+
     /// Finds the bottle to launch an App ID from: the remembered route when it
     /// still has the game installed, otherwise the first bottle that does.
     ///

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/WhiskyURL.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/WhiskyURL.swift
@@ -1,0 +1,85 @@
+//
+//  WhiskyURL.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// What a `whisky://` URL is allowed to say.
+///
+/// This parser is the security boundary of the URL scheme, which is why it
+/// lives apart from the code that acts on it and is tested on its own. There
+/// are exactly two forms and no third:
+///
+/// ```
+/// whisky://launch?steam=<appid>[&bottle=<name>]
+/// whisky://launch?pin=<name>[&bottle=<name>]
+/// ```
+///
+/// Neither can name an executable. A `path=` form would let any web page pick
+/// the program, so the guarantee is the absence of one: a URL can only reach
+/// state the user created, an app ID installed in a bottle they have or a pin
+/// they made by hand. The allowlist is the shape of this type rather than a
+/// list anyone maintains, and it stops being true the moment a form is added
+/// that takes a path or resolves against anything else.
+///
+/// Parsing does not decide whether the target exists. That is
+/// `QuickLaunch`'s job, and it happens before the user is asked to confirm, so
+/// the confirmation can name what will actually run.
+public enum WhiskyURL {
+    /// A well-formed request. `bottle` narrows the search when the same app ID
+    /// or pin name exists in more than one bottle.
+    public enum Request: Equatable, Sendable {
+        case steam(appId: Int, bottle: String?)
+        case pin(name: String, bottle: String?)
+    }
+
+    public static let scheme = "whisky"
+
+    /// Parses a URL, or returns `nil` for anything that is not one of the two
+    /// forms, including a different scheme, a different host, a missing or
+    /// non-numeric app ID, an empty pin name, and any unknown parameter.
+    ///
+    /// - Parameter url: The URL to parse.
+    /// - Returns: The request, or `nil` if the URL says anything else.
+    public static func parse(_ url: URL) -> Request? {
+        guard url.scheme?.lowercased() == scheme, url.host()?.lowercased() == "launch",
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return nil }
+
+        let items = components.queryItems ?? []
+        // an unknown parameter means a form this build does not know, which must
+        // not silently degrade into the half of it that parses
+        guard items.allSatisfy({ ["steam", "pin", "bottle"].contains($0.name) }) else { return nil }
+
+        let bottle = items.first { $0.name == "bottle" }?.value.flatMap { $0.isEmpty ? nil : $0 }
+        let steam = items.first { $0.name == "steam" }?.value
+        let pin = items.first { $0.name == "pin" }?.value
+
+        // guessing which of the two was meant is how a launcher starts the
+        // wrong thing
+        switch (steam, pin) {
+        case let (steam?, nil):
+            guard let appId = Int(steam), appId > 0 else { return nil }
+            return .steam(appId: appId, bottle: bottle)
+        case let (nil, pin?):
+            guard !pin.isEmpty else { return nil }
+            return .pin(name: pin, bottle: bottle)
+        default:
+            return nil
+        }
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/SteamLauncherTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/SteamLauncherTests.swift
@@ -190,4 +190,29 @@ struct SteamLauncherTests {
 
         #expect(resolved.url == ready.url)
     }
+
+    @Test("Resolving a game hands back the library entry with the bottle")
+    @MainActor func resolveGameCarriesTheEntry() throws {
+        let bottle = try Bottle(bottleUrl: makeSteamBottle("library", appIds: [1_245_620]))
+
+        let hit = try SteamLauncher.resolveGame(
+            appId: 1_245_620, in: [bottle], routing: makeRouting()
+        )
+
+        #expect(hit.bottle.url == bottle.url)
+        #expect(hit.game.appId == 1_245_620)
+        #expect(hit.game.name == "Game 1245620")
+    }
+
+    @Test("Narrowing to one bottle still refuses an App ID it does not have")
+    @MainActor func namedBottleWithoutTheGameIsRefused() throws {
+        let named = try Bottle(bottleUrl: makeSteamBottle("named", appIds: [4_576_510]))
+        let holder = try Bottle(bottleUrl: makeSteamBottle("holder", appIds: [1_245_620]))
+        let routing = makeRouting()
+        routing.record(appId: 1_245_620, bottleURL: holder.url)
+
+        #expect(throws: SteamLaunchError.gameNotFound(appId: 1_245_620)) {
+            try SteamLauncher.resolveGame(appId: 1_245_620, in: [named], routing: routing)
+        }
+    }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyURLTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyURLTests.swift
@@ -1,0 +1,107 @@
+//
+//  WhiskyURLTests.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("Whisky URL Tests")
+struct WhiskyURLTests {
+    private func parse(_ string: String) -> WhiskyURL.Request? {
+        guard let url = URL(string: string) else { return nil }
+        return WhiskyURL.parse(url)
+    }
+
+    // MARK: - The two forms
+
+    @Test("A steam app id parses, with and without a bottle")
+    func steamForm() {
+        #expect(parse("whisky://launch?steam=1086940") == .steam(appId: 1_086_940, bottle: nil))
+        #expect(
+            parse("whisky://launch?steam=1086940&bottle=Steam") == .steam(appId: 1_086_940, bottle: "Steam")
+        )
+    }
+
+    @Test("A pin name parses, with and without a bottle")
+    func pinForm() {
+        #expect(parse("whisky://launch?pin=ULTRAKILL") == .pin(name: "ULTRAKILL", bottle: nil))
+        #expect(
+            parse("whisky://launch?pin=ULTRAKILL&bottle=Games") == .pin(name: "ULTRAKILL", bottle: "Games")
+        )
+    }
+
+    @Test("A percent-encoded pin name survives parsing")
+    func pinNameIsDecoded() {
+        #expect(parse("whisky://launch?pin=Deep%20Rock%20Galactic")
+            == .pin(name: "Deep Rock Galactic", bottle: nil))
+    }
+
+    // MARK: - Everything a web page might try
+
+    @Test("There is no path form, which is what makes this safe")
+    func noPathForm() {
+        #expect(parse("whisky://launch?path=/Users/me/evil.exe") == nil)
+        #expect(parse("whisky://launch?exe=C:%5CWindows%5Csystem32%5Ccmd.exe") == nil)
+        #expect(parse("whisky://launch?program=cmd.exe") == nil)
+    }
+
+    @Test("An unknown parameter rejects the whole url rather than the half it knows")
+    func unknownParameterIsFatal() {
+        // a future form must not degrade into this one on an older build
+        #expect(parse("whisky://launch?steam=1086940&path=/evil.exe") == nil)
+        #expect(parse("whisky://launch?pin=Game&elevate=1") == nil)
+    }
+
+    @Test("Naming both a steam id and a pin is ambiguous, so neither runs")
+    func bothFormsAtOnce() {
+        #expect(parse("whisky://launch?steam=1086940&pin=Game") == nil)
+    }
+
+    @Test("A url that says nothing to launch parses to nothing")
+    func emptyRequest() {
+        #expect(parse("whisky://launch") == nil)
+        #expect(parse("whisky://launch?bottle=Steam") == nil)
+        #expect(parse("whisky://launch?pin=") == nil)
+    }
+
+    @Test("An app id that is not a positive number is refused")
+    func malformedAppID() {
+        #expect(parse("whisky://launch?steam=notanumber") == nil)
+        #expect(parse("whisky://launch?steam=") == nil)
+        #expect(parse("whisky://launch?steam=0") == nil)
+        #expect(parse("whisky://launch?steam=-1") == nil)
+    }
+
+    @Test("Another scheme or another host is not ours")
+    func wrongSchemeOrHost() {
+        #expect(parse("steam://launch?steam=1086940") == nil)
+        #expect(parse("https://example.com/launch?steam=1086940") == nil)
+        #expect(parse("whisky://install?steam=1086940") == nil)
+        #expect(parse("whisky://launch/extra?steam=1086940") != nil)
+    }
+
+    @Test("Scheme and host are matched case-insensitively, as the loader hands them over")
+    func caseInsensitiveSchemeAndHost() {
+        #expect(parse("WHISKY://LAUNCH?steam=1086940") == .steam(appId: 1_086_940, bottle: nil))
+    }
+
+    @Test("An empty bottle name is the same as not naming one")
+    func emptyBottleIsNoBottle() {
+        #expect(parse("whisky://launch?steam=1086940&bottle=") == .steam(appId: 1_086_940, bottle: nil))
+    }
+}


### PR DESCRIPTION
Raising this per your reply on #172, with the confirmation step in the same PR.

## the two forms

```
whisky://launch?steam=<appid>[&bottle=<name>]
whisky://launch?pin=<name>[&bottle=<name>]
```

The parser moved into `WhiskyKit/Whisky/WhiskyURL.swift` rather than staying in the app, because it is the security boundary and a boundary that cannot be unit tested is a boundary on trust. It rejects a path form, an unknown parameter, both forms at once, a non-positive app ID, an empty pin name, another scheme and another host. 12 tests cover exactly those, including the ones a page would actually try:

```swift
#expect(parse("whisky://launch?path=/Users/me/evil.exe") == nil)
#expect(parse("whisky://launch?steam=1086940&path=/evil.exe") == nil)
#expect(parse("whisky://launch?steam=1086940&pin=Game") == nil)
```

The second one is the case I would most want a reviewer to check. An unknown parameter rejects the whole URL rather than running the half it recognises, so a form added later cannot silently degrade into this one on an older build.

## the confirmation

A URL arrival resolves the target first, then confirms, then launches. Resolving first is what lets the dialog say "Launch Deep Rock Galactic?" rather than echoing back the app ID the page supplied, which is the difference between a dialog that informs and one people click through.

The suppression checkbox is `NSAlert`'s own, worded "Always allow this from links", and the approval is stored per target rather than globally. The key is scoped by bottle (`steam:<bottle>:<appid>`), since the same app ID in a different bottle is a different thing to have approved.

The Dock menu and the menu-bar extra deliberately do not confirm. The user is in the app and clicked the thing; a dialog there is friction with nothing behind it.

## the identity-layer framing, in the code

Per your request it is in the doc comments now, split across the two places it belongs. `QuickLaunch` carries why every outside-the-window surface resolves an identifier at launch time instead of baking a path, and that anything added later belongs there. `WhiskyURL` carries why there are exactly two forms and what adding a third would give up, since that is the one people will be tempted to extend.

## steam_appid.txt

Not in this PR, in either direction. Read-only stays as it is; the write side waits for a per-game `launchStrategy` field with testing behind it, as agreed.

## verified

- `WhiskyKit` suite: 1282 XCTest and 194 swift-testing, 0 failures, 12 new on the parser
- swiftformat `--lint` and swiftlint `--strict` clean, `british-english.py --check` clean
- the app target builds

One judgement call worth flagging: this carries the Dock menu and the drag-and-drop run flow alongside the scheme, because all three were the same commit and all three go through the one launch path that the scheme defines. Say the word and I will split them out, though the shared path is most of the point.
