### PR TITLE
fix: terminal quoting and the guided troubleshooting dead end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "Audio Troubleshooting" no longer opens as a small empty sheet. Same cause
   as the diagnosis sheet: presented on a flag while the content read a
   separate optional; it is presented from the engine itself now.
+- The bottle's Terminal button works for bottles whose name contains a space.
+  The name was backslash-escaped inside double quotes, so the shell passed
+  the backslashes through and WhiskyCmd reported that no such bottle exists.
+- Guided troubleshooting no longer dead-ends on a findings card. Info steps
+  such as "Missing dependencies found" only carry a Continue transition, and
+  nothing followed it; the wizard now shows a Continue button there, and Skip
+  moves on as well.
 - Diagnostic exports with "Include sensitive details" off no longer carry
   credentials in plain sight. Launch arguments were written to the archive
   verbatim regardless of the toggle, and log redaction only rewrote the home

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   such as "Missing dependencies found" only carry a Continue transition, and
   nothing followed it; the wizard now shows a Continue button there, and Skip
   moves on as well.
+- Guided troubleshooting no longer reports "Problem resolved" when it has
+  run out of automated steps. The flows' escalation node shares the export
+  phase with the resolved node, and the wizard drew both the same way; a node
+  that hands off to the escalation fragment now shows the escalation screen
+  with its export and retry options.
 - Diagnostic exports with "Include sensitive details" off no longer carry
   credentials in plain sight. Launch arguments were written to the archive
   verbatim regardless of the toggle, and log redaction only rewrote the home

--- a/Whisky/Extensions/Bottle+Extensions.swift
+++ b/Whisky/Extensions/Bottle+Extensions.swift
@@ -62,9 +62,14 @@ extension Bottle {
     func openTerminal() {
         guard let whiskyCmdURL = Bundle.main.url(forResource: "WhiskyCmd", withExtension: nil) else { return }
 
-        // Build a shell command that sources the WhiskyCmd environment
-        // Use .esc to escape shell metacharacters and prevent command injection
-        let command = "eval \"$(\"\(whiskyCmdURL.esc)\" shellenv \"\(settings.name.esc)\")\""
+        // Build a shell command that sources the WhiskyCmd environment.
+        // Single-quoted through ShellQuoting: `.esc` backslash-escapes spaces,
+        // and inside double quotes bash keeps those backslashes, so any bottle
+        // name with a space reached WhiskyCmd as `QA\ Smoke` and failed to
+        // resolve.
+        let whiskyCmd = whiskyCmdURL.path(percentEncoded: false)
+        let shellenv = ShellQuoting.commandLine([whiskyCmd, "shellenv", settings.name])
+        let command = "eval \"$(\(shellenv))\""
         let scriptContent = "#!/bin/bash\n\(command)\n"
 
         // Write to temp script file to handle all terminal apps consistently

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -95267,6 +95267,22 @@
         }
       }
     },
