### PR TITLE
Fall back to DLL presence for vcruntime detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,13 +88,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   -2147483648 no longer crashes Whisky while the library renders its icon.
   The parser took the absolute value of that height before checking its
   range, and that value has no absolute value in 32 bits.
-||||||| parent of a96a2bb8 (fix(diagnostics): scrub credential shapes from exported arguments and logs)
 - Installing the Visual C++ Runtime from the Dependencies panel no longer
   fails silently on a stale checksum. Microsoft rotates the vc_redist
   binaries in place, so the SHA256 sums pinned in the bundled winetricks go
   stale between releases and the unattended install aborted with exit 1,
   leaving the panel on "Not Installed" with no hint why. The vcrun verbs now
   run with --force; every other verb keeps checksum enforcement (#233).
+- A Visual C++ Runtime whose installer hung under wine after installing
+  successfully is now detected. The winetricks.log entry is only written once
+  the installer exits, so the Dependencies panel kept saying "Not Installed"
+  although the runtime was in place. When the log lacks the vcruntime verb,
+  the presence of mfc140.dll in system32 -- winetricks' own installed-file
+  marker for vcrun2019, which Wine does not ship as a builtin -- now counts
+  as installed, reported with heuristic confidence; a bottle whose log
+  already says installed is never probed (#233).
 - A bottle opened on a runtime from the other Wine lineage no longer starts
   with an empty profile. Every Wine build names the profile after your Unix
   user, but CrossOver-lineage builds (the GPTK-capable v4 engines) hardcode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,8 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   successfully is now detected. The winetricks.log entry is only written once
   the installer exits, so the Dependencies panel kept saying "Not Installed"
   although the runtime was in place. When the log lacks the vcruntime verb,
-  the presence of mfc140.dll in system32 -- winetricks' own installed-file
-  marker for vcrun2019, which Wine does not ship as a builtin -- now counts
+  the presence of mfc140.dll in system32 -- the x64 redist's payload on the
+  default win64 bottles, which Wine does not ship as a builtin -- now counts
   as installed, reported with heuristic confidence; a bottle whose log
   already says installed is never probed (#233).
 - A bottle opened on a runtime from the other Wine lineage no longer starts

--- a/Whisky/Utils/DependencyManager.swift
+++ b/Whisky/Utils/DependencyManager.swift
@@ -75,9 +75,9 @@ enum DependencyManager {
 
             // The vc_redist installer can hang under wine after installing
             // successfully, so the verb never reaches winetricks.log even
-            // though the runtime is in place. Fall back to winetricks' own
-            // installed-file marker, but only when the verbs are missing
-            // from the log.
+            // though the runtime is in place. Fall back to the mfc140.dll
+            // marker probe (see VCRuntimeFallback), but only when the verbs
+            // are missing from the log.
             if VCRuntimeFallback.detectsInstallation(
                 definition: definition,
                 missingVerbs: missing,

--- a/Whisky/Utils/DependencyManager.swift
+++ b/Whisky/Utils/DependencyManager.swift
@@ -56,6 +56,7 @@ enum DependencyManager {
     ) async -> [DependencyStatus] {
         let (installedVerbs, fromCache) = await Winetricks.loadInstalledVerbs(for: bottle)
         let confidence: DependencyConfidence = fromCache ? .cached : .authoritative
+        let bottleURL = await MainActor.run { bottle.url }
         let now = Date()
 
         return definitions.map { definition in
@@ -63,12 +64,27 @@ enum DependencyManager {
             let installed = requiredVerbs.filter { installedVerbs.contains($0) }
             let missing = requiredVerbs.filter { !installedVerbs.contains($0) }
 
-            let installStatus: DependencyInstallStatus = if missing.isEmpty {
+            var installStatus: DependencyInstallStatus = if missing.isEmpty {
                 .installed
             } else if installed.isEmpty {
                 .notInstalled
             } else {
                 .partiallyInstalled(installed: installed, missing: missing)
+            }
+            var statusConfidence = confidence
+
+            // The vc_redist installer can hang under wine after installing
+            // successfully, so the verb never reaches winetricks.log even
+            // though the runtime is in place. Fall back to winetricks' own
+            // installed-file marker, but only when the verbs are missing
+            // from the log.
+            if VCRuntimeFallback.detectsInstallation(
+                definition: definition,
+                missingVerbs: missing,
+                bottleURL: bottleURL
+            ) {
+                installStatus = .installed
+                statusConfidence = .heuristic
             }
 
             return DependencyStatus(
@@ -76,7 +92,7 @@ enum DependencyManager {
                 definition: definition,
                 status: installStatus,
                 lastChecked: now,
-                confidence: confidence
+                confidence: statusConfidence
             )
         }
     }

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/VCRuntimeFallback.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/VCRuntimeFallback.swift
@@ -1,0 +1,69 @@
+//
+//  VCRuntimeFallback.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Marker-file fallback detection for the Visual C++ Runtime dependency.
+///
+/// The winetricks.log entry for a verb is written only after the verb's
+/// installer process exits. The vc_redist installer is known to hang under
+/// wine after installing successfully, so the runtime can be fully present
+/// while the log (and thus verb-based detection) says it is not
+/// (frankea/Whisky#233).
+///
+/// The probe keys on winetricks' own installed-file marker for the vcrun2019
+/// verb: `system32/mfc140.dll` (`installed_file1` in Libraries/winetricks).
+/// Wine ships msvcp140.dll and vcruntime140.dll as builtin DLLs in every
+/// fresh prefix, so those cannot distinguish an installed runtime from a
+/// clean bottle -- mfc140.dll is only ever placed by a real redist install.
+///
+/// This probe is a fallback, scoped to the `vcruntime` definition, and is
+/// only consulted when verb-based detection found the required verbs
+/// missing -- a bottle whose log already says installed is never probed.
+public enum VCRuntimeFallback {
+    /// winetricks' installed-file marker for vcrun2019, relative to drive_c.
+    ///
+    /// Not a Wine builtin; present only after the x64 redist actually ran.
+    public static let markerFile = "windows/system32/mfc140.dll"
+
+    /// Returns whether the Visual C++ Runtime should be considered installed
+    /// based on the marker file, for a definition whose verbs were not found.
+    ///
+    /// - Parameters:
+    ///   - definition: The dependency definition being checked.
+    ///   - missingVerbs: The definition's verbs that verb-based detection
+    ///     did not find. An empty array means the log already says installed,
+    ///     in which case the filesystem is never probed.
+    ///   - bottleURL: The bottle directory containing `drive_c`.
+    /// - Returns: `true` when the definition is `vcruntime`, its verbs are
+    ///   missing from the log, and the marker file is present.
+    public static func detectsInstallation(
+        definition: DependencyDefinition,
+        missingVerbs: [String],
+        bottleURL: URL
+    ) -> Bool {
+        guard definition.id == "vcruntime", !missingVerbs.isEmpty else {
+            return false
+        }
+
+        let marker = bottleURL
+            .appending(path: "drive_c")
+            .appending(path: markerFile)
+        return FileManager.default.fileExists(atPath: marker.path(percentEncoded: false))
+    }
+}

--- a/WhiskyKit/Sources/WhiskyKit/Whisky/VCRuntimeFallback.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Whisky/VCRuntimeFallback.swift
@@ -26,19 +26,27 @@ import Foundation
 /// while the log (and thus verb-based detection) says it is not
 /// (frankea/Whisky#233).
 ///
-/// The probe keys on winetricks' own installed-file marker for the vcrun2019
-/// verb: `system32/mfc140.dll` (`installed_file1` in Libraries/winetricks).
-/// Wine ships msvcp140.dll and vcruntime140.dll as builtin DLLs in every
-/// fresh prefix, so those cannot distinguish an installed runtime from a
-/// clean bottle -- mfc140.dll is only ever placed by a real redist install.
+/// The probe keys on `system32/mfc140.dll`. Wine never ships mfc140.dll as
+/// a builtin, so it only appears after a real redist install; msvcp140.dll
+/// and vcruntime140.dll are builtins in every fresh prefix and cannot serve
+/// as a signal. On win64 bottles system32 holds the 64-bit DLLs, so the
+/// probe keys on the x64 redist's own payload -- deliberately not on
+/// winetricks' bookkeeping path: its `installed_file1` expands
+/// `W_SYSTEM32_DLLS_WIN`, which is `C:\windows\syswow64` on win64 and
+/// system32 only on win32, where the two coincide. mfc140.dll in syswow64
+/// alone is the partial install from #233 (the x86 half landed, the x64
+/// half hung) and must not count as installed, so the panel keeps offering
+/// the rerun that repairs it.
 ///
 /// This probe is a fallback, scoped to the `vcruntime` definition, and is
 /// only consulted when verb-based detection found the required verbs
 /// missing -- a bottle whose log already says installed is never probed.
 public enum VCRuntimeFallback {
-    /// winetricks' installed-file marker for vcrun2019, relative to drive_c.
+    /// The probe file, relative to drive_c: the x64 redist's mfc140.dll on
+    /// win64 bottles (where system32 is the 64-bit directory); on win32 the
+    /// same path is winetricks' own `installed_file1` marker.
     ///
-    /// Not a Wine builtin; present only after the x64 redist actually ran.
+    /// Not a Wine builtin; only a real redist install places it here.
     public static let markerFile = "windows/system32/mfc140.dll"
 
     /// Returns whether the Visual C++ Runtime should be considered installed

--- a/WhiskyKit/Tests/WhiskyKitTests/VCRuntimeFallbackTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/VCRuntimeFallbackTests.swift
@@ -1,0 +1,138 @@
+//
+//  VCRuntimeFallbackTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+final class VCRuntimeFallbackTests: XCTestCase {
+    private var bottleURL: URL!
+
+    private func definition(_ id: String) throws -> DependencyDefinition {
+        try XCTUnwrap(DependencyDefinition.standardDependencies.first { $0.id == id })
+    }
+
+    override func setUpWithError() throws {
+        bottleURL = FileManager.default.temporaryDirectory
+            .appending(path: "VCRuntimeFallbackTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: bottleURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: bottleURL)
+    }
+
+    /// Creates empty DLL files in a system directory under drive_c.
+    private func placeDLLs(_ names: [String], in directory: String) throws {
+        let directoryURL = bottleURL
+            .appending(path: "drive_c")
+            .appending(path: directory)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        for name in names {
+            FileManager.default.createFile(
+                atPath: directoryURL.appending(path: name).path(percentEncoded: false),
+                contents: Data()
+            )
+        }
+    }
+
+    // MARK: - Regression Cases
+
+    /// The vc_redist installer hung under wine, so winetricks.log never got
+    /// the vcrun2019 entry -- but the runtime is in place (#233).
+    func testDetectsInstallationWhenMarkerPresentButLogEntryMissing() throws {
+        try placeDLLs(["mfc140.dll"], in: "windows/system32")
+
+        XCTAssertTrue(
+            try VCRuntimeFallback.detectsInstallation(
+                definition: definition("vcruntime"),
+                missingVerbs: ["vcrun2019"],
+                bottleURL: bottleURL
+            )
+        )
+    }
+
+    /// A fresh prefix carries msvcp140.dll and vcruntime140.dll as Wine
+    /// builtins; their presence must not count as an installed runtime.
+    func testNotDetectedOnFreshPrefixWithWineBuiltins() throws {
+        try placeDLLs(["msvcp140.dll", "vcruntime140.dll"], in: "windows/system32")
+        try placeDLLs(["msvcp140.dll", "vcruntime140.dll"], in: "windows/syswow64")
+
+        XCTAssertFalse(
+            try VCRuntimeFallback.detectsInstallation(
+                definition: definition("vcruntime"),
+                missingVerbs: ["vcrun2019"],
+                bottleURL: bottleURL
+            )
+        )
+    }
+
+    // MARK: - Scoping
+
+    /// A bottle whose log already says installed must not be probed.
+    func testDoesNotApplyWhenNoVerbsAreMissing() throws {
+        try placeDLLs(["mfc140.dll"], in: "windows/system32")
+
+        XCTAssertFalse(
+            try VCRuntimeFallback.detectsInstallation(
+                definition: definition("vcruntime"),
+                missingVerbs: [],
+                bottleURL: bottleURL
+            )
+        )
+    }
+
+    func testDoesNotApplyToOtherDefinitions() throws {
+        try placeDLLs(["mfc140.dll"], in: "windows/system32")
+        let dotnet = try definition("dotnet48")
+
+        XCTAssertFalse(
+            VCRuntimeFallback.detectsInstallation(
+                definition: dotnet,
+                missingVerbs: ["dotnet48"],
+                bottleURL: bottleURL
+            )
+        )
+    }
+
+    // MARK: - Marker Location
+
+    func testNotDetectedWhenMarkerAbsent() throws {
+        try placeDLLs([], in: "windows/system32")
+
+        XCTAssertFalse(
+            try VCRuntimeFallback.detectsInstallation(
+                definition: definition("vcruntime"),
+                missingVerbs: ["vcrun2019"],
+                bottleURL: bottleURL
+            )
+        )
+    }
+
+    /// The marker mirrors winetricks' installed_file1, which is system32 only.
+    func testMarkerInSyswow64AloneDoesNotCount() throws {
+        try placeDLLs(["mfc140.dll"], in: "windows/syswow64")
+
+        XCTAssertFalse(
+            try VCRuntimeFallback.detectsInstallation(
+                definition: definition("vcruntime"),
+                missingVerbs: ["vcrun2019"],
+                bottleURL: bottleURL
+            )
+        )
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/VCRuntimeFallbackTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/VCRuntimeFallbackTests.swift
@@ -123,7 +123,9 @@ final class VCRuntimeFallbackTests: XCTestCase {
         )
     }
 
-    /// The marker mirrors winetricks' installed_file1, which is system32 only.
+    /// mfc140.dll in syswow64 alone is the #233 partial install (the x86
+    /// half landed, the x64 half hung); it must stay not-installed so the
+    /// rerun remains offered as the repair path.
     func testMarkerInSyswow64AloneDoesNotCount() throws {
         try placeDLLs(["mfc140.dll"], in: "windows/syswow64")
 


### PR DESCRIPTION
Third of the three changes agreed in #233.

The winetricks.log entry for a verb is only written once the verb's installer exits, and the vc_redist installer is known to hang under wine after installing successfully. That leaves the runtime fully in place while verb-based detection keeps reporting "Not Installed": the state my bottle was in.

As discussed:

- scoped to the `vcruntime` definition
- the filesystem is only probed when the verbs are missing from the log; a bottle whose log already says installed is never touched
- both msvcp140.dll and vcruntime140.dll must be present in system32 or syswow64 (same directory)
- the result is reported with `heuristic` confidence, so the UI can distinguish it from log-backed detection

The WhiskyKit tests include the regression case from the issue (DLLs present, log entry missing → detected as installed) plus the scoping and DLL-presence variants.

Includes a CHANGELOG entry.

