### PR TITLE
fix: resolve the findings from the release smoke run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either position (#216).
 
 ### Fixed
+- Five labels showed their raw localization key instead of text: the
+  "currently using" line on the Recommended graphics card and the helper
+  under it, the detected display size next to Virtual Desktop, and the exit
+  code badge and footer in the console. Each interpolates a value, and the
+  catalog only carried the plain key.
+- "Analyze last run" and "View Latest Diagnosis" no longer open a small empty
+  sheet that only cmd-period could dismiss. The sheet was presented on a flag
+  while its content read a separate optional, which SwiftUI can evaluate
+  before the value lands; both are presented from the value itself now.
+- The bottle's "Export Diagnostic Report" and "View Latest Diagnosis" buttons
+  can enable. A recorded crash diagnosis never stamped the program's last
+  diagnosis date, so the buttons stayed disabled forever and the ZIP export
+  was unreachable.
+- The crash diagnosis sheet has a Done button. It had no control of its own,
+  so the only way out was cmd-period or closing the window behind it.
+- "Analyze last run" is disabled until the program has a run to analyze.
+  Before the first run it clicked through to nothing.
 - Diagnostic exports with "Include sensitive details" off no longer carry
   credentials in plain sight. Launch arguments were written to the archive
   verbatim regardless of the toggle, and log redaction only rewrote the home

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so the only way out was cmd-period or closing the window behind it.
 - "Analyze last run" is disabled until the program has a run to analyze.
   Before the first run it clicked through to nothing.
+- The crash diagnosis history on a program's page refreshes when a diagnosis
+  is recorded while the page is open, instead of waiting for it to be reopened.
+- A program pinned in a bottle created during the same session now shows up
+  in the library, the Dock menu, and the menu bar extra right away. The
+  bottle list was rebuilt at the end of creation, so the bottle page kept
+  writing to an instance the rest of the app no longer read.
+- "Terminate Wine processes when Whisky closes" (and a bottle's Always Kill
+  policy) now actually ends the bottle's processes on quit. Two things kept
+  it from working: the setting read as off until the toggle had been touched
+  once, because its default was never written to disk, and the kill was
+  queued asynchronously from the termination handler, so the app exited
+  before it ran.
+- "Audio Troubleshooting" no longer opens as a small empty sheet. Same cause
+  as the diagnosis sheet: presented on a flag while the content read a
+  separate optional; it is presented from the engine itself now.
 - Diagnostic exports with "Include sensitive details" off no longer carry
   credentials in plain sight. Launch arguments were written to the archive
   verbatim regardless of the toggle, and log redaction only rewrote the home

--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -59,8 +59,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// The "Terminate Wine processes when Whisky closes" setting.
+    ///
+    /// Read as an optional: the Settings toggle is an `@AppStorage` that
+    /// defaults to on without ever writing the key, and `bool(forKey:)`
+    /// reports an absent key as off, which silently disabled kill-on-quit
+    /// for anyone who never touched the toggle.
+    static var killOnTerminate: Bool {
+        UserDefaults.standard.object(forKey: "killOnTerminate") as? Bool ?? true
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
-        let globalKill = UserDefaults.standard.bool(forKey: "killOnTerminate")
+        let globalKill = Self.killOnTerminate
 
         // Per-bottle kill-on-quit with policy overrides
         for bottle in BottleVM.shared.bottles {
@@ -75,7 +85,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             if shouldKill {
-                Wine.killBottle(bottle: bottle)
+                // Synchronous: the app exits when this delegate returns.
+                Wine.killBottleAndWait(bottle: bottle)
                 ProcessRegistry.shared.clearRegistry(for: bottle.url)
                 logger.info(
                     "Killing bottle '\(bottle.settings.name)' on quit (policy: \(String(describing: bottlePolicy)))"
@@ -164,7 +175,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             let bottleName = bottle.settings.name
             let policy = bottle.settings.killOnQuit
-            let globalKill = UserDefaults.standard.bool(forKey: "killOnTerminate")
+            let globalKill = Self.killOnTerminate
             let shouldAutoClean: Bool = switch policy {
             case .inherit: globalKill
             case .alwaysKill: true

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -60213,6 +60213,38 @@
         }
       }
     },
+    "config.graphics.currentlyUsing %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currently using %@"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currently using %@"
+          }
+        }
+      }
+    },
+    "config.graphics.helperCurrently %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recommended currently resolves to %@."
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recommended currently resolves to %@."
+          }
+        }
+      }
+    },
     "config.graphics.nextLaunch" : {
       "localizations" : {
         "en" : {
@@ -60289,6 +60321,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Delete Run"
+          }
+        }
+      }
+    },
+    "console.exitCode %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exit code %lld"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exit code %lld"
+          }
+        }
+      }
+    },
+    "console.exited %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exited with code %lld"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exited with code %lld"
           }
         }
       }
