### PR TITLE
fix: quote the winetricks terminal command and reject an Int32.min icon height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either position (#216).
 
 ### Fixed
+- Running a winetricks verb from the bottle's Winetricks screen no longer
+  hands the bottle's path to the terminal as shell text. A bottle imported
+  from a directory whose name carried `$(...)` or backticks would have had
+  that executed in the user's terminal; the command now goes through a temp
+  script with every value quoted, the same route as the bottle's own Open
+  Terminal, which also means it follows the preferred terminal setting
+  (iTerm and Warp) instead of always opening Terminal.
+- A Windows executable whose icon declares a bitmap height of exactly
+  -2147483648 no longer crashes Whisky while the library renders its icon.
+  The parser took the absolute value of that height before checking its
+  range, and that value has no absolute value in 32 bits.
 - Installing the Visual C++ Runtime from the Dependencies panel no longer
   fails silently on a stale checksum. Microsoft rotates the vc_redist
   binaries in place, so the SHA256 sums pinned in the bundled winetricks go

--- a/Whisky/Utils/Winetricks.swift
+++ b/Whisky/Utils/Winetricks.swift
@@ -79,16 +79,21 @@ class Winetricks {
         }
         // Winetricks ships in the app bundle Resources alongside cabextract. Invoke it via
         // `bash` (matching the headless install paths) so no executable bit is relied upon.
-        let winetricksPath = resourcesURL.appending(path: "winetricks").path(percentEncoded: false)
-        // swiftlint:disable:next line_length
-        let winetricksCmd = #"PATH=\"\#(WhiskyWineInstaller.binFolder.path):\#(resourcesURL.path(percentEncoded: false)):$PATH\" WINE=wine64 WINEPREFIX=\"\#(bottle.url.path)\" bash \"\#(winetricksPath)\" \#(command)"#
-
-        let script = """
-        tell application "Terminal"
-            activate
-            do script "\(winetricksCmd)"
-        end tell
-        """
+        //
+        // The command goes into a temp script that the terminal sources, the
+        // same route the bottle's "open terminal" uses, so no value reaches
+        // AppleScript as program text. Every value in the script is
+        // single-quoted: a bottle imported from a directory named with `$(...)`
+        // or backticks used to execute in the user's terminal here.
+        let scriptURL: URL
+        do {
+            scriptURL = try writeTerminalScript(command: command, bottle: bottle, resourcesURL: resourcesURL)
+        } catch {
+            logger.error("Failed to write winetricks script: \(error)")
+            showMissingResourcesAlert(command: command)
+            return
+        }
+        let script = TerminalApp.preferred.generateAppleScript(for: scriptURL.path)
 
         var error: NSDictionary?
         if let appleScript = NSAppleScript(source: script) {
@@ -110,6 +115,31 @@ class Winetricks {
                 }
             }
         }
+    }
+
+    /// Writes the winetricks invocation to a temp script the terminal sources.
+    ///
+    /// Every value is single-quoted so nothing in a path is read as shell
+    /// syntax; the script is tracked for cleanup like the bottle terminal's.
+    @MainActor
+    private static func writeTerminalScript(command: String, bottle: Bottle, resourcesURL: URL) throws -> URL {
+        let winetricksPath = resourcesURL.appending(path: "winetricks").path(percentEncoded: false)
+        let pathValue = "\(WhiskyWineInstaller.binFolder.path):\(resourcesURL.path(percentEncoded: false))"
+        let scriptContent = [
+            "#!/bin/bash",
+            "export PATH=\(ShellQuoting.quoted(pathValue)):\"$PATH\"",
+            "export WINE=wine64",
+            "export " + ShellQuoting.assignment("WINEPREFIX", bottle.url.path(percentEncoded: false)),
+            ShellQuoting.commandLine(["bash", winetricksPath, command]),
+            ""
+        ].joined(separator: "\n")
+
+        let scriptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whisky-winetricks-\(UUID().uuidString).sh")
+        try scriptContent.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        TempFileTracker.shared.register(file: scriptURL)
+        return scriptURL
     }
 
     /// Shown when the bundled winetricks resources can't be located. A missing

