### PR TITLE
feat(gptk): deploy the dxgi driver version interposer alongside the d3d12 one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either position (#216).
 
 ### Fixed
+- Games that check the graphics driver version can start. D3DMetal answers the
+  DXGI query with success and a version of -1, which reads back as
+  65535.65535.65535.65535 and fails every minimum-driver check: Helldivers 2 put
+  a modal "GPU drivers are out of date" box in front of the game. A runtime that
+  carries the DXGI interposer is now deployed with it, answering the same version
+  Wine already publishes for the adapter so the two agree. It has to be its own
+  module rather than part of the D3D12 one, because the check happens before a
+  game touches D3D12 at all. Runtimes without it are skipped as before.
 - Games that decode video themselves no longer fall back to a broken
   half-resolution path under D3DMetal: when the runtime ships the D3D12
   video processor interposer, it is installed automatically alongside the

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+Deployment.swift
@@ -180,10 +180,12 @@ extension GPTKImporter {
         // can be installed: it forwards into the payload's own shared dylib and
         // has nothing to bind to before this point.
         try installMetalFXBridge(intoLibraryFolder: folder, usingStore: store)
-        // Apple's D3D12 is in place now, which is the only moment the swap can
-        // be made: the runtime ships the interposer but has nothing to forward
+        // Apple's DLLs are in place now, which is the only moment the swaps can
+        // be made: the runtime ships the interposers but has nothing to forward
         // into until this point.
-        try installVideoProcessor(intoLibraryFolder: folder)
+        for interposer in interposers {
+            try install(interposer, intoLibraryFolder: folder)
+        }
         try installNVAPIBridge(intoLibraryFolder: folder, usingStore: store)
         logger.info("Deployed GPTK payload into the runtime tree")
     }

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+VideoProcessor.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/GPTKImporter+VideoProcessor.swift
@@ -35,7 +35,56 @@ enum GPTKVideoProcessorError: Error, Equatable {
 /// It cannot simply be installed at build time: it has to sit in the `d3d12.dll`
 /// builtin slot with Apple's DLL renamed alongside it, and Apple's DLL only
 /// exists once the payload here is deployed. So the swap happens on deploy.
+/// One builtin slot the runtime interposes: which shim goes in, and what Apple's
+/// DLL is called once it has been moved aside.
+///
+/// The two we ship are the same operation, so they share one implementation
+/// rather than two files that drift.
+struct GPTKInterposer: Sendable {
+    /// The shim's filename under `lib/gptk-video` in the runtime.
+    let shimFileName: String
+    /// The builtin slot it takes over.
+    let slotName: String
+    /// Apple's DLL under its second name. It can never be longer than
+    /// ``slotName``: the export name is patched in place, so it cannot grow.
+    let renamedName: String
+    /// The unix half beside the renamed PE, without which D3DMetal never binds.
+    let renamedUnixName: String
+    /// What to call it in a log line.
+    let label: String
+}
+
 extension GPTKImporter {
+    /// D3DMetal supplies no `ID3D12VideoDevice`, so a game that decodes video
+    /// itself and asks D3D12 to convert NV12 to RGB gets `E_NOINTERFACE`.
+    static let videoProcessorInterposer = GPTKInterposer(
+        shimFileName: "d3d12shim.dll",
+        slotName: "d3d12.dll",
+        renamedName: "d3dmt.dll",
+        renamedUnixName: "d3dmt.so",
+        label: "D3D12 video processor"
+    )
+
+    /// D3DMetal's `IDXGIAdapter::CheckInterfaceSupport` returns success and
+    /// writes -1 for the driver version. Engines format that as four words and
+    /// read "65535.65535.65535.65535", then refuse to run: Helldivers 2 puts a
+    /// modal "GPU drivers are out of date" box in front of the game.
+    static let dxgiVersionInterposer = GPTKInterposer(
+        shimFileName: "dxgishim.dll",
+        slotName: "dxgi.dll",
+        renamedName: "dxgm.dll",
+        renamedUnixName: "dxgm.so",
+        label: "DXGI driver version"
+    )
+
+    /// Every slot we interpose, in the order they are installed.
+    static let interposers = [videoProcessorInterposer, dxgiVersionInterposer]
+
+    static func shim(for interposer: GPTKInterposer, inLibraryFolder folder: URL) -> URL {
+        folder.appending(path: "Wine").appending(path: "lib")
+            .appending(path: "gptk-video").appending(path: interposer.shimFileName)
+    }
+
     /// Where the runtime ships the interposer, if it is new enough to carry one.
     static let videoProcessorShimPath = ["lib", "gptk-video", "d3d12shim.dll"]
     /// Apple's D3D12 under its second name. Nine characters, and that is not a
@@ -50,37 +99,45 @@ extension GPTKImporter {
 
     /// Whether `folder`'s runtime carries an interposer to install at all.
     /// Runtimes older than the one that introduced it simply do without.
-    static func hasVideoProcessor(inLibraryFolder folder: URL) -> Bool {
+    static func has(_ interposer: GPTKInterposer, inLibraryFolder folder: URL) -> Bool {
         FileManager.default.fileExists(
-            atPath: videoProcessorShim(inLibraryFolder: folder).path(percentEncoded: false)
+            atPath: shim(for: interposer, inLibraryFolder: folder).path(percentEncoded: false)
         )
     }
 
+    static func hasVideoProcessor(inLibraryFolder folder: URL) -> Bool {
+        has(videoProcessorInterposer, inLibraryFolder: folder)
+    }
+
     /// Whether the interposer currently occupies the `d3d12.dll` slot.
-    static func isVideoProcessorInstalled(inLibraryFolder folder: URL) -> Bool {
+    static func isInstalled(_ interposer: GPTKInterposer, inLibraryFolder folder: URL) -> Bool {
         let peDir = folder.appending(path: "Wine").appending(path: "lib")
             .appending(path: "wine").appending(path: "x86_64-windows")
         return FileManager.default.contentsEqual(
-            atPath: peDir.appending(path: videoProcessorSlotName).path(percentEncoded: false),
-            andPath: videoProcessorShim(inLibraryFolder: folder).path(percentEncoded: false)
+            atPath: peDir.appending(path: interposer.slotName).path(percentEncoded: false),
+            andPath: shim(for: interposer, inLibraryFolder: folder).path(percentEncoded: false)
         )
+    }
+
+    static func isVideoProcessorInstalled(inLibraryFolder folder: URL) -> Bool {
+        isInstalled(videoProcessorInterposer, inLibraryFolder: folder)
     }
 
     /// Puts the interposer in the `d3d12.dll` slot with Apple's DLL renamed
     /// beside it. Expects `d3d12.dll` to be Apple's, which is what deploy leaves
     /// behind, and does nothing if the runtime ships no interposer or the swap
     /// is already in place.
-    static func installVideoProcessor(intoLibraryFolder folder: URL) throws {
+    static func install(_ interposer: GPTKInterposer, intoLibraryFolder folder: URL) throws {
         let fileManager = FileManager.default
-        let shim = videoProcessorShim(inLibraryFolder: folder)
-        guard hasVideoProcessor(inLibraryFolder: folder) else { return }
-        guard !isVideoProcessorInstalled(inLibraryFolder: folder) else { return }
+        let shim = shim(for: interposer, inLibraryFolder: folder)
+        guard has(interposer, inLibraryFolder: folder) else { return }
+        guard !isInstalled(interposer, inLibraryFolder: folder) else { return }
 
         let wineLib = folder.appending(path: "Wine").appending(path: "lib")
         let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
         let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
-        let slot = peDir.appending(path: videoProcessorSlotName)
-        let renamed = peDir.appending(path: videoDeviceDLLName)
+        let slot = peDir.appending(path: interposer.slotName)
+        let renamed = peDir.appending(path: interposer.renamedName)
 
         guard fileManager.fileExists(atPath: slot.path(percentEncoded: false)) else { return }
 
@@ -88,10 +145,10 @@ extension GPTKImporter {
             try fileManager.removeItem(at: renamed)
         }
         try fileManager.copyItem(at: slot, to: renamed)
-        try rewriteExportName(at: renamed, from: videoProcessorSlotName, to: videoDeviceDLLName)
+        try rewriteExportName(at: renamed, from: interposer.slotName, to: interposer.renamedName)
 
         // The renamed PE needs its own unix half or D3DMetal never binds.
-        let link = unixDir.appending(path: videoDeviceUnixName)
+        let link = unixDir.appending(path: interposer.renamedUnixName)
         try? fileManager.removeItem(at: link)
         try fileManager.createSymbolicLink(
             atPath: link.path(percentEncoded: false),
@@ -101,11 +158,16 @@ extension GPTKImporter {
         // Stage the shim beside the slot and swap by rename. Removing the slot
         // before copying left a window where a crash strands the tree with no
         // d3d12.dll at all, a state the guard above then refuses to repair.
-        let staged = peDir.appending(path: videoProcessorSlotName + ".staging")
+        let staged = peDir.appending(path: interposer.slotName + ".staging")
         try? fileManager.removeItem(at: staged)
         try fileManager.copyItem(at: shim, to: staged)
         _ = try fileManager.replaceItemAt(slot, withItemAt: staged)
-        logger.info("Installed the D3D12 video processor, Apple's D3D12 is now \(videoDeviceDLLName)")
+        let moved = "\(interposer.label): Apple's \(interposer.slotName) is now \(interposer.renamedName)"
+        logger.info("Installed \(moved, privacy: .public)")
+    }
+
+    static func installVideoProcessor(intoLibraryFolder folder: URL) throws {
+        try install(videoProcessorInterposer, intoLibraryFolder: folder)
     }
 
     /// Takes the interposer back out and restores Apple's DLL into the slot from
@@ -115,23 +177,31 @@ extension GPTKImporter {
     /// Removal has to happen before the payload itself is removed, or the slot
     /// still holds the interposer, does not byte-match the store, and the
     /// restore loop skips it and leaves the tree with no working D3D12 at all.
-    static func removeVideoProcessor(fromLibraryFolder folder: URL, usingStore store: URL) {
+    static func remove(
+        _ interposer: GPTKInterposer, fromLibraryFolder folder: URL, usingStore store: URL
+    ) {
         let fileManager = FileManager.default
         let wineLib = folder.appending(path: "Wine").appending(path: "lib")
         let peDir = wineLib.appending(path: "wine").appending(path: "x86_64-windows")
         let unixDir = wineLib.appending(path: "wine").appending(path: "x86_64-unix")
-        let slot = peDir.appending(path: videoProcessorSlotName)
+        let slot = peDir.appending(path: interposer.slotName)
 
-        if isVideoProcessorInstalled(inLibraryFolder: folder) {
+        if isInstalled(interposer, inLibraryFolder: folder) {
             let pristine = store.appending(path: "lib").appending(path: "wine")
-                .appending(path: "x86_64-windows").appending(path: videoProcessorSlotName)
+                .appending(path: "x86_64-windows").appending(path: interposer.slotName)
             if fileManager.fileExists(atPath: pristine.path(percentEncoded: false)) {
                 try? fileManager.removeItem(at: slot)
                 try? fileManager.copyItem(at: pristine, to: slot)
             }
         }
-        try? fileManager.removeItem(at: peDir.appending(path: videoDeviceDLLName))
-        try? fileManager.removeItem(at: unixDir.appending(path: videoDeviceUnixName))
+        try? fileManager.removeItem(at: peDir.appending(path: interposer.renamedName))
+        try? fileManager.removeItem(at: unixDir.appending(path: interposer.renamedUnixName))
+    }
+
+    static func removeVideoProcessor(fromLibraryFolder folder: URL, usingStore store: URL) {
+        for interposer in interposers {
+            remove(interposer, fromLibraryFolder: folder, usingStore: store)
+        }
     }
 
     // MARK: - Prefixes
@@ -143,19 +213,25 @@ extension GPTKImporter {
     /// with it. `wineboot` writes these when a prefix is made or updated, so new
     /// bottles get it for free; bottles that already exist predate the name and
     /// would otherwise need a prefix update before they could run anything.
-    static func seedVideoDevicePlaceholder(inBottle bottle: URL, fromLibraryFolder folder: URL) {
+    static func seedPlaceholder(
+        for interposer: GPTKInterposer, inBottle bottle: URL, fromLibraryFolder folder: URL
+    ) {
         let fileManager = FileManager.default
         let source = folder.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
-            .appending(path: "x86_64-windows").appending(path: videoDeviceDLLName)
+            .appending(path: "x86_64-windows").appending(path: interposer.renamedName)
         guard fileManager.fileExists(atPath: source.path(percentEncoded: false)) else { return }
 
         let system32 = bottle.appending(path: "drive_c").appending(path: "windows")
             .appending(path: "system32")
         guard fileManager.fileExists(atPath: system32.path(percentEncoded: false)) else { return }
 
-        let placeholder = system32.appending(path: videoDeviceDLLName)
+        let placeholder = system32.appending(path: interposer.renamedName)
         guard !fileManager.fileExists(atPath: placeholder.path(percentEncoded: false)) else { return }
         try? fileManager.copyItem(at: source, to: placeholder)
+    }
+
+    static func seedVideoDevicePlaceholder(inBottle bottle: URL, fromLibraryFolder folder: URL) {
+        seedPlaceholder(for: videoProcessorInterposer, inBottle: bottle, fromLibraryFolder: folder)
     }
 
     /// Installs the video processor if the payload is already deployed, and

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKFixtures.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKFixtures.swift
@@ -65,14 +65,32 @@ func fakePEWithExportName(_ name: String, builtin: Bool = true) -> Data {
 
 /// Gives a store's `d3d12.dll` a walkable export directory, so the swap under
 /// test has something shaped like Apple's DLL to rename.
-func makeStoreD3D12Renameable(inStore store: URL) throws {
-    try fakePEWithExportName("d3d12.dll").write(
+func makeStoreSlotRenameable(inStore store: URL, slotName: String) throws {
+    try fakePEWithExportName(slotName).write(
         to: store.appending(path: "lib").appending(path: "wine")
-            .appending(path: "x86_64-windows").appending(path: "d3d12.dll")
+            .appending(path: "x86_64-windows").appending(path: slotName)
     )
 }
 
+func makeStoreD3D12Renameable(inStore store: URL) throws {
+    try makeStoreSlotRenameable(inStore: store, slotName: "d3d12.dll")
+}
+
 /// Puts an interposer in the runtime where the build ships one.
+@discardableResult
+func makeInterposerShim(
+    _ interposer: GPTKInterposer, at libraryFolder: URL, marker: String = "interposer"
+) throws -> URL {
+    let shim = GPTKImporter.shim(for: interposer, inLibraryFolder: libraryFolder)
+    try FileManager.default.createDirectory(
+        at: shim.deletingLastPathComponent(), withIntermediateDirectories: true
+    )
+    var data = fakePE(builtin: true)
+    data.append(Data(marker.utf8))
+    try data.write(to: shim)
+    return shim
+}
+
 @discardableResult
 func makeVideoProcessorShim(at libraryFolder: URL, marker: String = "interposer") throws -> URL {
     let shim = GPTKImporter.videoProcessorShim(inLibraryFolder: libraryFolder)

--- a/WhiskyKit/Tests/WhiskyKitTests/GPTKVideoProcessorTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GPTKVideoProcessorTests.swift
@@ -234,4 +234,76 @@ struct GPTKVideoProcessorTests {
         #expect(!FileManager.default.fileExists(atPath: bottle.appending(path: "drive_c")
                 .path(percentEncoded: false)))
     }
+
+    // MARK: - Every interposed slot
+
+    @Test("A renamed DLL never outgrows the slot it came from")
+    func renamedNamesFitInPlace() {
+        // The export name is patched in place, so a longer replacement would
+        // run off the end of the string and corrupt whatever follows it.
+        for interposer in GPTKImporter.interposers {
+            #expect(
+                interposer.renamedName.utf8.count <= interposer.slotName.utf8.count,
+                "\(interposer.renamedName) cannot replace \(interposer.slotName) in place"
+            )
+        }
+    }
+
+    @Test("No two interposers claim the same slot or the same renamed DLL")
+    func interposersDoNotCollide() {
+        let slots = GPTKImporter.interposers.map(\.slotName)
+        let renamed = GPTKImporter.interposers.map(\.renamedName)
+        #expect(Set(slots).count == slots.count)
+        #expect(Set(renamed).count == renamed.count)
+        #expect(Set(slots).isDisjoint(with: renamed))
+    }
+
+    @Test("Deploy installs the DXGI interposer with Apple's DXGI renamed beside it")
+    func deployInstallsDXGIInterposer() throws {
+        let interposer = GPTKImporter.dxgiVersionInterposer
+        let store = try makeImportedStore(in: tempDir)
+        try makeStoreD3D12Renameable(inStore: store)
+        try makeStoreSlotRenameable(inStore: store, slotName: interposer.slotName)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        try makeVideoProcessorShim(at: runtime)
+        try makeInterposerShim(interposer, at: runtime, marker: "dxgi interposer")
+
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        #expect(GPTKImporter.isInstalled(interposer, inLibraryFolder: runtime))
+        // The fixture's name slot is sized for the longest slot name, so a
+        // shorter replacement leaves the old terminator behind it.
+        let renamed = peDir(of: runtime).appending(path: interposer.renamedName)
+        let actual = try exportName(of: renamed).trimmingCharacters(in: ["\0"])
+        #expect(actual == interposer.renamedName, "export name is \(actual)")
+
+        let link = runtime.appending(path: "Wine").appending(path: "lib").appending(path: "wine")
+            .appending(path: "x86_64-unix").appending(path: interposer.renamedUnixName)
+        let destination = try FileManager.default.destinationOfSymbolicLink(
+            atPath: link.path(percentEncoded: false)
+        )
+        #expect(destination == GPTKImporter.unixLinkDestination)
+    }
+
+    @Test("Removing takes every interposer back out, not just the first")
+    func removeClearsEverySlot() throws {
+        let interposer = GPTKImporter.dxgiVersionInterposer
+        let store = try makeImportedStore(in: tempDir)
+        try makeStoreD3D12Renameable(inStore: store)
+        try makeStoreSlotRenameable(inStore: store, slotName: interposer.slotName)
+        let runtime = tempDir.appending(path: "Libraries")
+        try makeRuntime(at: runtime)
+        try makeVideoProcessorShim(at: runtime)
+        try makeInterposerShim(interposer, at: runtime, marker: "dxgi interposer")
+        try GPTKImporter.deploy(fromStore: store, intoLibraryFolder: runtime)
+
+        GPTKImporter.removeVideoProcessor(fromLibraryFolder: runtime, usingStore: store)
+
+        for each in GPTKImporter.interposers {
+            #expect(!GPTKImporter.isInstalled(each, inLibraryFolder: runtime))
+            let renamed = peDir(of: runtime).appending(path: each.renamedName)
+            #expect(!FileManager.default.fileExists(atPath: renamed.path(percentEncoded: false)))
+        }
+    }
 }


### PR DESCRIPTION
D3DMetal answers `IDXGIAdapter::CheckInterfaceSupport` with `S_OK` and writes `-1` into the version out-param. Engines format that `LARGE_INTEGER` as four words, read `65535.65535.65535.65535`, and refuse to run. Helldivers 2 puts a modal "GPU drivers are out of date" box in front of the game for it.

Measured with a probe that asks both APIs a game could plausibly be using:

```
== DXGI ==
  adapter 0  vendor=0x1002 device=0x66af  AMD Compatibility Mode
    CheckInterfaceSupport(IDXGIDevice) 0x00000000
  -> raw 0xffffffffffffffff          before
  -> raw 0x00230000000f17ce          after, 35.0.15.6094

== SetupAPI, display class ==
  device 0  desc=Apple M5
    DriverVersion = 35.0.15.6094     always correct, and not what the game reads
```

The version reported is the one Wine already publishes for the adapter in its class key, so the two agree rather than being separately invented.

## why it is its own module

It cannot be a few lines in the D3D12 interposer. Measured on Helldivers 2:

```
helldivers2.exe   28 imports, graphics: NONE (dynamic)
game.dll           3 imports, graphics: NONE (dynamic)
```

Both load D3D12 and DXGI through `LoadLibrary`, and the driver check runs before D3D12 is touched at all. Confirmed on a live run: the modal box was on screen while the D3D12 interposer had still not written a single line to its log, so it was not yet in the process and there was no import entry to patch either.

## why the refactor rather than a second file

Installing it is the same operation as the video processor: rename Apple's DLL aside with its PE export name rewritten in place, drop ours in the slot, symlink the unix half, seed a `system32` placeholder. Rather than a second near-copy of that file, the swap is now described by a `GPTKInterposer` value and done once. Your staged rename is kept as the swap step. The existing `videoProcessor` entry points stay as thin wrappers, so the tests that covered them still do.

## tests

New coverage for the DXGI slot end to end, for removal clearing every slot rather than only the first, and for two invariants that would silently break the in-place export rename: a renamed DLL can never be longer than the slot it came from, and no two interposers may claim the same name.

1282 tests pass, swiftformat and swiftlint --strict both clean.

## what it needs at runtime

A runtime carrying `lib/gptk-video/dxgishim.dll`. `dappermint/winecx-gptk` 4.5.121 is the first that does. A runtime without it is skipped exactly as one without the D3D12 interposer is, so this is inert until such a runtime is installed. Runtime side reported on #163.