### PR TITLE
fix(diagnostics): scrub credential shapes from exported arguments and logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either position (#216).
 
 ### Fixed
+- Diagnostic exports with "Include sensitive details" off no longer carry
+  credentials in plain sight. Launch arguments were written to the archive
+  verbatim regardless of the toggle, and log redaction only rewrote the home
+  path, so a `-token` argument or a bearer token a game logged went out in a
+  ZIP the sheet described as scrubbed. Arguments and both log members now
+  have common secret shapes removed (`name=value` and `--name value` forms
+  for token, password, secret and key style names, Bearer and Basic
+  credentials, URL user info, sensitive query parameters, JWTs), and the
+  sheet says so. It is best effort by nature; the toggle still exports raw.
 - Running a winetricks verb from the bottle's Winetricks screen no longer
   hands the bottle's path to the terminal as shell text. A bottle imported
   from a directory whose name carried `$(...)` or backticks would have had
@@ -79,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   -2147483648 no longer crashes Whisky while the library renders its icon.
   The parser took the absolute value of that height before checking its
   range, and that value has no absolute value in 32 bits.
+||||||| parent of a96a2bb8 (fix(diagnostics): scrub credential shapes from exported arguments and logs)
 - Installing the Visual C++ Runtime from the Dependencies panel no longer
   fails silently on a stale checksum. Microsoft rotates the vc_redist
   binaries in place, so the SHA256 sums pinned in the bundled winetricks go

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -1007,6 +1007,22 @@
         }
       }
     },