--- a/WhiskyKit/Sources/WhiskyKit/BitmapInfo.swift
+++ b/WhiskyKit/Sources/WhiskyKit/BitmapInfo.swift
@@ -78,9 +78,11 @@ public struct BitmapInfoHeader: Hashable {
     func renderBitmap(handle: FileHandle, offset: UInt64) -> NSImage? {
         // Reject crafted dimensions before allocating or looping. width/height
         // come straight from the file and can be non-positive or near Int32.max.
-        let actualHeight = abs(height)
+        // magnitude rather than abs: abs(Int32.min) has no representable
+        // result and traps, and a crafted icon can carry exactly that value.
+        let actualHeight = height.magnitude
         guard width > 0, actualHeight > 0,
-              width <= Self.maxDimension, actualHeight <= Self.maxDimension
+              width <= Self.maxDimension, actualHeight <= UInt32(Self.maxDimension)
         else {
             return nil
         }

--- a/WhiskyKit/Sources/WhiskyKit/Utils/ShellQuoting.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Utils/ShellQuoting.swift
@@ -1,0 +1,46 @@
+//
+//  ShellQuoting.swift
+//  WhiskyKit
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Turns values into shell words that a POSIX shell reads back verbatim.
+///
+/// Single quotes are the one quoting form in which nothing expands: no `$`,
+/// no backticks, no backslash escapes. The only character that needs care is
+/// the single quote itself, which ends the quoted run; it is written as
+/// `'\''` (close, escaped quote, reopen). Prefer this over backslash-escaping
+/// whenever a value ends up in shell text, such as a script handed to a
+/// terminal, rather than in a `Process` argument array.
+public enum ShellQuoting {
+    /// `value` as one shell word, safe to paste into any POSIX shell.
+    public static func quoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// `words` as one command line, each word quoted.
+    public static func commandLine(_ words: [String]) -> String {
+        words.map(quoted).joined(separator: " ")
+    }
+
+    /// A `NAME=value` assignment with the value quoted, for prefixing a command
+    /// (`WINEPREFIX='...' wine ...`). `name` must be a valid identifier; it is
+    /// the caller's constant, never data.
+    public static func assignment(_ name: String, _ value: String) -> String {
+        "\(name)=\(quoted(value))"
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/BitmapHeightTrapTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BitmapHeightTrapTests.swift
@@ -1,0 +1,52 @@
+//
+//  BitmapHeightTrapTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("Bitmap header height edge cases")
+struct BitmapHeightTrapTests {
+    private func header(height: Int32) throws -> (BitmapInfoHeader, FileHandle) {
+        var params = BitmapHeaderParams()
+        params.width = 16
+        params.height = height
+        let url = FileManager.default.temporaryDirectory.appending(path: "bmp-\(UUID().uuidString)")
+        try createBitmapInfoHeaderData(params).write(to: url)
+        let handle = try FileHandle(forReadingFrom: url)
+        return (BitmapInfoHeader(handle: handle, offset: 0), handle)
+    }
+
+    @Test("Int32.min as the height is rejected instead of trapping in abs")
+    func int32MinHeightIsRejected() throws {
+        let (info, handle) = try header(height: Int32.min)
+        defer { try? handle.close() }
+
+        #expect(info.height == Int32.min)
+        #expect(info.renderBitmap(handle: handle, offset: 40) == nil)
+    }
+
+    @Test("Other out-of-range heights are still rejected")
+    func outOfRangeHeights() throws {
+        for height: Int32 in [0, Int32.max, -(1 << 20), 1 << 20] {
+            let (info, handle) = try header(height: height)
+            defer { try? handle.close() }
+            #expect(info.renderBitmap(handle: handle, offset: 40) == nil, "height \(height)")
+        }
+    }
+}

--- a/WhiskyKit/Tests/WhiskyKitTests/ShellQuotingTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/ShellQuotingTests.swift
@@ -1,0 +1,85 @@
+//
+//  ShellQuotingTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("Shell quoting")
+struct ShellQuotingTests {
+    /// The values an attacker-named bottle directory could carry into a
+    /// terminal command, plus the ordinary ones.
+    private static let hostile: [String] = [
+        "Games",
+        "My Games",
+        "Bottle $(touch /tmp/whisky-quoting-pwned)",
+        "Bottle `touch /tmp/whisky-quoting-pwned`",
+        "It's a bottle",
+        "\"quoted\" name",
+        "back\\slash",
+        "semi; rm -rf ~",
+        "pipe | cat",
+        "amp && echo hi",
+        "hash # not a comment",
+        "tilde ~/home",
+        "star * glob",
+        "newline\nin name",
+        "unicode Ångström 游戏"
+    ]
+
+    /// Runs `printf %s <quoted>` through the real shell and compares.
+    private func shellReadsBack(_ value: String) throws -> String {
+        let process = Process()
+        process.executableURL = URL(filePath: "/bin/sh")
+        process.arguments = ["-c", "printf %s " + ShellQuoting.quoted(value)]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return String(bytes: data, encoding: .utf8) ?? ""
+    }
+
+    @Test("The shell reads every quoted value back verbatim", arguments: hostile)
+    func roundTrips(value: String) throws {
+        #expect(try shellReadsBack(value) == value)
+    }
+
+    @Test("Command substitution inside a quoted value never runs")
+    func substitutionIsInert() throws {
+        let marker = FileManager.default.temporaryDirectory
+            .appending(path: "whisky-quoting-\(UUID().uuidString)")
+        let value = "Bottle $(touch \(marker.path)) `touch \(marker.path)`"
+
+        _ = try shellReadsBack(value)
+
+        #expect(!FileManager.default.fileExists(atPath: marker.path))
+    }
+
+    @Test("A single quote becomes close, escaped quote, reopen")
+    func singleQuoteForm() {
+        #expect(ShellQuoting.quoted("it's") == "'it'\\''s'")
+        #expect(ShellQuoting.quoted("") == "''")
+    }
+
+    @Test("Command lines and assignments quote every value")
+    func commandLineAndAssignment() {
+        #expect(ShellQuoting.commandLine(["bash", "/p/w t", "vcrun2019"]) == "'bash' '/p/w t' 'vcrun2019'")
+        #expect(ShellQuoting.assignment("WINEPREFIX", "/Users/me/It's") == "WINEPREFIX='/Users/me/It'\\''s'")
+    }
+}


### PR DESCRIPTION
Two fixes from a security review of main, both with tests.

## Winetricks terminal command built from the bottle path

`Winetricks.runCommand` composed a shell command with `bottle.url.path` inside a double-quoted `WINEPREFIX="..."` and handed it to Terminal through AppleScript `do script`. Double quotes do not stop `$(...)` or backticks, so a bottle imported from a directory named that way would have executed its name in the user's terminal the first time they ran any verb. The verb itself is picked from a list, so the path was the only attacker-influenced value; the precondition is a victim importing a bottle from an attacker-named directory, then using the Winetricks screen.

The command now goes into a temp script that the terminal sources, the same route the bottle's Open Terminal already uses (`TerminalApp.generateAppleScript(for:)` with a UUID-named script), so no dynamic value reaches AppleScript as program text. Inside the script every value is single-quoted through a new `ShellQuoting` helper in the kit. Side benefit: winetricks now follows the preferred terminal setting (iTerm, Warp) instead of always opening Terminal, since it shares that launcher.

`ShellQuoting` is tested by round-tripping values through the real `/bin/sh` (`printf %s <quoted>` must reproduce the input): command substitution, backticks, single and double quotes, backslashes, `; | && # ~ *`, newlines, non-ASCII. A separate test proves `$(touch marker)` inside a quoted value leaves no marker behind.

## Int32.min bitmap height trap

`BitmapInfoHeader.renderBitmap` took `abs(height)` on the `Int32` read straight from the PE before the dimension guard. `abs(Int32.min)` has no representable result and traps, so an executable whose icon declares that height crashed Whisky while the library rendered its icon. The magnitude is now taken as `UInt32` and compared against the limit; the guard rejects it like any other out-of-range height. Regression test crafts that header and asserts `renderBitmap` returns nil, alongside the other out-of-range heights.

## verified

- WhiskyKit: 1301 XCTest plus 261 Swift Testing, 0 failures
- Whisky app builds
- pinned SwiftFormat 0.58.7 and SwiftLint strict clean on every changed file
- Changelog entries under Fixed for both
