### PR TITLE
fix: the remaining findings from the release smoke run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   phase with the resolved node, and the wizard drew both the same way; a node
   that hands off to the escalation fragment now shows the escalation screen
   with its export and retry options.
+- Applying a game configuration now sets the graphics backend it lists. The
+  entry's legacy DXVK flag was written after the backend and its "off" value
+  meant "back to Recommended", so every apply ended on Recommended while the
+  toast said it had applied. The preview also no longer lists Sequoia
+  Compatibility Mode, a setting that no longer exists.
+- Export as Archive writes the bottle as `<folder>/...` entries instead of
+  its absolute path, so the archive no longer carries the user's home
+  directory name and extracts where it is opened. Neither export carries
+  AppleDouble `._` files any more.
+- The Duplicate Bottle sheet's confirm button says Duplicate, not Rename.
+- Guided troubleshooting's install step names the verb it will install after
+  a resumed session, and its game-database check sees the program the wizard
+  was opened from.
+- Cancelling a dependency install stops it. Cancel only closed the sheet,
+  leaving winetricks and the installer it had spawned running in the bottle;
+  it now cancels the install and ends the bottle's Wine processes.
 - Diagnostic exports with "Include sensitive details" off no longer carry
   credentials in plain sight. Launch arguments were written to the archive
   verbatim regardless of the toggle, and log redaction only rewrote the home
@@ -139,7 +155,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   -2147483648 no longer crashes Whisky while the library renders its icon.
   The parser took the absolute value of that height before checking its
   range, and that value has no absolute value in 32 bits.
-||||||| parent of a96a2bb8 (fix(diagnostics): scrub credential shapes from exported arguments and logs)
 - Installing the Visual C++ Runtime from the Dependencies panel no longer
   fails silently on a stale checksum. Microsoft rotates the vc_redist
   binaries in place, so the SHA256 sums pinned in the bundled winetricks go

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -47474,6 +47474,22 @@
         }
       }
     },
