### PR TITLE
put dlss frame generation behind its own setting

### DIFF
--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -36522,6 +36522,38 @@
         }
       }
     },
+    "config.frameGeneration" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DLSS Frame Generation"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DLSS Frame Generation"
+          }
+        }
+      }
+    },
+    "config.frameGeneration.info" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Off by default. Frame generation reaches MetalFX frame interpolation, which on current macOS can leave the GPU driver unresponsive and end the login session. DLSS upscaling above is unaffected. Some NVIDIA Streamline titles will not start with it off, Deep Rock Galactic among them."
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Off by default. Frame generation reaches MetalFX frame interpolation, which on current macOS can leave the GPU driver unresponsive and end the login session. DLSS upscaling above is unaffected. Some NVIDIA Streamline titles will not start with it off, Deep Rock Galactic among them."
+          }
+        }
+      }
+    },
     "config.inspect" : {
       "localizations" : {
         "ar" : {

--- a/Whisky/Views/Bottle/GraphicsConfigSection.swift
+++ b/Whisky/Views/Bottle/GraphicsConfigSection.swift
@@ -83,6 +83,17 @@ struct GraphicsConfigSection: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+                // Frame generation reaches MetalFX through the same DLSS bridge
+                // as upscaling, so it has nothing to switch on without it.
+                Toggle(isOn: $bottle.settings.frameGeneration) {
+                    VStack(alignment: .leading) {
+                        Text("config.frameGeneration")
+                        Text("config.frameGeneration.info")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .disabled(!bottle.settings.metalFX)
             }
 
             // Force DX11 toggle -- always visible (Simple + Advanced)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleGraphicsConfig.swift
@@ -161,6 +161,23 @@ public struct BottleGraphicsConfig: Codable, Equatable {
     /// `DXGIAdapter::nvngxDLLLocation` to find, the variable is inert.
     var metalFX: Bool = true
 
+    /// Whether games in this bottle may turn on DLSS frame generation.
+    ///
+    /// Off, and it should stay off until a title is known to survive it. The
+    /// only thing this controls is `CX_ACTIVE_GRAPHICS_BACKEND`, which makes
+    /// win32u answer `KMTQAITYPE_WDDM_2_7_CAPS`, and NVIDIA Streamline refuses
+    /// to enter its DLSS-G path without that answer. So leaving it unset is
+    /// what keeps frame generation off, and it costs nothing else: DLSS
+    /// upscaling reaches MetalFX through ``metalFX`` and does not read this.
+    ///
+    /// Measured on Ready or Not, macOS 27.0 on an M5, D3DMetal 4.0b2: with
+    /// frame generation on, every command buffer carrying MetalFX work fails
+    /// (542 in one 8 minute session against 8 with it off), and the session
+    /// ends when WindowServer blocks in `IOGPUFamily` and its watchdog kills
+    /// it. Two unrelated processes were parked in the same driver at the same
+    /// instant, so this is not something a bottle can be trusted to contain.
+    var frameGeneration: Bool = false
+
     /// Creates a new graphics config with the default `.recommended` backend.
     public init() {}
 
@@ -170,5 +187,8 @@ public struct BottleGraphicsConfig: Codable, Equatable {
         // Matches the property default, so a bottle written before this key
         // existed adopts the new default instead of decoding as off.
         self.metalFX = (try? container.decodeIfPresent(Bool.self, forKey: .metalFX)) ?? true
+        // Off for a bottle written before the key existed, which is the same
+        // answer the property default gives a new one.
+        self.frameGeneration = (try? container.decodeIfPresent(Bool.self, forKey: .frameGeneration)) ?? false
     }
 }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleSettings.swift
@@ -389,6 +389,17 @@ public struct BottleSettings: Codable, Equatable {
         set { discordConfig.bridge = newValue }
     }
 
+    /// Whether games in this bottle may turn on DLSS frame generation.
+    ///
+    /// Separate from ``metalFX`` because the two features fail differently.
+    /// Upscaling is measured good; frame generation took the whole login
+    /// session down on the machine it was tested on. See
+    /// ``BottleGraphicsConfig/frameGeneration``.
+    public var frameGeneration: Bool {
+        get { graphicsConfig.frameGeneration }
+        set { graphicsConfig.frameGeneration = newValue }
+    }
+
     /// Whether DXVK is the active graphics backend.
     ///
     /// This property now derives from ``graphicsBackend``. Setting it to `true`
@@ -861,11 +872,14 @@ public struct BottleSettings: Codable, Equatable {
         case .d3dMetal, .recommended:
             // Wine answers KMTQAITYPE_WDDM_2_7_CAPS, the query behind "hardware
             // accelerated GPU scheduling", only when this says d3dmetal, and
-            // returns STATUS_NOT_IMPLEMENTED otherwise. Nothing set it, so a
-            // game asking whether scheduling is available was told it is not.
-            // The only other reader wants the value "wined3d" alongside
-            // CX_LIBVULKAN, so this is inert for it.
-            builder.set("CX_ACTIVE_GRAPHICS_BACKEND", "d3dmetal", layer: .bottleManaged)
+            // returns STATUS_NOT_IMPLEMENTED otherwise. NVIDIA Streamline
+            // refuses DLSS frame generation on that answer, so this variable is
+            // the whole frame generation switch. The only other reader wants
+            // the value "wined3d" alongside CX_LIBVULKAN, so this is inert for
+            // it.
+            if frameGeneration {
+                builder.set("CX_ACTIVE_GRAPHICS_BACKEND", "d3dmetal", layer: .bottleManaged)
+            }
             // The DLL placement that actually gates the DLSS-to-MetalFX path
             // happens in `Wine.applyMetalFX` at launch; this is the opt-in.
             if metalFX {

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineEnvironment.swift
@@ -131,7 +131,12 @@ extension Wine {
 
         // Apply per-program overrides to the programUser layer
         if let overrides = programOverrides {
-            applyProgramOverrides(overrides, builder: &builder, dllResolver: &dllResolver)
+            applyProgramOverrides(
+                overrides,
+                frameGeneration: bottle.settings.frameGeneration,
+                builder: &builder,
+                dllResolver: &dllResolver
+            )
         }
 
         // Layer 8: featureRuntime -- diagnostic WINEDEBUG preset override
@@ -178,6 +183,7 @@ extension Wine {
     /// bottleManaged and launcherManaged layers.
     static func applyProgramOverrides(
         _ overrides: ProgramOverrides,
+        frameGeneration: Bool = false,
         builder: inout EnvironmentBuilder,
         dllResolver: inout DLLOverrideResolver
     ) {
@@ -197,8 +203,12 @@ extension Wine {
                 builder.remove("DXVK_ASYNC", layer: .programUser)
                 builder.remove("WINED3DMETAL", layer: .programUser)
                 // One program on D3DMetal inside a bottle running something else
-                // still has to be told scheduling exists; see the bottle layer.
-                builder.set("CX_ACTIVE_GRAPHICS_BACKEND", "d3dmetal", layer: .programUser)
+                // still has to claim scheduling itself; see the bottle layer.
+                // Gated on the same setting, or turning frame generation off
+                // would leave this one route still open.
+                if frameGeneration {
+                    builder.set("CX_ACTIVE_GRAPHICS_BACKEND", "d3dmetal", layer: .programUser)
+                }
 
             case .dxvk:
                 // Enable DXVK DLLs at program level

--- a/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/EnvironmentVariablesTests.swift
@@ -555,15 +555,40 @@ final class EnvironmentVariablesTests: XCTestCase {
 
     // MARK: - hardware scheduling is claimed only where it applies
 
-    func testD3DMetalBottleClaimsHardwareScheduling() {
+    func testD3DMetalBottleClaimsHardwareSchedulingForFrameGeneration() {
         // Wine answers the WDDM 2.7 caps query only for a caller that says it is
-        // on D3DMetal; without it, a game asking about GPU scheduling is told
-        // the feature is not implemented.
+        // on D3DMetal, and NVIDIA Streamline refuses DLSS frame generation
+        // without that answer.
         var settings = BottleSettings()
         settings.graphicsBackend = .d3dMetal
+        settings.frameGeneration = true
         var env: [String: String] = [:]
         settings.environmentVariables(wineEnv: &env)
         XCTAssertEqual(env["CX_ACTIVE_GRAPHICS_BACKEND"], "d3dmetal")
+    }
+
+    /// Frame generation took a whole login session down: MetalFX interpolation
+    /// left the GPU driver unresponsive and WindowServer's watchdog killed it.
+    /// A bottle has to ask for that, and asking is what this variable is.
+    func testD3DMetalBottleWithholdsTheClaimByDefault() {
+        var settings = BottleSettings()
+        settings.graphicsBackend = .d3dMetal
+        XCTAssertFalse(settings.frameGeneration)
+        var env: [String: String] = [:]
+        settings.environmentVariables(wineEnv: &env)
+        XCTAssertNil(env["CX_ACTIVE_GRAPHICS_BACKEND"])
+    }
+
+    /// Upscaling and frame generation are separate features that fail
+    /// differently, so the upscaling switch must not drag the other one on.
+    func testMetalFXDoesNotImplyFrameGeneration() {
+        var settings = BottleSettings()
+        settings.graphicsBackend = .d3dMetal
+        settings.metalFX = true
+        var env: [String: String] = [:]
+        settings.environmentVariables(wineEnv: &env)
+        XCTAssertEqual(env["D3DM_ENABLE_METALFX"], "1")
+        XCTAssertNil(env["CX_ACTIVE_GRAPHICS_BACKEND"])
     }
 
     func testDXVKBottleDoesNotClaimHardwareScheduling() {
@@ -650,6 +675,7 @@ final class EnvironmentVariablesTests: XCTestCase {
         // turn on DLSS frame generation even though it ran on D3DMetal.
         var settings = BottleSettings()
         settings.graphicsBackend = .d3dMetal
+        settings.frameGeneration = true
 
         var overrides = ProgramOverrides()
         overrides.graphicsBackend = .dxvk
@@ -662,6 +688,7 @@ final class EnvironmentVariablesTests: XCTestCase {
         // DXMT translates d3d11 only, so d3d12 is still D3DMetal underneath.
         var settings = BottleSettings()
         settings.graphicsBackend = .d3dMetal
+        settings.frameGeneration = true
 
         var overrides = ProgramOverrides()
         overrides.graphicsBackend = .dxmt
@@ -675,11 +702,55 @@ final class EnvironmentVariablesTests: XCTestCase {
         // there is nothing behind the claim.
         var settings = BottleSettings()
         settings.graphicsBackend = .d3dMetal
+        settings.frameGeneration = true
 
         var overrides = ProgramOverrides()
         overrides.graphicsBackend = .wined3d
 
         let env = resolvedEnvironment(bottleSettings: settings, programOverrides: overrides)
         XCTAssertNil(env["CX_ACTIVE_GRAPHICS_BACKEND"])
+    }
+
+    /// The .d3dMetal program branch claims scheduling itself, because a bottle
+    /// on another backend never does. Ungated, that was a second way in.
+    func testD3DMetalProgramOverrideRespectsFrameGenerationOff() {
+        var settings = BottleSettings()
+        settings.graphicsBackend = .dxvk
+        var builder = EnvironmentBuilder()
+        var dllResolver = DLLOverrideResolver(managed: [], bottleCustom: [], programCustom: [])
+        dllResolver.managed.append(contentsOf: settings.populateBottleManagedLayer(builder: &builder))
+
+        var overrides = ProgramOverrides()
+        overrides.graphicsBackend = .d3dMetal
+        Wine.applyProgramOverrides(
+            overrides,
+            frameGeneration: settings.frameGeneration,
+            builder: &builder,
+            dllResolver: &dllResolver
+        )
+
+        let (resolved, _) = builder.resolve()
+        XCTAssertNil(resolved["CX_ACTIVE_GRAPHICS_BACKEND"])
+    }
+
+    func testD3DMetalProgramOverrideClaimsWhenFrameGenerationIsOn() {
+        var settings = BottleSettings()
+        settings.graphicsBackend = .dxvk
+        settings.frameGeneration = true
+        var builder = EnvironmentBuilder()
+        var dllResolver = DLLOverrideResolver(managed: [], bottleCustom: [], programCustom: [])
+        dllResolver.managed.append(contentsOf: settings.populateBottleManagedLayer(builder: &builder))
+
+        var overrides = ProgramOverrides()
+        overrides.graphicsBackend = .d3dMetal
+        Wine.applyProgramOverrides(
+            overrides,
+            frameGeneration: settings.frameGeneration,
+            builder: &builder,
+            dllResolver: &dllResolver
+        )
+
+        let (resolved, _) = builder.resolve()
+        XCTAssertEqual(resolved["CX_ACTIVE_GRAPHICS_BACKEND"], "d3dmetal")
     }
 }


### PR DESCRIPTION
DLSS frame generation is now its own bottle setting, off by default, instead of
riding on the MetalFX toggle.

Both features reach MetalFX through the same nvngx bridge, but they fail
differently. Upscaling is measured good and is unchanged here. Frame generation
ended the login session on the machine I tested it on.

## what happens with it on

Ready or Not, macOS 27.0 on an M5, D3DMetal 4.0b2. Every command buffer carrying
MetalFX work fails:

```
Error: command buffer exited with error status.
	The Metal Performance Shaders operations encoded on it may not have completed.
	The operation couldn't be completed. (MTL4CommandQueueErrorDomain error 1.)
	<MTL3On4CommandBuffer: 0x7fbbcc04db30>
```

Eight minutes later WindowServer's main thread blocks in the GPU driver and does
not come back:

```
Thread "ws_main_thread"   12 samples   last ran 28.906s ago
    IOKit + 125868
  * IOGPUFamily + 42324 / 243144 / 243864 / 255596 / 247152 / 245376
  * AGXG17G + 223712 / 227696
  * IOGPUFamily + 151308
```

Its watchdog kills it 40 seconds later, which ends the session. NotificationCenter
and WarpPreview were parked at the same offsets in the same driver at the same
instant, neither of them aware the game existed, so this is not something a
bottle can be trusted to contain.

Same machine, same build, only the setting different:

| | frame gen off | frame gen on |
| --- | --- | --- |
| session length | 9m 09s, ended by quitting | 7m 59s, ended by the watchdog |
| command buffer failures | 8 | 542 |
| WindowServer wedge | no | yes |

Filed with Apple separately, with the spin report attached.

## what the change is

`CX_ACTIVE_GRAPHICS_BACKEND` is the whole gate. It makes win32u answer
`KMTQAITYPE_WDDM_2_7_CAPS`, and NVIDIA Streamline refuses to enter its DLSS-G
path without that answer. Not setting it costs nothing else: upscaling reaches
MetalFX through the nvngx bridge and never reads it, and the only other reader
in the runtime wants the value `wined3d` alongside `CX_LIBVULKAN`.

There were two ways in. The `.d3dMetal` program override sets the same variable
itself, because a bottle on another backend never does, so a program steered
onto D3DMetal would have kept frame generation after the bottle switch was
turned off. Both routes read the setting now, and there is a test for each.

A bottle written before the key existed decodes to off, same as a new one.

## checks

- WhiskyKit: 1286 XCTest + 187 swift-testing, no failures
- Whisky app builds
- `config.frameGeneration` and `.info` added for `en` and `en-GB`

SwiftLint did not run locally, it will not load `sourcekitdInProc` on this
machine. Line lengths checked by hand and the additions are small.