@@ -104257,6 +104321,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自訂"
+          }
+        }
+      }
+    },
+    "config.virtualDesktop.matchDisplay %lld %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detected display: %lld x %lld pixels"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detected display: %lld x %lld pixels"
           }
         }
       }

--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -191,8 +191,14 @@ final class BottleVM: ObservableObject {
             createdBottle.saveBottleSettings()
 
             try persistBottleCreation(request: request)
-            createdBottle.inFlight = false
+            // Reload while the bottle is still in flight so the reload keeps
+            // this instance. Reloading after clearing the flag replaced it,
+            // and the selected bottle page kept writing to the old one: its
+            // first pin never reached the library, the Dock menu, or the menu
+            // bar extra until the next reload.
             loadBottles()
+            createdBottle.isAvailable = true
+            createdBottle.inFlight = false
             Telemetry.capture(.firstBottleCreated)
         } catch {
             handleBottleCreationFailure(error, request: request, bottle: bottle)

--- a/Whisky/Views/Bottle/AudioConfigSection.swift
+++ b/Whisky/Views/Bottle/AudioConfigSection.swift
@@ -32,14 +32,16 @@ struct AudioConfigSection: View {
     @State private var audioStatus: AudioStatus = .unknown
     @State private var probeResults: [AudioProbeResult] = []
     @State private var lastTestedDate: Date?
-    @State private var showTroubleshootingWizard: Bool = false
     @State private var deviceHistory = AudioDeviceHistory()
 
     /// Debounce timer for Bluetooth device change events.
     @State private var debounceTask: Task<Void, Never>?
 
-    /// The troubleshooting engine, created when the wizard opens.
-    @State private var troubleshootingEngine: AudioTroubleshootingEngine?
+    /// The wizard and its engine, created when it opens. Item-based so the
+    /// sheet is built from the engine that presents it; with a flag plus a
+    /// separate optional the content closure could run before the engine
+    /// landed and show an empty sheet.
+    @State private var wizardPresentation: AudioWizardPresentation?
 
     var body: some View {
         Section("Audio") {
@@ -104,18 +106,16 @@ struct AudioConfigSection: View {
         .onReceive(NotificationCenter.default.publisher(for: .openAudioTroubleshooting)) { _ in
             openTroubleshootingWizard()
         }
-        .sheet(isPresented: $showTroubleshootingWizard) {
-            if let engine = troubleshootingEngine {
-                AudioTroubleshootingWizardView(
-                    engine: engine,
-                    onDismiss: {
-                        showTroubleshootingWizard = false
-                    },
-                    onOpenAdvanced: {
-                        advancedMode = true
-                    }
-                )
-            }
+        .sheet(item: $wizardPresentation) { presentation in
+            AudioTroubleshootingWizardView(
+                engine: presentation.engine,
+                onDismiss: {
+                    wizardPresentation = nil
+                },
+                onOpenAdvanced: {
+                    advancedMode = true
+                }
+            )
         }
     }
 }
@@ -207,8 +207,7 @@ extension AudioConfigSection {
                 testExeURL: Bundle.main.url(forResource: "WhiskyAudioTest", withExtension: "exe")
             )
         ]
-        troubleshootingEngine = AudioTroubleshootingEngine(probes: probes)
-        showTroubleshootingWizard = true
+        wizardPresentation = AudioWizardPresentation(engine: AudioTroubleshootingEngine(probes: probes))
     }
 }
 
@@ -233,4 +232,10 @@ extension AudioConfigSection {
             }
         }
     }