+    "duplicate.bottle.confirm" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplicate"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplicate"
+          }
+        }
+      }
+    },
     "duplicate.bottle.title" : {
       "localizations" : {
         "ar" : {

--- a/Whisky/Utils/Winetricks+Install.swift
+++ b/Whisky/Utils/Winetricks+Install.swift
@@ -58,9 +58,12 @@ extension Winetricks {
         timeout: TimeInterval = 600
     ) -> AsyncStream<WinetricksInstallProgress> {
         AsyncStream { continuation in
-            Task {
+            let task = Task {
                 await executeVerbInstall(verb, for: bottle, timeout: timeout, continuation: continuation)
             }
+            // A consumer that stops iterating (the install sheet's Cancel)
+            // cancels the install rather than leaving it running headless.
+            continuation.onTermination = { _ in task.cancel() }
         }
     }
 
@@ -79,14 +82,15 @@ extension Winetricks {
         for bottle: Bottle
     ) -> AsyncStream<(verb: String, progress: WinetricksInstallProgress)> {
         AsyncStream { continuation in
-            Task {
-                for verb in verbs {
+            let task = Task {
+                for verb in verbs where !Task.isCancelled {
                     for await progress in installVerb(verb, for: bottle) {
                         continuation.yield((verb: verb, progress: progress))
                     }
                 }
                 continuation.finish()
             }
+            continuation.onTermination = { _ in task.cancel() }
         }
     }
 
@@ -191,7 +195,14 @@ extension Winetricks {
             return
         }
 
-        await awaitProcessCompletion(process, verb: verb, timeout: timeout)
+        await withTaskCancellationHandler {
+            await awaitProcessCompletion(process, verb: verb, timeout: timeout)
+        } onCancel: {
+            if process.isRunning {
+                logger.info("winetricks install '\(verb)' cancelled, terminating")
+                process.terminate()
+            }
+        }
         stdoutPipe.fileHandleForReading.readabilityHandler = nil
         stderrPipe.fileHandleForReading.readabilityHandler = nil
 

--- a/Whisky/Views/Bottle/BottleListEntry.swift
+++ b/Whisky/Views/Bottle/BottleListEntry.swift
@@ -101,7 +101,8 @@ struct BottleListEntry: View {
                 name: BottleOperations.nextDuplicateName(
                     baseName: name,
                     existingNames: BottleVM.shared.bottles.map(\.settings.name)
-                )
+                ),
+                confirmTitle: "duplicate.bottle.confirm"
             ) { newName in
                 Task {
                     do {

--- a/Whisky/Views/Bottle/BottleView.swift
+++ b/Whisky/Views/Bottle/BottleView.swift
@@ -126,7 +126,8 @@ struct BottleView: View {
                     name: BottleOperations.nextDuplicateName(
                         baseName: bottle.settings.name,
                         existingNames: BottleVM.shared.bottles.map(\.settings.name)
-                    )
+                    ),
+                    confirmTitle: "duplicate.bottle.confirm"
                 ) { newName in
                     Task {
                         do {

--- a/Whisky/Views/Common/RenameView.swift
+++ b/Whisky/Views/Common/RenameView.swift
@@ -20,13 +20,20 @@ import SwiftUI
 
 struct RenameView: View {
     let title: Text
+    let confirmTitle: LocalizedStringKey
     var renameAction: (String) -> Void
 
     @State private var name: String = ""
     @Environment(\.dismiss) private var dismiss
 
-    init(_ title: LocalizedStringKey, name: String, renameAction: @escaping (String) -> Void) {
+    init(
+        _ title: LocalizedStringKey,
+        name: String,
+        confirmTitle: LocalizedStringKey = "rename.rename",
+        renameAction: @escaping (String) -> Void
+    ) {
         self.title = Text(title)
+        self.confirmTitle = confirmTitle
         self._name = State(initialValue: name)
         self.renameAction = renameAction
     }
@@ -46,7 +53,7 @@ struct RenameView: View {
                     .keyboardShortcut(.cancelAction)
                 }
                 ToolbarItem(placement: .primaryAction) {
-                    Button("rename.rename") {
+                    Button(confirmTitle) {
                         submit()
                     }
                     .keyboardShortcut(.defaultAction)

--- a/Whisky/Views/Install/DependencyInstallSheet.swift
+++ b/Whisky/Views/Install/DependencyInstallSheet.swift
@@ -31,6 +31,10 @@ struct DependencyInstallSheet: View {
     @ObservedObject var bottle: Bottle
     @Environment(\.dismiss) private var dismiss
 
+    /// The running install, kept so Cancel can stop it. Dismissing the sheet
+    /// alone left winetricks and the redist installer running in the bottle.
+    @State private var installTask: Task<Void, Never>?
+
     @State private var stage: InstallStage = .info
     @State private var logLines: [String] = []
     @State private var isInstalling: Bool = false
@@ -337,6 +341,7 @@ extension DependencyInstallSheet {
         HStack {
             if stage != .verify {
                 Button("Cancel") {
+                    cancelInstall()
                     dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
@@ -395,7 +400,7 @@ extension DependencyInstallSheet {
         isInstalling = true
         logLines = []
 
-        Task {
+        installTask = Task {
             let verbStream = Winetricks.installVerbs(definition.winetricksVerbs, for: bottle)
             var lastExitCode: Int32 = 0
             var hadError = false
@@ -417,6 +422,10 @@ extension DependencyInstallSheet {
                 }
             }
 
+            // Cancelled: the sheet is gone and the processes are being killed;
+            // there is nothing to verify or record.
+            guard !Task.isCancelled else { return }
+
             let result: InstallResult = if hadError {
                 .error("One or more verbs failed")
             } else if lastExitCode == 0 {
@@ -434,6 +443,17 @@ extension DependencyInstallSheet {
             await runVerification()
             await saveInstallAttempt(result)
         }
+    }
+
+    /// Stops a running install. Cancelling the task terminates winetricks
+    /// through the stream, and the bottle's wine processes are killed so the
+    /// redist installer it spawned does not keep running headless.
+    private func cancelInstall() {
+        guard isInstalling else { return }
+        installTask?.cancel()
+        installTask = nil
+        isInstalling = false
+        Wine.killBottle(bottle: bottle)
     }
 
     private func runVerification() async {

--- a/Whisky/Views/Troubleshooting/FixPreviewView.swift
+++ b/Whisky/Views/Troubleshooting/FixPreviewView.swift
@@ -223,11 +223,27 @@ extension FixPreviewView {
     private var resolvedParams: [String: String] {
         var params = node.params ?? [:]
         if node.fixId == "install-winetricks-verb", params["verb"] == nil,
-           let missing = engine.lastCheckResult?.evidence["missing"],
+           let missing = missingVerbsEvidence,
            let first = missing.split(separator: ",").first {
             params["verb"] = first.trimmingCharacters(in: .whitespaces)
         }
         return params
+    }
+
+    /// The `missing` evidence of the most recent check on the path here.
+    ///
+    /// Read from the session rather than `lastCheckResult`: that one is not
+    /// persisted, so a resumed session offered to install "unknown".
+    private var missingVerbsEvidence: String? {
+        if let missing = engine.lastCheckResult?.evidence["missing"] {
+            return missing
+        }
+        for step in engine.session.stepHistory.reversed() {
+            if let missing = engine.session.checkResults[step.nodeId]?.evidence["missing"] {
+                return missing
+            }
+        }
+        return nil
     }
 
     private func loadPreview() {

--- a/WhiskyKit/Sources/WhiskyKit/Diagnostics/DiagnosticExporter.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Diagnostics/DiagnosticExporter.swift
@@ -440,7 +440,7 @@ extension DiagnosticExporter {
         process.arguments = [
             "-c",
             "-k",
-            "--sequesterRsrc",
+            "--norsrc",
             contentDir.path(percentEncoded: false),
             zipURL.path(percentEncoded: false)
         ]

--- a/WhiskyKit/Sources/WhiskyKit/GameDatabase/GameConfigApplicator.swift
+++ b/WhiskyKit/Sources/WhiskyKit/GameDatabase/GameConfigApplicator.swift
@@ -227,7 +227,7 @@ public enum GameConfigApplicator {
             ))
         }
 
-        if let dxvk = settings.dxvk, dxvk != bottle.settings.dxvk {
+        if settings.graphicsBackend == nil, let dxvk = settings.dxvk, dxvk != bottle.settings.dxvk {
             changes.append(ConfigChange(
                 category: "Graphics",
                 settingName: "DXVK",
@@ -243,15 +243,6 @@ public enum GameConfigApplicator {
                 settingName: "DXVK Async",
                 currentValue: bottle.settings.dxvkAsync ? "Enabled" : "Disabled",
                 newValue: dxvkAsync ? "Enabled" : "Disabled"
-            ))
-        }
-
-        if let sequoiaCompat = settings.sequoiaCompatMode, sequoiaCompat != bottle.settings.sequoiaCompatMode {
-            changes.append(ConfigChange(
-                category: "Graphics",
-                settingName: "Sequoia Compatibility Mode",
-                currentValue: bottle.settings.sequoiaCompatMode ? "Enabled" : "Disabled",
-                newValue: sequoiaCompat ? "Enabled" : "Disabled"
             ))
         }
 
@@ -370,11 +361,13 @@ public enum GameConfigApplicator {
     /// Applies variant settings to the bottle's settings.
     @MainActor
     private static func applyVariantSettings(_ settings: GameConfigVariantSettings, to bottle: Bottle) {
+        // `dxvk` is the legacy backend switch: its setter maps `false` back to
+        // Recommended, so applying it after an explicit backend undid the
+        // backend. An explicit backend wins; `dxvk` only speaks when there is
+        // none.
         if let graphicsBackend = settings.graphicsBackend {
             bottle.settings.graphicsBackend = graphicsBackend
-        }
-
-        if let dxvk = settings.dxvk {
+        } else if let dxvk = settings.dxvk {
             bottle.settings.dxvk = dxvk
         }
 
@@ -401,10 +394,6 @@ public enum GameConfigApplicator {
 
         if let avxEnabled = settings.avxEnabled {
             bottle.settings.avxEnabled = avxEnabled
-        }
-
-        if let sequoiaCompatMode = settings.sequoiaCompatMode {
-            bottle.settings.sequoiaCompatMode = sequoiaCompatMode
         }
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/Tar.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Tar.swift
@@ -47,7 +47,16 @@ public class Tar {
         let pipe = Pipe()
 
         process.executableURL = tarBinary
-        process.arguments = ["-zcf", "\(toURL.path)", "\(folder.path)"]
+        // Archive the folder by name from its parent so the entries are
+        // `<folder>/...` rather than the absolute path it happened to live at
+        // (which also put the user's home directory name into every export).
+        // COPYFILE_DISABLE keeps bsdtar from adding `._` AppleDouble entries.
+        process.arguments = [
+            "-zcf", toURL.path, "-C", folder.deletingLastPathComponent().path, folder.lastPathComponent
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment["COPYFILE_DISABLE"] = "1"
+        process.environment = environment
         process.standardOutput = pipe
         process.standardError = pipe
 

--- a/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingFlowEngine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Troubleshooting/TroubleshootingFlowEngine.swift
@@ -228,7 +228,11 @@ public final class TroubleshootingFlowEngine: ObservableObject {
                 bottleURL: session.preflightSnapshot?.bottleURL ?? session.bottleURL ?? URL(filePath: "/"),
                 bottleName: session.preflightSnapshot?.bottleName ?? "Unknown",
                 programURL: session.preflightSnapshot?.programURL ?? session.programURL,
-                programName: session.preflightSnapshot?.programName,
+                // The name is what the game-database check matches on; a
+                // wizard opened from a program page has the URL but not always
+                // the name, so fall back to the executable's filename.
+                programName: session.preflightSnapshot?.programName
+                    ?? (session.preflightSnapshot?.programURL ?? session.programURL)?.lastPathComponent,
                 preflight: session.preflightSnapshot ?? PreflightData(
                     bottleURL: session.bottleURL ?? URL(filePath: "/"),
                     bottleName: "Unknown",

--- a/WhiskyKit/Tests/WhiskyKitTests/GameApplicatorTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/GameApplicatorTests.swift
@@ -114,6 +114,23 @@ final class GameApplicatorTests: XCTestCase {
         XCTAssertEqual(loaded?.appliedEntryId, "test-game")
     }
 
+    @MainActor
+    func testExplicitBackendSurvivesTheLegacyDXVKFlag() throws {
+        let bottle = try makeTestBottle()
+        defer { cleanupBottle(bottle) }
+
+        // Real entries pair an explicit backend with `dxvk: false`; the legacy
+        // setter maps that `false` to Recommended, which used to undo the backend.
+        let variant = makeTestVariant(graphicsBackend: .d3dMetal, dxvk: false)
+        let entry = makeTestEntry(variant: variant)
+
+        _ = try GameConfigApplicator.apply(entry: entry, variant: variant, to: bottle)
+
+        XCTAssertEqual(bottle.settings.graphicsBackend, .d3dMetal)
+        let changes = GameConfigApplicator.previewChanges(variant: variant, bottle: bottle)
+        XCTAssertFalse(changes.contains { $0.settingName == "DXVK" }, "no DXVK row when the backend is explicit")
+    }
+
     // MARK: - Test 2: Apply Mutates Bottle Settings
 
     @MainActor

--- a/WhiskyKit/Tests/WhiskyKitTests/TarTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/TarTests.swift
@@ -207,6 +207,29 @@ final class TarIntegrationTests: XCTestCase {
         }
     }
 
+    func testTarEntriesAreRelativeToTheFolder() throws {
+        let sourceDir = tempDir.appendingPathComponent("relative-source")
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try "x".write(to: sourceDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        let tarURL = tempDir.appendingPathComponent("relative.tar.gz")
+
+        try Tar.tar(folder: sourceDir, toURL: tarURL)
+
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        process.arguments = ["-tzf", tarURL.path]
+        process.standardOutput = pipe
+        try process.run()
+        let listing = try String(data: pipe.fileHandleForReading.readToEnd() ?? Data(), encoding: .utf8) ?? ""
+        process.waitUntilExit()
+
+        let entries = listing.split(separator: "\n").map(String.init)
+        XCTAssertTrue(entries.contains("relative-source/file.txt"), "entries: \(entries)")
+        XCTAssertFalse(entries.contains { $0.hasPrefix("/") || $0.hasPrefix("Users/") || $0.hasPrefix("private/") })
+        XCTAssertFalse(entries.contains { $0.contains("._") }, "no AppleDouble entries: \(entries)")
+    }
+
     func testTarWithMultipleFiles() throws {
         try Data("File 1 content".utf8).write(to: sourceDir.appending(path: "file1.txt"))
         try Data("File 2 content".utf8).write(to: sourceDir.appending(path: "file2.txt"))


### PR DESCRIPTION
Fourth and last round from the local release smoke run, covering the findings left open after #245 and #246. All pre-existing.

## What was broken

1. **GameDB apply never set the backend.** `applyVariantSettings` writes `graphicsBackend`, then `dxvk`. `BottleSettings.dxvk` is a legacy accessor whose setter maps `false` to `.recommended`, and real entries pair an explicit backend with `dxvk: false` (Celeste: `d3dMetal` + `dxvk: false`), so the backend was undone one line later while the toast said "Applied Celeste configuration". An explicit backend now wins and the flag is consulted only when there is none; the preview drops the DXVK row in that case and no longer lists Sequoia Compatibility Mode (#216 removed the setting). Test added.
2. **Export as Archive used the absolute path.** `tar -zcf dest /abs/path` produced `Users/<name>/Library/Containers/.../Bottles/<UUID>/...` entries: the export carried the username and extracted into that whole tree. It archives `-C parent <folder>` now, with `COPYFILE_DISABLE=1` so no `._` entries; the diagnostics ZIP passes `--norsrc` to ditto for the same reason. Test added; the untar path is unchanged (it only ever consumed the Libraries tarball, whose entries were already relative).
3. **Install sheet Cancel orphaned the install.** Cancel was a bare `dismiss()`; the winetricks wrapper and `vc_redist.x86.exe` kept running in the bottle. The install is held as a task the sheet cancels, `installVerb`/`installVerbs` cancel their inner task on stream termination, `executeVerbInstall` terminates the process under `withTaskCancellationHandler`, and the sheet kills the bottle's wine processes so the redist child does not survive.
4. **Duplicate Bottle sheet said Rename.** `RenameView` takes a confirm title; the duplicate sheet passes "Duplicate" (new key `duplicate.bottle.confirm`).
5. **Wizard details.** The install step's verb fell back to `lastCheckResult`, which is not persisted, so a resumed session offered "unknown"; it reads the session's check results now. The game-database check needed `programName`, which a wizard opened from a program page did not always carry; the executable filename is used when the snapshot has none.
6. `CHANGELOG.md` carried a `||||||| parent of a96a2bb8 ...` diff3 marker from #243; removed.

## Verification

- Kit: full suite green including the two new tests (explicit backend survives `dxvk: false`; tar entries are `<folder>/...` with no `._` files).
- App: Release build; retested on a throwaway bottle after the build.
- SwiftFormat 0.58.7 lint and SwiftLint strict clean; en-GB check passes.