+    "Arguments and logs have common secret shapes scrubbed unless sensitive details are included" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arguments and logs have common secret shapes scrubbed unless sensitive details are included"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arguments and logs have common secret shapes scrubbed unless sensitive details are included"
+          }
+        }
+      }
+    },
     "Auto-Enable DXVK for Launchers" : {
       "localizations" : {
         "ar" : {

--- a/Whisky/Views/Diagnostics/DiagnosticExportSheet.swift
+++ b/Whisky/Views/Diagnostics/DiagnosticExportSheet.swift
@@ -101,7 +101,12 @@ extension DiagnosticExportSheet {
             }
 
             Toggle(isOn: $includeFullLog) {
-                Text("Include full log file")
+                VStack(alignment: .leading) {
+                    Text("Include full log file")
+                    Text("Arguments and logs have common secret shapes scrubbed unless sensitive details are included")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
     }

--- a/WhiskyKit/Sources/WhiskyKit/Diagnostics/DiagnosticExporter.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Diagnostics/DiagnosticExporter.swift
@@ -270,13 +270,19 @@ public enum DiagnosticExporter {
     }
 
     /// Generates a JSON string with program settings summary.
+    ///
+    /// Launch arguments are free text the user typed and routinely carry
+    /// tokens and passwords, so they get the same scrubbing as a log line
+    /// unless sensitive details were asked for.
     @MainActor
-    static func programSettingsSummary(program: Program) -> String {
+    static func programSettingsSummary(program: Program, options: ExportOptions) -> String {
         var info: [String: String] = [:]
         info["name"] = program.name
         info["path"] = Redactor.redactHomePaths(program.url.path(percentEncoded: false))
         info["locale"] = "\(program.settings.locale)"
-        info["arguments"] = program.settings.arguments
+        info["arguments"] = options.includeSensitiveDetails
+            ? program.settings.arguments
+            : Redactor.redactLogText(program.settings.arguments)
         info["hasOverrides"] = "\(program.settings.overrides != nil)"
 
         return dictionaryToJSON(info)
@@ -345,7 +351,7 @@ extension DiagnosticExporter {
                 options: context.options
             ),
             bottleSummary: bottleSettingsSummary(bottle: context.bottle),
-            programSummary: programSettingsSummary(program: context.program),
+            programSummary: programSettingsSummary(program: context.program, options: context.options),
             systemInfo: generateSystemInfoJSON(),
             environmentJSON: generateEnvironmentJSON(bottle: context.bottle, options: context.options)
         )

--- a/WhiskyKit/Sources/WhiskyKit/Diagnostics/Redactor.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Diagnostics/Redactor.swift
@@ -29,6 +29,11 @@ import Foundation
 /// - Home paths (`/Users/<username>`) are replaced with `/Users/<redacted>`
 /// - Environment variable keys matching ``sensitiveKeyPatterns`` are removed
 ///   unless explicitly included
+/// - Free text (launch arguments, log lines) has common secret shapes scrubbed
+///   by ``redactSecrets(_:)``: `token=...` and `--password ...` forms,
+///   `Bearer`/`Basic` credentials, URL user info, sensitive query parameters,
+///   and JWTs. Best effort by nature; a secret with no recognizable shape
+///   passes through, which is why the export UI says so.
 public enum Redactor {
     /// Substrings that identify sensitive environment variable keys.
     ///
@@ -79,13 +84,59 @@ public enum Redactor {
         return result
     }
 
-    /// Redacts home directory paths throughout log text.
+    /// Redacts home directory paths and common secret shapes throughout free
+    /// text such as a log or a launch argument string.
     ///
-    /// - Parameter text: The log text to redact.
-    /// - Returns: The text with all home paths replaced.
+    /// - Parameter text: The text to redact.
+    /// - Returns: The text with home paths and recognizable secrets replaced.
     public static func redactLogText(_ text: String) -> String {
-        redactHomePaths(text)
+        redactSecrets(redactHomePaths(text))
     }
+
+    /// Replaces the value of anything that looks like a credential with
+    /// `<redacted>`, leaving the key or flag in place so the line still reads.
+    ///
+    /// Shapes covered, in order:
+    /// 1. `name=value` and `name: value` where the name ends in a sensitive
+    ///    word (token, secret, password, passwd, pwd, pass, auth, credential,
+    ///    api key, access key, private key, key)
+    /// 2. `--name value` and `-name value` flags with the same names
+    /// 3. `Bearer <token>` and `Basic <base64>`
+    /// 4. `scheme://user:pass@host` user info
+    /// 5. `?name=value` query parameters with the same names, plus `sig`
+    /// 6. JWTs (three base64url segments starting with `eyJ`)
+    ///
+    /// Prose is deliberately not matched: "auth failed" has no separator, so
+    /// it stays. A key whose name merely contains a sensitive word
+    /// ("keyboard") is not a match either; the word has to end the name.
+    public static func redactSecrets(_ text: String) -> String {
+        var result = text
+        for (pattern, template) in secretPatterns {
+            result = result.replacingOccurrences(
+                of: pattern, with: template, options: [.regularExpression, .caseInsensitive]
+            )
+        }
+        return result
+    }
+
+    private static let sensitiveWord =
+        "(?:token|secret|password|passwd|pwd|pass|auth|credential|api[_-]?key|access[_-]?key|private[_-]?key|key)"
+
+    /// Regex and replacement template pairs, applied in order.
+    private static let secretPatterns: [(String, String)] = [
+        // 1. name=value, name: value, name := value; the value runs to whitespace or a quote.
+        ("\\b([\\w.-]*" + sensitiveWord + ")(\\s*(?::=|[:=])\\s*)(\"[^\"]*\"|'[^']*'|[^\\s\"'&]+)", "$1$2<redacted>"),
+        // 2. --name value / -name value
+        ("(?<![\\w-])(--?[\\w-]*" + sensitiveWord + ")(\\s+)([^\\s\"'-][^\\s\"']*)", "$1$2<redacted>"),
+        // 3. HTTP authorization credentials
+        ("\\b(Bearer|Basic)(\\s+)[A-Za-z0-9._~+/=-]{8,}", "$1$2<redacted>"),
+        // 4. URL user info
+        ("([a-z][a-z0-9+.-]*://)[^/\\s:@]+(?::[^/\\s@]*)?@", "$1<redacted>@"),
+        // 5. sensitive query parameters
+        ("([?&][\\w-]*(?:" + sensitiveWord + "|sig|signature)=)([^&\\s\"']+)", "$1<redacted>"),
+        // 6. JWTs
+        ("\\beyJ[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}", "<redacted>")
+    ]
 
     // MARK: - Private
 

--- a/WhiskyKit/Tests/WhiskyKitTests/RedactorSecretTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/RedactorSecretTests.swift
@@ -1,0 +1,104 @@
+//
+//  RedactorSecretTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WhiskyKit
+
+@Suite("Redactor: secret shapes")
+struct RedactorSecretTests {
+    private func redact(_ text: String) -> String {
+        Redactor.redactSecrets(text)
+    }
+
+    @Test("key=value and key: value forms lose their value", arguments: [
+        ("token=abc123", "token=<redacted>"),
+        ("api_key=sk-live-9f8e7d", "api_key=<redacted>"),
+        ("Password: hunter2", "Password: <redacted>"),
+        ("STEAM_AUTH := deadbeef", "STEAM_AUTH := <redacted>"),
+        ("access-token=eyJ.abc", "access-token=<redacted>"),
+        ("secret=\"quoted value\" next", "secret=<redacted> next")
+    ])
+    func keyValueForms(input: String, expected: String) {
+        #expect(redact(input) == expected)
+    }
+
+    @Test("Flag forms lose their value but keep the flag and the rest of the line")
+    func flagForms() {
+        #expect(redact("-dx11 -token abc123 -windowed") == "-dx11 -token <redacted> -windowed")
+        #expect(redact("--password hunter2 --nolauncher") == "--password <redacted> --nolauncher")
+        #expect(redact("-pass 1234 --auth x") == "-pass <redacted> --auth <redacted>")
+    }
+
+    @Test("Authorization credentials, URL user info, query parameters and JWTs")
+    func webShapes() {
+        #expect(redact("Authorization: Bearer abcdefgh12345678") == "Authorization: Bearer <redacted>")
+        #expect(redact("Basic dXNlcjpwYXNz==") == "Basic <redacted>")
+        #expect(redact("https://user:p%40ss@example.com/path") == "https://<redacted>@example.com/path")
+        #expect(redact("https://alice@example.com/") == "https://<redacted>@example.com/")
+        #expect(redact("GET /api?token=abc&x=1&sig=zzz") == "GET /api?token=<redacted>&x=1&sig=<redacted>")
+        #expect(redact("jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV")
+            == "jwt <redacted>")
+    }
+
+    @Test("Prose and ordinary keys are left alone")
+    func negatives() {
+        for line in [
+            "auth failed, retrying",
+            "keyboard layout: US",
+            "Steam token refresh scheduled",
+            "err:winediag:secur32 no password given",
+            "-dx11 -windowed -width=1920",
+            "fixme:ntdll:NtQueryInformationToken stub"
+        ] {
+            #expect(redact(line) == line, "\(line)")
+        }
+    }
+
+    @Test("Log text redaction combines home paths and secrets")
+    func logTextCombines() {
+        var home = FileManager.default.homeDirectoryForCurrentUser.path(percentEncoded: false)
+        if home.hasSuffix("/") {
+            home.removeLast()
+        }
+        let text = "loading \(home)/Games/x.exe --token abc"
+        let out = Redactor.redactLogText(text)
+        #expect(out.contains("/Users/<redacted>/Games/x.exe"))
+        #expect(out.hasSuffix("--token <redacted>"))
+    }
+
+    @Test("Program arguments are scrubbed unless sensitive details are included")
+    @MainActor func programSummaryGating() throws {
+        let dir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir.appending(path: "drive_c"), withIntermediateDirectories: true)
+        let bottle = Bottle(bottleUrl: dir, inFlight: false, isAvailable: true)
+        let exe = dir.appending(path: "drive_c/game.exe")
+        try Data().write(to: exe)
+        let program = Program(url: exe, bottle: bottle, peFile: nil)
+        program.settings.arguments = "-dx11 -token abc123"
+
+        let scrubbed = DiagnosticExporter.programSettingsSummary(program: program, options: ExportOptions())
+        #expect(scrubbed.contains("-token <redacted>"))
+        #expect(!scrubbed.contains("abc123"))
+
+        let raw = DiagnosticExporter.programSettingsSummary(
+            program: program, options: ExportOptions(includeSensitiveDetails: true)
+        )
+        #expect(raw.contains("-token abc123"))
+    }
+}


### PR DESCRIPTION
From the security review of main: diagnostic exports with "Include sensitive details" off could still carry credentials.

## what was wrong

Two gaps behind one toggle. `programSettingsSummary` wrote `program.settings.arguments` to `program-settings.json` verbatim no matter what the option said, and `Redactor.redactLogText` only rewrote the home path, so `wine.log` (on by default) and `wine.tail.log` (always) went out with whatever a game logged. The toggle's actual scope was environment keys matching TOKEN/KEY/SECRET/PASSWORD/AUTH, which is not what the sheet implied.

## the change

`Redactor.redactSecrets(_:)` scrubs common credential shapes from free text, keeping the key or flag so the line still reads:

1. `name=value`, `name: value`, `name := value` where the name ends in token, secret, password, passwd, pwd, pass, auth, credential, api key, access key, private key, or key; quoted values are taken whole
2. `--name value` and `-name value` flags with the same names
3. `Bearer <token>` and `Basic <base64>`
4. `scheme://user:pass@host` user info
5. sensitive query parameters, plus `sig` and `signature`
6. JWTs

Prose is not matched ("auth failed" has no separator) and a name that merely contains a sensitive word ("keyboard") is not a key. `redactLogText` now applies home paths plus secrets, so both log members and the Markdown report get it for free. `programSettingsSummary` takes the export options and scrubs arguments the same way unless sensitive details are on. The sheet gains a caption under the full-log toggle saying exactly that; the toggle still exports raw.

Full log stays on by default: the 500-line tail is always included regardless, so making the full log opt-in would change volume, not exposure. The scrubbing is what closes the gap, and it is best effort by nature, which the caption says.

## tests

6 new Swift Testing cases: the key=value forms (parameterized), flag forms, the web shapes, a negative set of prose and ordinary flags that must survive untouched, the combined log redaction, and `programSettingsSummary` gating with a real `Program` (scrubbed by default, raw with the option). Existing exporter and redactor XCTests unchanged and green.

## verified

- WhiskyKit: full suite, 0 failures
- Whisky app builds; the new caption's catalog key is inserted by hand at its sorted position with en and en-GB, `british-english.py --check` clean
- pinned SwiftFormat 0.58.7 and SwiftLint strict clean on every changed file
- Changelog entry under Fixed