+    "troubleshooting.wizard.continue" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
+          }
+        }
+      }
+    },
     "troubleshooting.wizard.runningChecks" : {
       "localizations" : {
         "en" : {

--- a/Whisky/Views/Troubleshooting/TroubleshootingWizardView.swift
+++ b/Whisky/Views/Troubleshooting/TroubleshootingWizardView.swift
@@ -105,6 +105,10 @@ extension TroubleshootingWizardView {
                     .disabled(engine.session.stepHistory.count <= 1)
                 Button("troubleshooting.wizard.skip") { engine.skipStep() }
                     .disabled(engine.currentNode == nil)
+                if engine.canContinue {
+                    Button("troubleshooting.wizard.continue") { engine.continueStep() }
+                        .keyboardShortcut(.defaultAction)
+                }
             }
         }
         .padding(.horizontal, 16)

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingFlowEngine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingFlowEngine.swift
@@ -348,10 +348,34 @@ public final class TroubleshootingFlowEngine: ObservableObject {
     /// Skips the current step, navigating to the "skipped" or "default" target.
     ///
     /// Per the locked "skip for now" decision, users can skip any step.
+    /// Whether the current node has a `continue` transition, which is how an
+    /// info node hands over to the next step.
+    public var canContinue: Bool {
+        currentNode?.on?["continue"] != nil
+    }
+
+    /// Follows the current node's `continue` transition.
+    ///
+    /// Info nodes (a findings card between a check and its fix) only carry
+    /// this transition. Nothing followed it, so every flow that reached one
+    /// stopped there with Skip and Back as the only controls.
+    public func continueStep() {
+        guard let node = currentNode else { return }
+
+        if let nextNodeId = node.on?["continue"] ?? node.on?["default"] {
+            logger.debug("Continuing from step \(node.id) -> \(nextNodeId)")
+            session.recordBranch(from: node.id, targetNodeId: nextNodeId, reason: "Continue")
+            navigateToNode(nextNodeId)
+        } else {
+            logger.warning("No continue target for node \(node.id)")
+        }
+    }
+
     public func skipStep() {
         guard let node = currentNode else { return }
 
-        if let nextNodeId = node.on?["skipped"] ?? node.on?["default"] {
+        // `continue` is the fallback: skipping an info node means moving on.
+        if let nextNodeId = node.on?["skipped"] ?? node.on?["default"] ?? node.on?["continue"] {
             logger.debug("Skipping step \(node.id) -> \(nextNodeId)")
             navigateToNode(nextNodeId)
         } else {

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingFlowEngine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingFlowEngine.swift
@@ -175,6 +175,16 @@ public final class TroubleshootingFlowEngine: ObservableObject {
             return
         }
 
+        // A flow's own hand-off to the escalation fragment. Every flow ends
+        // its unresolved branch on an info node that references it, tagged
+        // with the export phase like the resolved node, so without this the
+        // wizard showed "Problem resolved" to someone it had given up on.
+        if node.fragmentRef == "export-escalation" {
+            logger.debug("Node \(node.id) hands off to the escalation fragment")
+            escalate()
+            return
+        }
+
         // Cycle protection
         let isUserInteraction = node.type == .fix || node.type == .verify
         if isUserInteraction {
@@ -360,27 +370,24 @@ public final class TroubleshootingFlowEngine: ObservableObject {
     /// this transition. Nothing followed it, so every flow that reached one
     /// stopped there with Skip and Back as the only controls.
     public func continueStep() {
-        guard let node = currentNode else { return }
-
-        if let nextNodeId = node.on?["continue"] ?? node.on?["default"] {
-            logger.debug("Continuing from step \(node.id) -> \(nextNodeId)")
-            session.recordBranch(from: node.id, targetNodeId: nextNodeId, reason: "Continue")
-            navigateToNode(nextNodeId)
-        } else {
-            logger.warning("No continue target for node \(node.id)")
-        }
+        follow(["continue", "default"], reason: "Continue")
     }
 
+    /// Skips the current step. `continue` is the last fallback: skipping an
+    /// info node means moving on.
     public func skipStep() {
-        guard let node = currentNode else { return }
+        follow(["skipped", "default", "continue"], reason: "Skip")
+    }
 
-        // `continue` is the fallback: skipping an info node means moving on.
-        if let nextNodeId = node.on?["skipped"] ?? node.on?["default"] ?? node.on?["continue"] {
-            logger.debug("Skipping step \(node.id) -> \(nextNodeId)")
-            navigateToNode(nextNodeId)
-        } else {
-            logger.warning("No skip target for node \(node.id)")
+    private func follow(_ keys: [String], reason: String) {
+        guard let node = currentNode else { return }
+        guard let nextNodeId = keys.lazy.compactMap({ node.on?[$0] }).first else {
+            logger.warning("No \(reason) target for node \(node.id)")
+            return
         }
+        logger.debug("\(reason): step \(node.id) -> \(nextNodeId)")
+        session.recordBranch(from: node.id, targetNodeId: nextNodeId, reason: reason)
+        navigateToNode(nextNodeId)
     }
 
     /// Goes back to the previous step in the history.

--- a/WhiskyKit/Tests/WhiskyKitTests/TroubleshootingFlowEngineTransitionTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/TroubleshootingFlowEngineTransitionTests.swift
@@ -1,0 +1,101 @@
+//
+//  TroubleshootingFlowEngineTransitionTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+/// Transitions the wizard drives by hand: Continue on an info node, Skip's
+/// fallback to it, and the hand-off to the escalation fragment.
+@MainActor
+final class TroubleshootingFlowEngineTransitionTests: XCTestCase {
+    private func infoNode(
+        _ nodeId: String,
+        phase: FlowPhase = .checks,
+        transitions: [String: String]? = nil,
+        fragmentRef: String? = nil
+    ) -> FlowStepNode {
+        FlowStepNode(
+            id: nodeId, type: .info, phase: phase, title: "Info \(nodeId)", on: transitions, fragmentRef: fragmentRef
+        )
+    }
+
+    private func makeEngine(
+        nodes: [String: FlowStepNode],
+        fragments: [String: FlowDefinition] = [:]
+    ) -> TroubleshootingFlowEngine {
+        let flow = FlowDefinition(version: 1, categoryId: "graphics", nodes: nodes, entryNodeId: "start")
+        var session = TroubleshootingSession(bottleURL: URL(filePath: "/tmp/engine-transition-test-bottle"))
+        session.currentFlowCategoryId = "graphics"
+        return TroubleshootingFlowEngine(
+            flowDefinitions: ["graphics": flow],
+            fragments: fragments,
+            checkRegistry: CheckRegistry(),
+            sessionStore: SpySessionStore(),
+            session: session
+        )
+    }
+
+    func testContinueFollowsTheInfoNodeTransition() {
+        let engine = makeEngine(nodes: [
+            "start": infoNode("start", transitions: ["continue": "next"]),
+            "next": infoNode("next")
+        ])
+
+        engine.navigateToNode("start")
+        XCTAssertTrue(engine.canContinue)
+
+        engine.continueStep()
+
+        XCTAssertEqual(engine.currentNode?.id, "next")
+        XCTAssertFalse(engine.canContinue)
+    }
+
+    func testSkipFallsBackToTheContinueTransition() {
+        let engine = makeEngine(nodes: [
+            "start": infoNode("start", transitions: ["continue": "next"]),
+            "next": infoNode("next")
+        ])
+
+        engine.navigateToNode("start")
+        engine.skipStep()
+
+        XCTAssertEqual(engine.currentNode?.id, "next")
+    }
+
+    func testNodeReferencingTheEscalationFragmentEscalates() {
+        let fragment = FlowDefinition(
+            version: 1,
+            categoryId: "export-escalation",
+            nodes: ["export-start": infoNode("export-start", phase: .export)],
+            entryNodeId: "export-start"
+        )
+        let engine = makeEngine(
+            nodes: [
+                "start": infoNode("start", transitions: ["continue": "escalate"]),
+                "escalate": infoNode("escalate", phase: .export, fragmentRef: "export-escalation")
+            ],
+            fragments: ["export-escalation": fragment]
+        )
+
+        engine.navigateToNode("start")
+        engine.continueStep()
+
+        XCTAssertEqual(engine.session.phase, .escalation)
+        XCTAssertEqual(engine.currentNode?.id, "export-start")
+    }
+}


### PR DESCRIPTION
Third round of the local release smoke run (Release build, throwaway bottles), following #245. All three findings are pre-existing and both sit on paths the 3.7.0 changelog touches (the winetricks quoting fix in #242, the troubleshooting fixes in #213).

## What was broken

1. **Terminal button fails for bottle names with a space.** `openTerminal` built `eval "$("<cmd>" shellenv "<name>")"` with `.esc`, which backslash-escapes spaces. Inside double quotes bash keeps the backslash, so WhiskyCmd received `QA\ Smoke\ 7\ Copy` and printed "A bottle with that name doesn't exist." Reproduced through Terminal.app; `WhiskyCmd shellenv "QA Smoke 7 Copy"` works when called directly. The command is now assembled with `ShellQuoting.commandLine`.
2. **Guided troubleshooting dead-ends on info nodes.** In `install-dependencies.json` the entry check fails into `show_missing_deps`, whose only transition is `continue`. Nothing in the engine or the wizard follows a `continue` transition and Skip only looks at `skipped`/`default`, so the wizard sat on "Missing dependencies found" with Back as the only working control. The same shape exists in five of the eight flows. `TroubleshootingFlowEngine.continueStep()` follows it, the toolbar shows a Continue button (default action) when the node has one, and Skip falls back to `continue`.

3. **The wizard says "Problem resolved" after giving up.** Every flow ends its unresolved branch on an info node tagged `phase: export` (the same phase as `resolved`) with `fragmentRef: export-escalation`, and the wizard renders every export-phase node as the resolved summary. Walked the dependency flow to its end: findings, findings, game-config check, then a green "Problem resolved" for a bottle nothing had been fixed in. A node referencing the escalation fragment now routes through `escalate()`, which lands on the escalation screen with its export and retry options. Skip and Continue share one transition helper; three engine tests cover Continue, the Skip fallback, and the hand-off.

## Verification

- Terminal.app: bottle "QA Smoke 7 Copy", Terminal button, the tab shows the shellenv exports instead of the error.
- Wizard: Install / dependency problems on a program with a dependency-loading diagnosis, Continue on the findings card reaches the Fix step.
- Wizard end state: the same walk now ends on the escalation screen.
- Kit troubleshooting and quoting suites green (21 engine tests incl. the 3 new ones); SwiftFormat 0.58.7 lint and SwiftLint strict clean; en-GB check passes (new key `troubleshooting.wizard.continue`).