### PR TITLE
Record a tail of winetricks output in the dependency install history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Failed dependency installs now record the last few KB of winetricks output
   in dependency-history.plist alongside the exit code, so the reason for a
-  failure (such as a vc_redist checksum mismatch) is visible in diagnostics
-  without re-running winetricks by hand (#233).
+  failure (such as a vc_redist checksum mismatch) is on disk next to the
+  attempt instead of lost with the process (#233).
 - Ways into a game from outside the window. A whisky:// URL scheme launches a
   Steam game (whisky://launch?steam=<appid>) or a pinned program
   (whisky://launch?pin=<name>), optionally scoped to a bottle. Only games

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Failed dependency installs now record the last few KB of winetricks output
+  in dependency-history.plist alongside the exit code, so the reason for a
+  failure (such as a vc_redist checksum mismatch) is visible in diagnostics
+  without re-running winetricks by hand (#233).
 - Ways into a game from outside the window. A whisky:// URL scheme launches a
   Steam game (whisky://launch?steam=<appid>) or a pinned program
   (whisky://launch?pin=<name>), optionally scoped to a bottle. Only games

--- a/Whisky/Views/Install/DependencyInstallSheet.swift
+++ b/Whisky/Views/Install/DependencyInstallSheet.swift
@@ -464,12 +464,21 @@ extension DependencyInstallSheet {
             exitCode = nil
         }
 
+        // Keep a bounded tail of the winetricks output for failed attempts so
+        // the recorded exit code comes with the error text that explains it.
+        let outputTail: String? = if success {
+            nil
+        } else {
+            await MainActor.run { DependencyInstallAttempt.boundedTail(of: logLines) }
+        }
+
         let attempt = DependencyInstallAttempt(
             definitionId: definition.id,
             verbsAttempted: definition.winetricksVerbs,
             timestamp: Date(),
             success: success,
-            exitCode: exitCode
+            exitCode: exitCode,
+            outputTail: outputTail
         )
         history.append(attempt)
         try? history.save(to: bottleURL)

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/BottleDependencyConfig.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/BottleDependencyConfig.swift
@@ -206,19 +206,62 @@ public struct DependencyInstallAttempt: Codable, Sendable {
     public let success: Bool
     /// The process exit code, if available.
     public let exitCode: Int32?
+    /// The last few KB of winetricks output, recorded for failed attempts.
+    ///
+    /// `nil` for successful attempts and for entries written by earlier
+    /// versions that did not capture output.
+    public let outputTail: String?
 
     public init(
         definitionId: String,
         verbsAttempted: [String],
         timestamp: Date,
         success: Bool,
-        exitCode: Int32?
+        exitCode: Int32?,
+        outputTail: String? = nil
     ) {
         self.definitionId = definitionId
         self.verbsAttempted = verbsAttempted
         self.timestamp = timestamp
         self.success = success
         self.exitCode = exitCode
+        self.outputTail = outputTail
+    }
+
+    /// Maximum number of output bytes retained in ``outputTail``.
+    public static let maxOutputTailBytes = 4_096
+
+    /// Joins the newest output lines that fit within ``maxOutputTailBytes``.
+    ///
+    /// Lines are kept whole and in order; when even the newest line alone
+    /// exceeds the budget, its trailing bytes are kept. Returns `nil` for
+    /// empty input so entries without output stay compact.
+    ///
+    /// - Parameter lines: Process output lines, oldest first.
+    /// - Returns: The bounded tail joined with newlines, or `nil`.
+    public static func boundedTail(of lines: [String]) -> String? {
+        guard !lines.isEmpty else { return nil }
+
+        var kept: [String] = []
+        var bytes = 0
+        for line in lines.reversed() {
+            let lineBytes = line.utf8.count + (kept.isEmpty ? 0 : 1)
+            if bytes + lineBytes > maxOutputTailBytes { break }
+            kept.append(line)
+            bytes += lineBytes
+        }
+
+        if kept.isEmpty, let last = lines.last {
+            var data = Data(last.utf8).suffix(maxOutputTailBytes)
+            // The byte cut can land inside a multi-byte character; drop
+            // leading continuation bytes so the suffix decodes cleanly.
+            while let first = data.first, first & 0b1100_0000 == 0b1000_0000 {
+                data = data.dropFirst()
+            }
+            return String(bytes: data, encoding: .utf8)
+        }
+
+        return kept.reversed().joined(separator: "\n")
     }
 }
 

--- a/WhiskyKit/Tests/WhiskyKitTests/DependencyInstallAttemptTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/DependencyInstallAttemptTests.swift
@@ -1,0 +1,118 @@
+//
+//  DependencyInstallAttemptTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+final class DependencyInstallAttemptTests: XCTestCase {
+    // MARK: - Output Tail Round-Trip
+
+    func testOutputTailSurvivesPlistRoundTrip() throws {
+        let attempt = DependencyInstallAttempt(
+            definitionId: "vcruntime",
+            verbsAttempted: ["vcrun2019"],
+            timestamp: Date(),
+            success: false,
+            exitCode: 1,
+            outputTail: "SHA256 mismatch!\nExpected: 49545cb0"
+        )
+
+        let data = try PropertyListEncoder().encode(attempt)
+        let decoded = try PropertyListDecoder().decode(DependencyInstallAttempt.self, from: data)
+
+        XCTAssertEqual(decoded.outputTail, "SHA256 mismatch!\nExpected: 49545cb0")
+        XCTAssertEqual(decoded.exitCode, 1)
+    }
+
+    func testEntriesWithoutOutputTailStillDecode() throws {
+        // Entries written before the outputTail field existed.
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" \
+        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>definitionId</key><string>vcruntime</string>
+            <key>verbsAttempted</key><array><string>vcrun2019</string></array>
+            <key>timestamp</key><date>2026-08-28T19:18:23Z</date>
+            <key>success</key><false/>
+            <key>exitCode</key><integer>1</integer>
+        </dict>
+        </plist>
+        """
+
+        let decoded = try PropertyListDecoder().decode(
+            DependencyInstallAttempt.self,
+            from: Data(plist.utf8)
+        )
+
+        XCTAssertNil(decoded.outputTail)
+        XCTAssertEqual(decoded.exitCode, 1)
+    }
+
+    // MARK: - Bounded Tail
+
+    func testBoundedTailReturnsNilForEmptyInput() {
+        XCTAssertNil(DependencyInstallAttempt.boundedTail(of: []))
+    }
+
+    func testBoundedTailKeepsAllLinesWhenUnderBudget() {
+        let lines = ["one", "two", "three"]
+        XCTAssertEqual(DependencyInstallAttempt.boundedTail(of: lines), "one\ntwo\nthree")
+    }
+
+    func testBoundedTailKeepsNewestLinesWithinBudget() {
+        let filler = String(repeating: "x", count: 1_000)
+        let lines = (0 ..< 10).map { "\($0) \(filler)" }
+
+        let tail = try? XCTUnwrap(DependencyInstallAttempt.boundedTail(of: lines))
+        let kept = tail?.components(separatedBy: "\n") ?? []
+
+        XCTAssertLessThanOrEqual(
+            tail?.utf8.count ?? .max,
+            DependencyInstallAttempt.maxOutputTailBytes
+        )
+        // Newest lines survive, oldest are dropped.
+        XCTAssertEqual(kept.last, lines.last)
+        XCTAssertFalse(kept.contains(lines.first ?? ""))
+    }
+
+    func testBoundedTailTruncatesSingleOversizedLine() {
+        let oversized = String(repeating: "y", count: 10_000)
+
+        let tail = DependencyInstallAttempt.boundedTail(of: [oversized])
+
+        XCTAssertEqual(tail?.utf8.count, DependencyInstallAttempt.maxOutputTailBytes)
+        XCTAssertTrue(tail?.allSatisfy { $0 == "y" } ?? false)
+    }
+
+    func testBoundedTailSurvivesCutInsideMultiByteCharacter() {
+        // 2-byte characters with an odd byte budget guarantee the cut lands
+        // mid-character; the tail must still decode.
+        let oversized = String(repeating: "ä", count: 5_000)
+
+        let tail = DependencyInstallAttempt.boundedTail(of: [oversized])
+
+        XCTAssertNotNil(tail)
+        XCTAssertLessThanOrEqual(
+            tail?.utf8.count ?? .max,
+            DependencyInstallAttempt.maxOutputTailBytes
+        )
+        XCTAssertTrue(tail?.allSatisfy { $0 == "ä" } ?? false)
+    }
+}


### PR DESCRIPTION
Second of the three changes agreed in #233.

A failed dependency install lands in dependency-history.plist as nothing but exit code 1 — the actual reason (in my case a vc_redist SHA256 mismatch) is invisible unless you re-run winetricks by hand.

This records a bounded tail of the winetricks stdout/stderr in the history entry when the attempt fails:

- capped at 4 KB, whole lines kept newest-first (a single oversized line is truncated to its trailing bytes)
- successful attempts store nothing
- the field is optional, so entries written by earlier versions decode unchanged

WhiskyKit tests cover the plist round-trip, decoding of pre-existing entries without the field, and the tail bounding.

Includes a CHANGELOG entry.