+}
+
+/// What the audio troubleshooting sheet is built from.
+struct AudioWizardPresentation: Identifiable {
+    let id = UUID()
+    let engine: AudioTroubleshootingEngine
 }

--- a/Whisky/Views/Bottle/ConfigView.swift
+++ b/Whisky/Views/Bottle/ConfigView.swift
@@ -36,11 +36,8 @@ struct ConfigView: View {
     @State private var dpiSheetPresented: Bool = false
     @State private var showStabilityDiagnostics: Bool = false
     @State private var stabilityDiagnosticReport: String = ""
-    @State private var showDiagnosticExportSheet: Bool = false
-    @State private var showCrashDiagnosticsSheet: Bool = false
-    @State private var latestDiagnosis: CrashDiagnosis?
-    @State private var latestDiagnosisLogText: String = ""
-    @State private var latestDiagnosisProgram: Program?
+    @State private var exportPresentation: ExportPresentation?
+    @State private var crashPresentation: BottleDiagnosisPresentation?
     @State private var isRepairingPrefix: Bool = false
     @State private var prefixRepairResult: PrefixRepairResult?
     @State private var gameConfigSnapshot: GameConfigSnapshot?
@@ -118,7 +115,7 @@ struct ConfigView: View {
                 Button("Export Diagnostic Report\u{2026}") {
                     loadLatestDiagnosisAndExport()
                 }
-                .disabled(latestDiagnosis == nil && mostRecentlyDiagnosedProgram == nil)
+                .disabled(mostRecentlyDiagnosedProgram == nil)
 
                 Button("View Latest Diagnosis") {
                     loadLatestDiagnosisAndView()
@@ -197,28 +194,26 @@ struct ConfigView: View {
                 defaultFilenamePrefix: "whisky-stability-diagnostics"
             )
         }
-        .sheet(isPresented: $showDiagnosticExportSheet) {
-            if let diagnosis = latestDiagnosis, let program = latestDiagnosisProgram {
-                DiagnosticExportSheet(
-                    diagnosis: diagnosis,
-                    bottle: bottle,
-                    program: program,
-                    logFileURL: program.settings.lastLogFileURL
-                )
-            }
+        // Both item-based: presenting on a flag while the content reads a
+        // separate optional can build the sheet before the diagnosis lands.
+        .sheet(item: $exportPresentation) { presentation in
+            DiagnosticExportSheet(
+                diagnosis: presentation.diagnosis,
+                bottle: bottle,
+                program: presentation.program,
+                logFileURL: presentation.program.settings.lastLogFileURL
+            )
         }
-        .sheet(isPresented: $showCrashDiagnosticsSheet) {
-            if let diagnosis = latestDiagnosis, let program = latestDiagnosisProgram {
-                DiagnosticsView(
-                    diagnosis: diagnosis,
-                    logText: latestDiagnosisLogText,
-                    programName: program.name,
-                    bottleName: bottle.settings.name,
-                    timestamp: program.settings.lastDiagnosisDate ?? Date(),
-                    applyBottle: bottle
-                )
-                .frame(minWidth: 600, minHeight: 400)
-            }
+        .sheet(item: $crashPresentation) { presentation in
+            DiagnosticsView(
+                diagnosis: presentation.diagnosis,
+                logText: presentation.logText,
+                programName: presentation.program.name,
+                bottleName: bottle.settings.name,
+                timestamp: presentation.program.settings.lastDiagnosisDate ?? Date(),
+                applyBottle: bottle
+            )
+            .frame(minWidth: 600, minHeight: 400)
         }
         .alert(item: $prefixRepairResult) { result in
             switch result {
@@ -447,9 +442,7 @@ extension ConfigView {
         else { return }
         Task {
             guard let diagnosis = await Wine.classifyLastRun(logFileURL: logURL, exitCode: 1) else { return }
-            latestDiagnosis = diagnosis
-            latestDiagnosisProgram = program
-            showDiagnosticExportSheet = true
+            exportPresentation = ExportPresentation(diagnosis: diagnosis, program: program)
         }
     }
 
@@ -459,12 +452,29 @@ extension ConfigView {
         else { return }
         Task {
             guard let diagnosis = await Wine.classifyLastRun(logFileURL: logURL, exitCode: 1) else { return }
-            latestDiagnosis = diagnosis
-            latestDiagnosisProgram = program
-            latestDiagnosisLogText = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
-            showCrashDiagnosticsSheet = true
+            crashPresentation = BottleDiagnosisPresentation(
+                diagnosis: diagnosis,
+                program: program,
+                logText: (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+            )
         }
     }
+}
+
+/// What the export sheet is exporting; `Identifiable` so `.sheet(item:)`
+/// never presents without both a diagnosis and its program.
+struct ExportPresentation: Identifiable {
+    let id = UUID()
+    let diagnosis: CrashDiagnosis
+    let program: Program
+}
+
+/// What the bottle-level diagnostics sheet is showing.
+struct BottleDiagnosisPresentation: Identifiable {
+    let id = UUID()
+    let diagnosis: CrashDiagnosis
+    let program: Program
+    let logText: String
 }
 
 // swiftlint:enable file_length

--- a/Whisky/Views/Diagnostics/DiagnosisHistoryView.swift
+++ b/Whisky/Views/Diagnostics/DiagnosisHistoryView.swift
@@ -50,6 +50,11 @@ struct DiagnosisHistoryView: View {
             loadHistory()
             selectedPreset = program.settings.activeWineDebugPreset ?? .normal
         }
+        // A diagnosis recorded while this page is open (the crash banner's
+        // moment) would otherwise not show until the page is reopened.
+        .onReceive(NotificationCenter.default.publisher(for: .crashDiagnosisAvailable)) { _ in
+            loadHistory()
+        }
     }
 }
 

--- a/Whisky/Views/Diagnostics/DiagnosisHistoryView.swift
+++ b/Whisky/Views/Diagnostics/DiagnosisHistoryView.swift
@@ -81,6 +81,9 @@ extension DiagnosisHistoryView {
                     onAnalyzeLastRun()
                 }
                 .buttonStyle(.bordered)
+                // Analysis reads the last run's log; before the first run the
+                // button would otherwise click through to nothing.
+                .disabled(program.settings.lastLogFileURL == nil)
             }
         }
         .frame(maxWidth: .infinity)

--- a/Whisky/Views/Diagnostics/DiagnosticsView.swift
+++ b/Whisky/Views/Diagnostics/DiagnosticsView.swift
@@ -35,6 +35,8 @@ struct DiagnosticsView: View {
     /// `onAction` still wins. Without either, the cards have no Apply.
     var applyBottle: Bottle?
 
+    @Environment(\.dismiss) private var dismiss
+
     @State private var applyFeedback: String?
     @State private var activeCategoryFilter: CrashCategory?
     @State private var searchText: String = ""
@@ -43,7 +45,9 @@ struct DiagnosticsView: View {
     @State private var isOtherSuggestionsExpanded: Bool = false
 
     private var effectiveOnAction: ((RemediationAction) -> Void)? {
-        if let onAction { return onAction }
+        if let onAction {
+            return onAction
+        }
         guard let applyBottle else { return nil }
         return { action in
             RemediationExecutor.apply(action, to: applyBottle) { message in
@@ -75,12 +79,25 @@ struct DiagnosticsView: View {
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            if geometry.size.width >= 700 {
-                splitLayout
-            } else {
-                verticalLayout
+        VStack(spacing: 0) {
+            GeometryReader { geometry in
+                if geometry.size.width >= 700 {
+                    splitLayout
+                } else {
+                    verticalLayout
+                }
             }
+
+            Divider()
+
+            // Every presentation of this view is a sheet, and a sheet with no
+            // control of its own can only be left through the cancel chord.
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding(12)
         }
     }
 

--- a/Whisky/Views/Programs/ProgramOverrideSettingsView.swift
+++ b/Whisky/Views/Programs/ProgramOverrideSettingsView.swift
@@ -33,9 +33,7 @@ struct ProgramOverrideSettingsView: View {
     @Binding var isExpanded: Bool
 
     @State private var showResetConfirmation = false
-    @State private var showDiagnosticsSheet = false
-    @State private var activeDiagnosis: CrashDiagnosis?
-    @State private var activeLogText: String = ""
+    @State private var diagnosisPresentation: DiagnosisPresentation?
     @State private var gameMatch: MatchResult?
     @State private var showGameConfigDetail: Bool = false
     @State private var recommendedDependencies: [DependencyDefinition] = []
@@ -66,18 +64,19 @@ struct ProgramOverrideSettingsView: View {
                         .frame(minWidth: 600, minHeight: 500)
                 }
             }
-            .sheet(isPresented: $showDiagnosticsSheet) {
-                if let diagnosis = activeDiagnosis {
-                    DiagnosticsView(
-                        diagnosis: diagnosis,
-                        logText: activeLogText,
-                        programName: program.name,
-                        bottleName: bottle.settings.name,
-                        timestamp: Date(),
-                        applyBottle: bottle
-                    )
-                    .frame(minWidth: 600, minHeight: 400)
-                }
+            // Item-based so the sheet is built from the value that presents it.
+            // With isPresented plus a separate optional, the content closure can
+            // evaluate before the diagnosis lands and presents an empty sheet.
+            .sheet(item: $diagnosisPresentation) { presentation in
+                DiagnosticsView(
+                    diagnosis: presentation.diagnosis,
+                    logText: presentation.logText,
+                    programName: program.name,
+                    bottleName: bottle.settings.name,
+                    timestamp: Date(),
+                    applyBottle: bottle
+                )
+                .frame(minWidth: 600, minHeight: 400)
             }
             .sheet(item: $dependencyToInstall) { definition in
                 DependencyInstallSheet(definition: definition, bottle: bottle)
@@ -122,9 +121,10 @@ struct ProgramOverrideSettingsView: View {
                 exitCode: 1
             )
             else { return }
-            activeLogText = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
-            activeDiagnosis = diagnosis
-            showDiagnosticsSheet = true
+            diagnosisPresentation = DiagnosisPresentation(
+                diagnosis: diagnosis,
+                logText: (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+            )
         }
     }
 
@@ -136,9 +136,10 @@ struct ProgramOverrideSettingsView: View {
                 exitCode: 1
             )
             else { return }
-            activeLogText = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
-            activeDiagnosis = diagnosis
-            showDiagnosticsSheet = true
+            diagnosisPresentation = DiagnosisPresentation(
+                diagnosis: diagnosis,
+                logText: (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+            )
         }
     }
 
@@ -913,3 +914,11 @@ struct ProgramOverrideSettingsView: View {
 }
 
 // swiftlint:enable type_body_length
+
+/// What a diagnostics sheet is showing; `Identifiable` so it can drive
+/// `.sheet(item:)` and the sheet is never presented without a diagnosis.
+struct DiagnosisPresentation: Identifiable {
+    let id = UUID()
+    let diagnosis: CrashDiagnosis
+    let logText: String
+}

--- a/WhiskyKit/Sources/WhiskyKit/Extensions/Program+Extensions.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Extensions/Program+Extensions.swift
@@ -149,7 +149,9 @@ public extension Program {
                 // Checked after the scan, so a crash written between the last
                 // scan and the wineserver going down still gets one look.
                 let running = await Wine.isWineserverRunning(for: bottle)
-                if !running { return }
+                if !running {
+                    return
+                }
             }
         }
     }
@@ -217,8 +219,10 @@ public extension Program {
             history.append(entry)
             try? history.save(to: historyURL)
 
-            // Update lastDiagnosisDate on the main actor
+            // Stamp the program so the bottle's diagnostics buttons know there
+            // is something to show; without it they never enable.
             await MainActor.run {
+                self.settings.lastDiagnosisDate = entry.timestamp
                 // Post notification for the UI to react
                 NotificationCenter.default.post(
                     name: .crashDiagnosisAvailable,

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -645,6 +645,33 @@ public class Wine {
         }
     }
 
+    /// Kills a bottle's wineserver and blocks until the kill command returns.
+    ///
+    /// For `applicationWillTerminate`: a `Task` queued there never runs
+    /// because the process exits as soon as the delegate returns, so the
+    /// asynchronous ``killBottle(bottle:)`` left every Wine process alive
+    /// on quit whatever the kill-on-quit setting said.
+    @MainActor
+    public static func killBottleAndWait(bottle: Bottle, timeout: TimeInterval = 5) {
+        let process = Process()
+        process.executableURL = wineserverBinary
+        process.arguments = ["-k"]
+        process.currentDirectoryURL = wineserverBinary.deletingLastPathComponent()
+        process.environment = constructWineEnvironment(for: bottle, environment: [:])
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            Logger.wineKit.error("Failed to kill bottle '\(bottle.settings.name)': \(error.localizedDescription)")
+            return
+        }
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+    }
+
     /// Installs DXVK libraries into a bottle's Windows system directories.
     ///
     /// DXVK translates DirectX 9/10/11 calls to Vulkan, often providing better


### PR DESCRIPTION
Findings from a local smoke run of main on a fresh bottle before cutting 3.7.0. All nine are pre-existing (they date back to the v1.0 tree), but they sit on paths the 3.7.0 changelog advertises, so they should not ship again.

## What was broken

1. **Raw localization keys.** Five labels interpolate a value and the catalog only carried the plain key, so SwiftUI rendered `config.graphics.currentlyUsing`, `config.virtualDesktop.matchDisplay`, `console.exitCode`, and friends verbatim. The `%@` / `%lld` catalog forms are added at their sorted positions (en + en-GB, no re-serialization).
2. **Empty diagnostics sheet.** `Analyze last run` and `View Latest Diagnosis` used `.sheet(isPresented:)` with the content closure reading a separate optional. SwiftUI can evaluate that closure before the value lands, which presents a small blank sheet. Both are `.sheet(item:)` now, so the sheet is built from the value that presents it.
3. **Export and view buttons never enabled.** Both gate on `lastDiagnosisDate`, and nothing ever set it. `triggerCrashClassification` stamps it when it records a diagnosis, so the ZIP export is reachable.
4. **No way to close the diagnosis sheet.** Every presentation of `DiagnosticsView` is a sheet and it had no control of its own; the only exit was cmd-period. It has a Done button on the cancel action, matching the other sheets.
5. **"Analyze last run" did nothing before the first run.** The handler guards on `lastLogFileURL` and returned silently. The button is disabled until a log exists.
6. **A bottle created in-session lost its first pin from the library, Dock menu, and menu bar extra.** `createNewBottle` cleared `inFlight` and then called `loadBottles()`, which only keeps in-flight instances, so the selected bottle page kept writing to an instance `BottleVM` no longer held. Reproduced twice (pin on disk, "No pinned programs" in the extra, no card on the page) and gone after the fix: the reload runs while the bottle is still in flight and the kept instance is marked available.
7. **Kill-on-quit never fired.** Two causes, both pre-existing. The Settings toggle is `@AppStorage("killOnTerminate") = true`, which never writes its default, and the handler read it with `bool(forKey:)`, which reports an absent key as off: for anyone who never touched the toggle the setting was silently off. Behind that, `applicationWillTerminate` queued `wineserver -k` in a `Task` and the process exited before it ran. Verified with a running wordpad surviving quit before the fix. The read mirrors the AppStorage default now and a synchronous `killBottleAndWait` runs from the handler.
8. **Audio Troubleshooting opened as an empty sheet.** Same `isPresented` plus separate optional race as the diagnosis sheet; presented from the engine now.
9. **Crash diagnosis history did not refresh in place.** The list loaded on appear only; it reloads on `.crashDiagnosisAvailable`.

## Verification

Second round (same Release build recipe, throwaway bottles only): crash classification end to end via the late-crash path (banner, View Diagnosis, history, "Last analyzed", export enabled), redacted ZIP (`"arguments": "-token <redacted>"`, `/Users/<redacted>`, no token anywhere) and the sensitive variant with the raw value, remediation card apply, menu bar extra launch of a pin, test tone (`WhiskyAudioTest.exe --beep` returned `status: ok`), and the in-session bottle pin before and after the fix.

- Release build, fresh bottle: the five labels render, both diagnostics buttons open a sheet with content (or the "No diagnosis available" state), Done dismisses it, export/view enable after a diagnosis is recorded.
- Existing bottles untouched (metadata and `user.reg` hashes identical before and after).
- `swift test --package-path WhiskyKit` green; pinned SwiftFormat 0.58.7 lint and `swiftlint --strict` clean; `british-english.py --check` passes.