### PR TITLE
Pass --force to winetricks for the vcrun verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either position (#216).
 
 ### Fixed
+- Installing the Visual C++ Runtime from the Dependencies panel no longer
+  fails silently on a stale checksum. Microsoft rotates the vc_redist
+  binaries in place, so the SHA256 sums pinned in the bundled winetricks go
+  stale between releases and the unattended install aborted with exit 1,
+  leaving the panel on "Not Installed" with no hint why. The vcrun verbs now
+  run with --force; every other verb keeps checksum enforcement (#233).
 - A bottle opened on a runtime from the other Wine lineage no longer starts
   with an empty profile. Every Wine build names the profile after your Unix
   user, but CrossOver-lineage builds (the GPTK-capable v4 engines) hardcode

--- a/Whisky/Utils/Winetricks+Install.swift
+++ b/Whisky/Utils/Winetricks+Install.swift
@@ -93,6 +93,11 @@ extension Winetricks {
     // MARK: - Private Helpers
 
     /// Configures and returns a Process for running a winetricks verb.
+    ///
+    /// The vcrun verbs are passed `--force`: Microsoft rotates the vc_redist
+    /// binaries in place, so the checksums pinned in the bundled winetricks go
+    /// stale between releases and the unattended install aborts with exit 1 on
+    /// the SHA256 mismatch (winetricks#2195).
     private static func configureInstallProcess(
         verb: String,
         bottleURL: URL,
@@ -101,7 +106,12 @@ extension Winetricks {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         let winetricksPath = resourcesURL.appending(path: "winetricks").path(percentEncoded: false)
-        process.arguments = ["bash", winetricksPath, verb]
+        var arguments = ["bash", winetricksPath]
+        if verb.hasPrefix("vcrun") {
+            arguments.append("--force")
+        }
+        arguments.append(verb)
+        process.arguments = arguments
         process.environment = [
             "WINEPREFIX": bottleURL.path(percentEncoded: false),
             "WINE": "wine64",


### PR DESCRIPTION
First of the three changes agreed in #233.

Microsoft rotates the vc_redist binaries in place, so the SHA256 sums pinned in the bundled winetricks go stale between releases (upstream: Winetricks/winetricks#2195). In unattended mode winetricks aborts with exit 1 on the mismatch, and the Dependencies panel just flips back to "Not Installed".

This passes `--force` to winetricks for verbs with the `vcrun` prefix only — everything else keeps checksum enforcement. Verified the argument order against the bundled winetricks: options must precede the verb.

Includes a CHANGELOG entry.
