### PR TITLE
Run the vcrun verbs unattended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either position (#216).
 
 ### Fixed
+- Installing the Visual C++ Runtime no longer stalls on an invisible install
+  wizard. winetricks was run without -q, so the vc_redist installer showed
+  its setup dialog inside the prefix and waited for a click nothing in the
+  Dependencies panel prompts for -- the process never exited, the
+  winetricks.log entry was never written, and the panel stayed on "Not
+  Installed" even after a successful install. The vcrun verbs now run
+  unattended (#233).
 - Five labels showed their raw localization key instead of text: the
   "currently using" line on the Recommended graphics card and the helper
   under it, the detected display size next to Virtual Desktop, and the exit

--- a/Whisky/Utils/Winetricks+Install.swift
+++ b/Whisky/Utils/Winetricks+Install.swift
@@ -98,6 +98,12 @@ extension Winetricks {
     /// binaries in place, so the checksums pinned in the bundled winetricks go
     /// stale between releases and the unattended install aborts with exit 1 on
     /// the SHA256 mismatch (winetricks#2195).
+    ///
+    /// They also get `-q` (W_OPT_UNATTENDED, adds `/q` to the redist install):
+    /// without it the vc_redist installer shows its wizard and waits for a
+    /// click nothing in the panel prompts for, so the process never exits and
+    /// the winetricks.log entry is never written. Scoped to the vcrun verbs
+    /// until other verbs are checked for unattended behavior.
     private static func configureInstallProcess(
         verb: String,
         bottleURL: URL,
@@ -109,6 +115,7 @@ extension Winetricks {
         var arguments = ["bash", winetricksPath]
         if verb.hasPrefix("vcrun") {
             arguments.append("--force")
+            arguments.append("-q")
         }
         arguments.append(verb)
         process.arguments = arguments


### PR DESCRIPTION
Whisky runs winetricks without -q, so the vc_redist installer is not
unattended: it shows its setup wizard inside the prefix and waits for a
click that nothing in the Dependencies panel prompts for. The process
never exits, winetricks never writes the log entry, and the panel keeps
reporting "Not Installed" even when the runtime installed fine
(frankea/Whisky#233).

Pass -q (W_OPT_UNATTENDED, which adds /q to the redist install) for the
vcrun verbs, alongside the existing --force. Scoped to the vcrun path
rather than globally until other verbs are checked for unattended
behavior.
