### PR TITLE
feat(graphics): turn metal 4 off for a single program

### DIFF
--- a/Whisky/Views/Programs/ProgramOverrideSettingsView.swift
+++ b/Whisky/Views/Programs/ProgramOverrideSettingsView.swift
@@ -283,6 +283,13 @@ struct ProgramOverrideSettingsView: View {
                     graphicsControls
                 }
 
+                // D3DMetal only takes the Metal 4 path for D3D12 devices, so
+                // this is the one graphics setting a single title needs to be
+                // able to turn off while the bottle keeps it.
+                if resolvedOverriddenBackend == .d3dMetal {
+                    Toggle("config.metal4", isOn: metal4Binding)
+                }
+
                 // "Takes effect next launch" note
                 Text("config.graphics.nextLaunch")
                     .font(.caption)
@@ -629,11 +636,13 @@ struct ProgramOverrideSettingsView: View {
                     // a backend override is set, and one is set right here.
                     program.settings.overrides?.dxvkAsync = bottle.settings.dxvkAsync
                     program.settings.overrides?.dxvkHud = bottle.settings.dxvkHud
+                    program.settings.overrides?.metal4Enabled = bottle.settings.metal4Enabled
                 } else {
                     program.settings.overrides?.graphicsBackend = nil
                     program.settings.overrides?.dxvk = nil
                     program.settings.overrides?.dxvkAsync = nil
                     program.settings.overrides?.dxvkHud = nil
+                    program.settings.overrides?.metal4Enabled = nil
                 }
             }
         )
@@ -741,6 +750,13 @@ struct ProgramOverrideSettingsView: View {
         Binding(
             get: { program.settings.overrides?.dxvkAsync ?? bottle.settings.dxvkAsync },
             set: { program.settings.overrides?.dxvkAsync = $0 }
+        )
+    }
+
+    private var metal4Binding: Binding<Bool> {
+        Binding(
+            get: { program.settings.overrides?.metal4Enabled ?? bottle.settings.metal4Enabled },
+            set: { program.settings.overrides?.metal4Enabled = $0 }
         )
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramOverrides.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/ProgramOverrides.swift
@@ -53,6 +53,12 @@ public struct ProgramOverrides: Codable, Equatable, Sendable {
 
     /// Whether to force DirectX 11 mode. `nil` inherits from bottle.
     public var forceD3D11: Bool?
+    /// Whether D3DMetal uses the Metal 4 command encoding backend. `nil` inherits from bottle.
+    ///
+    /// D3DMetal only takes that path for D3D12 devices, so this is the one
+    /// graphics setting a single D3D12 title needs to turn off on its own while
+    /// the rest of the bottle keeps it.
+    public var metal4Enabled: Bool?
 
     // MARK: - Performance
 
@@ -110,6 +116,7 @@ public struct ProgramOverrides: Codable, Equatable, Sendable {
             && dxvkHud == nil
             && enhancedSync == nil
             && forceD3D11 == nil
+            && metal4Enabled == nil
             && performancePreset == nil
             && shaderCacheEnabled == nil
             && controllerCompatibilityMode == nil
@@ -135,6 +142,7 @@ public struct ProgramOverrides: Codable, Equatable, Sendable {
         self.dxvkHud = try container.decodeIfPresent(DXVKHUD.self, forKey: .dxvkHud)
         self.enhancedSync = try container.decodeIfPresent(EnhancedSync.self, forKey: .enhancedSync)
         self.forceD3D11 = try container.decodeIfPresent(Bool.self, forKey: .forceD3D11)
+        self.metal4Enabled = try container.decodeIfPresent(Bool.self, forKey: .metal4Enabled)
         self.performancePreset = container.decodeLenientIfPresent(PerformancePreset.self, forKey: .performancePreset)
         self.shaderCacheEnabled = try container.decodeIfPresent(Bool.self, forKey: .shaderCacheEnabled)
         self.controllerCompatibilityMode = try container.decodeIfPresent(

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
@@ -295,6 +295,18 @@ extension Wine {
             }
         }
 
+        // Metal 4 override. `D3DMDevice::MTL4OptionEnabled` only takes that path
+        // for D3D12 devices, so a D3D12 title whose renderer wedges on a fence
+        // the Metal 4 submission path never signals has to be able to drop back
+        // without the rest of the bottle losing it.
+        if let metal4Enabled = overrides.metal4Enabled {
+            if metal4Enabled {
+                builder.set("D3DM_MTL4", "1", layer: .programUser)
+            } else {
+                builder.remove("D3DM_MTL4", layer: .programUser)
+            }
+        }
+
         // Shader cache override, on the variable DXVK actually reads.
         if let shaderCache = overrides.shaderCacheEnabled {
             if !shaderCache {
@@ -361,7 +373,7 @@ extension Wine {
         // Non-sensitive keys allowed in the launch summary
         let allowedKeys = [
             "DXVK_ASYNC", "DXVK_HUD", "WINEESYNC", "WINEMSYNC",
-            "D3DM_FORCE_D3D11", "MTL_HUD_ENABLED", "WINED3DMETAL"
+            "D3DM_FORCE_D3D11", "D3DM_MTL4", "MTL_HUD_ENABLED", "WINED3DMETAL"
         ]
         let safeEntries = allowedKeys.compactMap { key -> String? in
             guard let value = environment[key] else { return nil }

--- a/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
@@ -573,4 +573,55 @@ final class EnvironmentVariablesTests: XCTestCase {
         settings.environmentVariables(wineEnv: &env)
         XCTAssertNil(env["CX_ACTIVE_GRAPHICS_BACKEND"])
     }
+
+    // MARK: - Metal 4 is per program, because D3DMetal only takes that path for D3D12
+
+    /// Resolves the environment a program gets from a D3DMetal bottle, which is
+    /// where `D3DM_MTL4` is set, with its own overrides layered on top.
+    private func resolvedEnvironment(_ overrides: ProgramOverrides) -> [String: String] {
+        var settings = BottleSettings()
+        settings.graphicsBackend = .d3dMetal
+        var builder = EnvironmentBuilder()
+        var dllResolver = DLLOverrideResolver(managed: [], bottleCustom: [], programCustom: [])
+
+        _ = settings.populateBottleManagedLayer(builder: &builder)
+        Wine.applyProgramOverrides(overrides, builder: &builder, dllResolver: &dllResolver)
+
+        return builder.resolve().environment
+    }
+
+    func testD3DMetalBottleEnablesMetal4() {
+        XCTAssertEqual(resolvedEnvironment(ProgramOverrides())["D3DM_MTL4"], "1")
+    }
+
+    func testProgramCanDisableMetal4WithoutTheBottleLosingIt() {
+        // A D3D12 title whose renderer wedges on a fence the Metal 4 submission
+        // path never signals has to be able to drop back on its own.
+        var overrides = ProgramOverrides()
+        overrides.metal4Enabled = false
+
+        XCTAssertNil(resolvedEnvironment(overrides)["D3DM_MTL4"])
+    }
+
+    func testProgramCanKeepMetal4Explicitly() {
+        var overrides = ProgramOverrides()
+        overrides.metal4Enabled = true
+
+        XCTAssertEqual(resolvedEnvironment(overrides)["D3DM_MTL4"], "1")
+    }
+
+    func testMetal4OverrideUnsetInheritsTheBottle() {
+        XCTAssertNil(ProgramOverrides().metal4Enabled)
+        XCTAssertTrue(ProgramOverrides().isEmpty)
+    }
+
+    func testMetal4OverrideSurvivesASettingsRoundTrip() throws {
+        var overrides = ProgramOverrides()
+        overrides.metal4Enabled = false
+
+        let data = try PropertyListEncoder().encode(overrides)
+        let decoded = try PropertyListDecoder().decode(ProgramOverrides.self, from: data)
+
+        XCTAssertEqual(decoded.metal4Enabled, false)
+    }
 }


### PR DESCRIPTION
closes the code half of #229. the reasoning and the fence trace are there, this is just the change.

`D3DMDevice::MTL4OptionEnabled` takes the metal 4 path for d3d12 devices only, and two queues that each signal a fence the other waits on inside one frame can deadlock there: one queue stops retiring work, every fence it signals freezes at the same value, and the title's wait never returns. `metal4Enabled` defaults true and `BottleSettings.swift:852` sets `D3DM_MTL4=1` for every d3dmetal bottle, so today a user with one bad d3d12 title has to give up metal 4 for the whole prefix.

## what this does

- `metal4Enabled: Bool?` on `ProgramOverrides`, same shape as `forceD3D11`
- `applyProgramOverrides` sets or removes `D3DM_MTL4` at the `programUser` layer, so one program drops back and the bottle keeps it
- a toggle in the graphics group, shown when the resolved backend is d3dmetal. reuses the existing `config.metal4` string, no new keys
- `D3DM_MTL4` added to the launch summary's allowed keys, since it now varies per program

five tests on the resolved environment: the bottle enables it, a program can turn it off, a program can keep it, unset inherits, and the setting survives a settings file round trip.

1287 xctest plus 187 swift-testing green, swiftformat and swiftlint clean, app target builds.

## what i deliberately left out

**no gamedb entry.** the title i found this on is helldivers 2, and it only reaches the metal 4 path when something launches it directly rather than through the windows steam client in the bottle. launchers resolve to dxvk, that branch never sets `D3DM_MTL4`, and steam's children inherit steam's environment, so on the normal path here nobody is exposed. an entry claiming otherwise would be wrong for your users. happy to add one if you would rather have it as documentation.

**no default change.** turning metal 4 off for everyone is your call, not mine, and it costs whatever it wins on titles that do not hit this. this only adds the escape hatch.

## the ordering question from #229

the escape hatch matters the moment the served runtime carries gptk 4.0's d3dmetal. if the feed is still on 3.1.1 then this is not urgent and can sit until you want it.
