### PR TITLE
fix(dxvk): deploy markerless native dxgi into prefix when gptk is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without the D3DMetal payload resolved launchers to DXMT, whose Direct3D
   layer launcher UIs cannot render on, leaving the client running with no
   window (#163).
-- Enabling DXVK now removes a stale native dxgi.dll that a previous DXMT
-  launch left in the bottle's system directories. The leftover paired
-  DXVK's d3d11 with DXMT's dxgi, which cannot create window swapchains,
-  leaving Chromium-based launchers such as Steam running with no window
-  after a switch from DXMT to DXVK (#163).
+- Enabling DXVK now reconciles the bottle's dxgi.dll against the D3DMetal
+  payload. With the payload deployed, the builtin dxgi is Apple's forwarder,
+  which DXVK's d3d11 cannot pair with, so Wine's own backed-up dxgi is
+  installed into system32 with its builtin marker stripped and loads as a
+  true native PE. Without the payload, a stale native dxgi.dll a previous
+  DXMT launch left in the bottle's system directories is removed instead:
+  that leftover paired DXVK's d3d11 with DXMT's dxgi, which cannot create
+  window swapchains, leaving Chromium-based launchers such as Steam running
+  with no window after a switch from DXMT to DXVK (#163).
 - A Visual C++ Runtime whose installer hung under wine after installing
   successfully is now detected. The winetricks.log entry is only written once
   the installer exits, so the Dependencies panel kept saying "Not Installed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Removing a stale native dxgi.dll from a bottle now puts Wine's own marked
+  builtin copy back in its place. Wine's loader only finds a builtin through
+  its system32 placeholder, so an empty slot made `dxgi.dll` unloadable and
+  Chromium's GPU process crash-looped into software rendering, which left
+  Steam's Store, Community and Profile pages black. It only surfaced on a
+  runtime whose wine.inf matched the bottle's update stamp, because every
+  other runtime triggers a prefix update that silently reinstalls the
+  placeholder. That is why it looked like a wine 11.16 regression (#163).
 - The Recommended graphics backend now resolves launchers (Steam and other
   Chromium-based clients) to DXVK on every runtime. Previously a runtime
   without the D3DMetal payload resolved launchers to DXMT, whose Direct3D

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -694,6 +694,10 @@ public class Wine {
             withContentsIn: Wine.dxvkFolder.appending(path: "x32")
         )
         removeStaleNativeDXGI(prefixRoot: bottle.url)
+        // DXVK-macOS ships no dxgi.dll, but when D3DMetal is deployed, the builtin dxgi is Apple's.
+        // Deploy Wine's clean dxgi.dll from the store backup with the 0x40 builtin marker stripped
+        // so it loads as a true native PE when overridden.
+        deployCleanDXGIForDXVK(bottle: bottle)
     }
 
     /// Removes a stale native `dxgi.dll` that a DXMT deploy left in the prefix.
@@ -733,6 +737,39 @@ public class Wine {
                     "Could not remove stale native dxgi.dll: \(error.localizedDescription, privacy: .public)"
                 )
             }
+        }
+    }
+
+    /// Strips the "Wine builtin DLL" marker at offset 0x40 from a PE file.
+    private static func stripBuiltinMarker(at fileURL: URL) throws {
+        guard FileManager.default.fileExists(atPath: fileURL.path(percentEncoded: false)) else { return }
+        let handle = try FileHandle(forUpdating: fileURL)
+        defer { try? handle.close() }
+        let dosCode: [UInt8] = [
+            0x0E, 0x1F, 0xBA, 0x0E, 0x00, 0xB4, 0x09, 0xCD,
+            0x21, 0xB8, 0x01, 0x4C, 0xCD, 0x21, 0x90, 0x90
+        ]
+        try handle.seek(toOffset: 0x40)
+        try handle.write(contentsOf: Data(dosCode))
+    }
+
+    /// Deploys Wine's backed-up native dxgi.dll into the prefix for DXVK bottles.
+    @MainActor
+    static func deployCleanDXGIForDXVK(bottle: Bottle) {
+        let store = GPTKImporter.storeFolder
+        let originals = store.appending(path: "originals")
+        let origDXGI = originals.appending(path: "dxgi.dll")
+        guard FileManager.default.fileExists(atPath: origDXGI.path(percentEncoded: false)) else { return }
+
+        let sys32DXGI = bottle.url.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32").appending(path: "dxgi.dll")
+        do {
+            try FileManager.default.installFile(at: sys32DXGI, from: origDXGI)
+            try stripBuiltinMarker(at: sys32DXGI)
+        } catch {
+            Logger.wineKit.warning(
+                "Could not deploy clean dxgi.dll into prefix: \(error.localizedDescription, privacy: .public)"
+            )
         }
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -722,10 +722,11 @@ public class Wine {
         prefixRoot: URL,
         gptkOriginalsDXGI: URL = GPTKImporter.storeFolder
             .appending(path: "originals").appending(path: "dxgi.dll"),
-        gptkPayloadIsDeployed: Bool = GPTKImporter.isDeployed()
+        gptkPayloadIsDeployed: Bool = GPTKImporter.isDeployed(),
+        libraryFolder: URL = WhiskyWineInstaller.libraryFolder
     ) {
         guard gptkPayloadIsDeployed else {
-            removeStaleNativeDXGI(prefixRoot: prefixRoot)
+            removeStaleNativeDXGI(prefixRoot: prefixRoot, libraryFolder: libraryFolder)
             return
         }
         deployCleanDXGI(prefixRoot: prefixRoot, from: gptkOriginalsDXGI)
@@ -751,9 +752,13 @@ public class Wine {
     /// Whether removal is the right answer at all is decided by
     /// ``reconcileDXGIForDXVK(prefixRoot:gptkOriginalsDXGI:gptkPayloadIsDeployed:)``,
     /// which owns the payload predicate.
-    static func removeStaleNativeDXGI(prefixRoot: URL) {
+    static func removeStaleNativeDXGI(
+        prefixRoot: URL,
+        libraryFolder: URL = WhiskyWineInstaller.libraryFolder
+    ) {
         let fileManager = FileManager.default
-        for dir in ["system32", "syswow64"] {
+        let builtinDirs = ["system32": "x86_64-windows", "syswow64": "i386-windows"]
+        for (dir, arch) in builtinDirs {
             let dxgi = prefixRoot.appending(path: "drive_c").appending(path: "windows")
                 .appending(path: dir).appending(path: "dxgi.dll")
             guard fileManager.fileExists(atPath: dxgi.path(percentEncoded: false)),
@@ -765,6 +770,29 @@ public class Wine {
             } catch {
                 Logger.wineKit.warning(
                     "Could not remove stale native dxgi.dll: \(error.localizedDescription, privacy: .public)"
+                )
+                continue
+            }
+            // The removal must not leave the slot empty. Wine's loader only reaches a
+            // builtin through its system32 placeholder (ntdll/loader.c
+            // find_builtin_without_file refuses every non-16-bit DLL that has no
+            // file), so with nothing here `LoadLibrary("dxgi.dll")` fails outright
+            // and Chromium's GPU process cannot bring up D3D11. wineboot would
+            // reinstall the placeholder on the next prefix update, but a runtime
+            // whose wine.inf matches the prefix stamp never runs one. Put back the
+            // runtime's own marked copy, which is what wineboot installs.
+            let builtin = libraryFolder.appending(path: "Wine").appending(path: "lib")
+                .appending(path: "wine").appending(path: arch).appending(path: "dxgi.dll")
+            guard fileManager.fileExists(atPath: builtin.path(percentEncoded: false)) else {
+                Logger.wineKit.warning("No builtin dxgi.dll to restore into \(dir, privacy: .public)")
+                continue
+            }
+            do {
+                try fileManager.copyItem(at: builtin, to: dxgi)
+                Logger.wineKit.info("Restored builtin dxgi.dll placeholder into \(dir, privacy: .public)")
+            } catch {
+                Logger.wineKit.warning(
+                    "Could not restore builtin dxgi.dll: \(error.localizedDescription, privacy: .public)"
                 )
             }
         }

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -756,6 +756,19 @@ public class Wine {
     /// Deploys Wine's backed-up native dxgi.dll into the prefix for DXVK bottles.
     @MainActor
     static func deployCleanDXGIForDXVK(bottle: Bottle) {
+        // The store outlives an engine install but the deployed payload does not, so a stale
+        // originals/ can belong to a previous engine. Without the payload the builtin is already
+        // Wine's own and there is nothing to work around.
+        guard GPTKImporter.isDeployed() else {
+            // A previous deploy may have left a stripped copy in the prefix. Without the
+            // payload it matches the restored builtin today but will skew after the next
+            // runtime update, so drop it and let the `,b` half load the builtin.
+            let sys32DXGI = bottle.url.appending(path: "drive_c").appending(path: "windows")
+                .appending(path: "system32").appending(path: "dxgi.dll")
+            try? FileManager.default.removeItem(at: sys32DXGI)
+            return
+        }
+
         let store = GPTKImporter.storeFolder
         let originals = store.appending(path: "originals")
         let origDXGI = originals.appending(path: "dxgi.dll")
@@ -771,6 +784,18 @@ public class Wine {
                 "Could not deploy clean dxgi.dll into prefix: \(error.localizedDescription, privacy: .public)"
             )
         }
+    }
+
+    /// Removes a native dxgi.dll from the prefix when GPTK is no longer deployed.
+    /// The stripped copy in system32 is only meaningful while GPTK is active; if GPTK is
+    /// later un-deployed, a leftover native dxgi would keep loading and could diverge from
+    /// the restored builtin after a runtime update.
+    @MainActor
+    static func removeCleanDXGIForDXVK(bottle: Bottle) {
+        let sys32DXGI = bottle.url.appending(path: "drive_c").appending(path: "windows")
+            .appending(path: "system32").appending(path: "dxgi.dll")
+        guard FileManager.default.fileExists(atPath: sys32DXGI.path(percentEncoded: false)) else { return }
+        try? FileManager.default.removeItem(at: sys32DXGI)
     }
 
     /// Errors thrown by ``enableDXMT(bottle:)``.

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -693,14 +693,45 @@ public class Wine {
             in: bottle.url.appending(path: "drive_c").appending(path: "windows").appending(path: "syswow64"),
             withContentsIn: Wine.dxvkFolder.appending(path: "x32")
         )
-        removeStaleNativeDXGI(prefixRoot: bottle.url)
-        // DXVK-macOS ships no dxgi.dll, but when D3DMetal is deployed, the builtin dxgi is Apple's.
-        // Deploy Wine's clean dxgi.dll from the store backup with the 0x40 builtin marker stripped
-        // so it loads as a true native PE when overridden.
-        deployCleanDXGIForDXVK(bottle: bottle)
+        reconcileDXGIForDXVK(prefixRoot: bottle.url)
     }
 
-    /// Removes a stale native `dxgi.dll` that a DXMT deploy left in the prefix.
+    /// Reconciles the prefix's `dxgi.dll` with the GPTK payload state, keyed on
+    /// whether that payload is deployed.
+    ///
+    /// DXVK-macOS ships no `dxgi.dll`, so ``enableDXVK(bottle:)`` never
+    /// overwrites one and whatever the prefix already holds stays behind the
+    /// `n,b` override. Which copy is correct depends entirely on what the
+    /// builtin is right now:
+    ///
+    /// - Payload deployed: the builtin is Apple's D3DMetal forwarder, which
+    ///   cannot pair with DXVK's `d3d11`. The prefix needs Wine's own clean
+    ///   dxgi from the store, marker-stripped so the loader takes it as a true
+    ///   native PE.
+    /// - Payload absent: the builtin is Wine's own, which is the pairing DXVK
+    ///   is written against, so any native copy in the prefix is residue and
+    ///   must go.
+    ///
+    /// The store outlives an engine install but the deployed payload does not,
+    /// so a populated `originals/` alone does not mean the forwarder is in
+    /// place. Keying on the payload rather than the store is what makes the
+    /// stale-store case (originals from a previous engine, payload gone) take
+    /// the removal path instead of deploying a dxgi the current runtime never
+    /// shipped.
+    static func reconcileDXGIForDXVK(
+        prefixRoot: URL,
+        gptkOriginalsDXGI: URL = GPTKImporter.storeFolder
+            .appending(path: "originals").appending(path: "dxgi.dll"),
+        gptkPayloadIsDeployed: Bool = GPTKImporter.isDeployed()
+    ) {
+        guard gptkPayloadIsDeployed else {
+            removeStaleNativeDXGI(prefixRoot: prefixRoot)
+            return
+        }
+        deployCleanDXGI(prefixRoot: prefixRoot, from: gptkOriginalsDXGI)
+    }
+
+    /// Removes a native `dxgi.dll` the prefix must not keep under DXVK.
     ///
     /// DXVK-macOS ships no `dxgi.dll`, so ``enableDXVK(bottle:)`` never
     /// overwrites one. After a bottle has launched under DXMT, its system
@@ -711,18 +742,17 @@ public class Wine {
     /// leftover lets the `,b` half of the override load the builtin, which is
     /// the pairing DXVK is written against.
     ///
-    /// Only the GPTK-less case is handled here: when the importer's
-    /// `originals/` backup exists, the builtin behind `,b` is Apple's
-    /// forwarder and the prefix needs a clean native copy instead, which is
-    /// its own change. A builtin-marked file is never touched: that is wine's
-    /// own fake DLL, exactly what DXVK expects to defer to.
-    static func removeStaleNativeDXGI(
-        prefixRoot: URL,
-        gptkOriginalsDXGI: URL = GPTKImporter.storeFolder
-            .appending(path: "originals").appending(path: "dxgi.dll")
-    ) {
+    /// Both arches are swept, because a DXMT launch writes both and a 32-bit
+    /// title otherwise keeps the bad pairing. A builtin-marked file is never
+    /// touched: that is wine's own fake DLL, exactly what DXVK expects to
+    /// defer to, and leaving it in place is what keeps this off the
+    /// per-launch prefix-mutation path.
+    ///
+    /// Whether removal is the right answer at all is decided by
+    /// ``reconcileDXGIForDXVK(prefixRoot:gptkOriginalsDXGI:gptkPayloadIsDeployed:)``,
+    /// which owns the payload predicate.
+    static func removeStaleNativeDXGI(prefixRoot: URL) {
         let fileManager = FileManager.default
-        guard !fileManager.fileExists(atPath: gptkOriginalsDXGI.path(percentEncoded: false)) else { return }
         for dir in ["system32", "syswow64"] {
             let dxgi = prefixRoot.appending(path: "drive_c").appending(path: "windows")
                 .appending(path: dir).appending(path: "dxgi.dll")
@@ -753,49 +783,26 @@ public class Wine {
         try handle.write(contentsOf: Data(dosCode))
     }
 
-    /// Deploys Wine's backed-up native dxgi.dll into the prefix for DXVK bottles.
-    @MainActor
-    static func deployCleanDXGIForDXVK(bottle: Bottle) {
-        // The store outlives an engine install but the deployed payload does not, so a stale
-        // originals/ can belong to a previous engine. Without the payload the builtin is already
-        // Wine's own and there is nothing to work around.
-        guard GPTKImporter.isDeployed() else {
-            // A previous deploy may have left a stripped copy in the prefix. Without the
-            // payload it matches the restored builtin today but will skew after the next
-            // runtime update, so drop it and let the `,b` half load the builtin.
-            let sys32DXGI = bottle.url.appending(path: "drive_c").appending(path: "windows")
-                .appending(path: "system32").appending(path: "dxgi.dll")
-            try? FileManager.default.removeItem(at: sys32DXGI)
-            return
-        }
+    /// Deploys Wine's backed-up clean `dxgi.dll` into the prefix, with the
+    /// builtin marker stripped so the loader accepts it as a true native PE.
+    ///
+    /// Only `system32` is written: GPTK deploys forwarders into
+    /// `wine/x86_64-windows` only, so the 32-bit builtin is still Wine's own
+    /// and the stored 64-bit original has no business in `syswow64`.
+    static func deployCleanDXGI(prefixRoot: URL, from gptkOriginalsDXGI: URL) {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: gptkOriginalsDXGI.path(percentEncoded: false)) else { return }
 
-        let store = GPTKImporter.storeFolder
-        let originals = store.appending(path: "originals")
-        let origDXGI = originals.appending(path: "dxgi.dll")
-        guard FileManager.default.fileExists(atPath: origDXGI.path(percentEncoded: false)) else { return }
-
-        let sys32DXGI = bottle.url.appending(path: "drive_c").appending(path: "windows")
+        let sys32DXGI = prefixRoot.appending(path: "drive_c").appending(path: "windows")
             .appending(path: "system32").appending(path: "dxgi.dll")
         do {
-            try FileManager.default.installFile(at: sys32DXGI, from: origDXGI)
+            try fileManager.installFile(at: sys32DXGI, from: gptkOriginalsDXGI)
             try stripBuiltinMarker(at: sys32DXGI)
         } catch {
             Logger.wineKit.warning(
                 "Could not deploy clean dxgi.dll into prefix: \(error.localizedDescription, privacy: .public)"
             )
         }
-    }
-
-    /// Removes a native dxgi.dll from the prefix when GPTK is no longer deployed.
-    /// The stripped copy in system32 is only meaningful while GPTK is active; if GPTK is
-    /// later un-deployed, a leftover native dxgi would keep loading and could diverge from
-    /// the restored builtin after a runtime update.
-    @MainActor
-    static func removeCleanDXGIForDXVK(bottle: Bottle) {
-        let sys32DXGI = bottle.url.appending(path: "drive_c").appending(path: "windows")
-            .appending(path: "system32").appending(path: "dxgi.dll")
-        guard FileManager.default.fileExists(atPath: sys32DXGI.path(percentEncoded: false)) else { return }
-        try? FileManager.default.removeItem(at: sys32DXGI)
     }
 
     /// Errors thrown by ``enableDXMT(bottle:)``.

--- a/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/WineDLLOverrideRegistry.swift
@@ -172,13 +172,15 @@ public extension Wine {
         LauncherType.detect(from: url)?.helperExecutables ?? []
     }
 
-    /// Adds `nvapi64=` to an override string, keeping whatever else it holds.
+    /// Adds `nvapi64=`, `nvapi=`, and `nvngx=` to an override string, keeping whatever else it holds.
     ///
     /// - Parameter overrides: A `WINEDLLOVERRIDES`-syntax string, possibly empty.
-    /// - Returns: The same string with nvapi64 disabled.
+    /// - Returns: The same string with NVIDIA bridges disabled.
     static func disablingNVAPI(in overrides: String) -> String {
         var parsed = parseDLLOverrides(overrides)
         parsed["nvapi64"] = ""
+        parsed["nvapi"] = ""
+        parsed["nvngx"] = ""
         return parsed.keys.sorted().map { "\($0)=\(parsed[$0] ?? "")" }.joined(separator: ";")
     }
 

--- a/WhiskyKit/Tests/WhiskyKitTests/NVAPIBridgeTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/NVAPIBridgeTests.swift
@@ -110,11 +110,11 @@ final class NVAPIBridgeTests: XCTestCase {
 
     func testHelpersGetNVAPIDisabledWithoutLosingTheirOtherOverrides() {
         let result = Wine.disablingNVAPI(in: "dxgi=n,b;d3d11=n,b")
-        XCTAssertEqual(result, "d3d11=n,b;dxgi=n,b;nvapi64=")
+        XCTAssertEqual(result, "d3d11=n,b;dxgi=n,b;nvapi=;nvapi64=;nvngx=")
     }
 
     func testDisablingNVAPIOnAnEmptyStringStillDisablesIt() {
-        XCTAssertEqual(Wine.disablingNVAPI(in: ""), "nvapi64=")
+        XCTAssertEqual(Wine.disablingNVAPI(in: ""), "nvapi=;nvapi64=;nvngx=")
     }
 
     /// The regression: a Steam game launch sets `applyToDescendants`, and the

--- a/WhiskyKit/Tests/WhiskyKitTests/WineDXVKResidueTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WineDXVKResidueTests.swift
@@ -68,7 +68,7 @@ final class WineDXVKResidueTests: XCTestCase {
         let bystander = prefixRoot.appending(path: "drive_c/windows/system32/d3d11.dll")
         try nativeFake("dxvk-d3d11").write(to: bystander)
 
-        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot)
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, libraryFolder: noRuntime)
 
         XCTAssertFalse(exists(dxgi("system32")))
         XCTAssertFalse(exists(dxgi("syswow64")))
@@ -80,7 +80,7 @@ final class WineDXVKResidueTests: XCTestCase {
     func testBuiltinMarkedDXGIIsKept() throws {
         try builtinFake("wine-fake").write(to: dxgi("system32"))
 
-        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot)
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, libraryFolder: noRuntime)
 
         XCTAssertTrue(exists(dxgi("system32")))
     }
@@ -88,7 +88,7 @@ final class WineDXVKResidueTests: XCTestCase {
     /// A prefix that never saw DXMT has no dxgi.dll of its own; the removal
     /// must be a silent no-op.
     func testMissingDXGIIsANoOp() {
-        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot)
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, libraryFolder: noRuntime)
 
         XCTAssertFalse(exists(dxgi("system32")))
         XCTAssertFalse(exists(dxgi("syswow64")))
@@ -100,7 +100,7 @@ final class WineDXVKResidueTests: XCTestCase {
     func testTruncatedFileIsLeftAlone() throws {
         try Data("stub".utf8).write(to: dxgi("system32"))
 
-        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot)
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, libraryFolder: noRuntime)
 
         XCTAssertTrue(exists(dxgi("system32")))
     }
@@ -168,20 +168,25 @@ final class WineDXVKResidueTests: XCTestCase {
     /// The stale-store case: `originals/` survives from a previous engine but
     /// the payload is gone, so the builtin is wine's own again and residue in
     /// *both* arches has to go. A store-keyed predicate would misread this as
-    /// "GPTK active" and leave the 32-bit bad pairing in place.
-    func testStaleStoreRemovesResidueFromBothArches() throws {
+    /// "GPTK active" and leave the 32-bit bad pairing in place. What replaces
+    /// the residue is the runtime's own marked builtin, never an empty slot:
+    /// wine's loader only finds a builtin through that placeholder (#163).
+    func testStaleStoreReplacesResidueWithBuiltinInBothArches() throws {
         try writeOriginals(builtinFake("stale-original"))
         try nativeFake("dxmt-64").write(to: dxgi("system32"))
         try nativeFake("dxmt-32").write(to: dxgi("syswow64"))
 
-        Wine.reconcileDXGIForDXVK(
+        try Wine.reconcileDXGIForDXVK(
             prefixRoot: prefixRoot,
             gptkOriginalsDXGI: originalsDXGI,
-            gptkPayloadIsDeployed: false
+            gptkPayloadIsDeployed: false,
+            libraryFolder: makeRuntime()
         )
 
-        XCTAssertFalse(exists(dxgi("system32")))
-        XCTAssertFalse(exists(dxgi("syswow64")))
+        XCTAssertEqual(try Data(contentsOf: dxgi("system32")), builtinFake("builtin-x86_64-windows"))
+        XCTAssertEqual(try Data(contentsOf: dxgi("syswow64")), builtinFake("builtin-i386-windows"))
+        XCTAssertFalse(try Wine.isNativePE(dxgi("system32")))
+        XCTAssertFalse(try Wine.isNativePE(dxgi("syswow64")))
     }
 
     /// Without the payload, wine's builtin-marked placeholder must survive a
@@ -193,7 +198,8 @@ final class WineDXVKResidueTests: XCTestCase {
         Wine.reconcileDXGIForDXVK(
             prefixRoot: prefixRoot,
             gptkOriginalsDXGI: originalsDXGI,
-            gptkPayloadIsDeployed: false
+            gptkPayloadIsDeployed: false,
+            libraryFolder: noRuntime
         )
 
         XCTAssertTrue(exists(dxgi("system32")))
@@ -212,5 +218,48 @@ final class WineDXVKResidueTests: XCTestCase {
         )
 
         XCTAssertEqual(try Data(contentsOf: dxgi("system32")), builtinFake("wine-fake"))
+    }
+
+    // MARK: - Placeholder restore
+
+    /// A runtime folder holding no builtins: removal then has nothing to put
+    /// back, which is the behaviour the removal tests above pin down.
+    private var noRuntime: URL { tempDir.appending(path: "no-runtime") }
+
+    /// A runtime folder laid out like an installed WhiskyWine, carrying a
+    /// marked builtin dxgi for each arch.
+    private func makeRuntime() throws -> URL {
+        let root = tempDir.appending(path: "runtime")
+        for arch in ["x86_64-windows", "i386-windows"] {
+            let dir = root.appending(path: "Wine/lib/wine/\(arch)")
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try builtinFake("builtin-\(arch)").write(to: dir.appending(path: "dxgi.dll"))
+        }
+        return root
+    }
+
+    /// Wine's loader only reaches a builtin through its system32 placeholder,
+    /// so clearing residue must leave the runtime's own marked copy behind,
+    /// not an empty slot that makes `dxgi.dll` unloadable (#163).
+    func testRemovedResidueIsReplacedByBuiltinPlaceholder() throws {
+        try nativeFake("dxmt64").write(to: dxgi("system32"))
+        try nativeFake("dxmt32").write(to: dxgi("syswow64"))
+
+        try Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, libraryFolder: makeRuntime())
+
+        XCTAssertEqual(try Data(contentsOf: dxgi("system32")), builtinFake("builtin-x86_64-windows"))
+        XCTAssertEqual(try Data(contentsOf: dxgi("syswow64")), builtinFake("builtin-i386-windows"))
+        XCTAssertFalse(try Wine.isNativePE(dxgi("system32")))
+        XCTAssertFalse(try Wine.isNativePE(dxgi("syswow64")))
+    }
+
+    /// A marked builtin already in place is the correct state and is not
+    /// rewritten, so a good bottle stays off the prefix-mutation path.
+    func testExistingBuiltinPlaceholderIsNotRewritten() throws {
+        try builtinFake("already-there").write(to: dxgi("system32"))
+
+        try Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, libraryFolder: makeRuntime())
+
+        XCTAssertEqual(try Data(contentsOf: dxgi("system32")), builtinFake("already-there"))
     }
 }

--- a/WhiskyKit/Tests/WhiskyKitTests/WineDXVKResidueTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WineDXVKResidueTests.swift
@@ -68,7 +68,7 @@ final class WineDXVKResidueTests: XCTestCase {
         let bystander = prefixRoot.appending(path: "drive_c/windows/system32/d3d11.dll")
         try nativeFake("dxvk-d3d11").write(to: bystander)
 
-        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, gptkOriginalsDXGI: originalsDXGI)
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot)
 
         XCTAssertFalse(exists(dxgi("system32")))
         XCTAssertFalse(exists(dxgi("syswow64")))
@@ -80,22 +80,7 @@ final class WineDXVKResidueTests: XCTestCase {
     func testBuiltinMarkedDXGIIsKept() throws {
         try builtinFake("wine-fake").write(to: dxgi("system32"))
 
-        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, gptkOriginalsDXGI: originalsDXGI)
-
-        XCTAssertTrue(exists(dxgi("system32")))
-    }
-
-    /// With GPTK originals present the builtin behind `,b` is Apple's
-    /// forwarder, so the removal must stand down and leave the prefix to the
-    /// originals-aware path.
-    func testNativeDXGIIsKeptWhenGPTKOriginalsExist() throws {
-        try FileManager.default.createDirectory(
-            at: originalsDXGI.deletingLastPathComponent(), withIntermediateDirectories: true
-        )
-        try builtinFake("backed-up-original").write(to: originalsDXGI)
-        try nativeFake("dxmt-64").write(to: dxgi("system32"))
-
-        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, gptkOriginalsDXGI: originalsDXGI)
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot)
 
         XCTAssertTrue(exists(dxgi("system32")))
     }
@@ -103,7 +88,7 @@ final class WineDXVKResidueTests: XCTestCase {
     /// A prefix that never saw DXMT has no dxgi.dll of its own; the removal
     /// must be a silent no-op.
     func testMissingDXGIIsANoOp() {
-        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, gptkOriginalsDXGI: originalsDXGI)
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot)
 
         XCTAssertFalse(exists(dxgi("system32")))
         XCTAssertFalse(exists(dxgi("syswow64")))
@@ -115,8 +100,117 @@ final class WineDXVKResidueTests: XCTestCase {
     func testTruncatedFileIsLeftAlone() throws {
         try Data("stub".utf8).write(to: dxgi("system32"))
 
-        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, gptkOriginalsDXGI: originalsDXGI)
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot)
 
         XCTAssertTrue(exists(dxgi("system32")))
+    }
+
+    // MARK: - Reconciliation against the GPTK payload
+
+    private func writeOriginals(_ contents: Data) throws {
+        try FileManager.default.createDirectory(
+            at: originalsDXGI.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try contents.write(to: originalsDXGI)
+    }
+
+    private func markerWindow(_ url: URL) throws -> Data {
+        try Data(contentsOf: url).subdata(in: 0x40 ..< 0x50)
+    }
+
+    /// With the payload deployed the builtin is Apple's forwarder, so the
+    /// stored original is installed and its builtin marker stripped, leaving a
+    /// file the loader takes as a true native PE.
+    func testDeployedPayloadInstallsStrippedOriginal() throws {
+        try writeOriginals(builtinFake("stored-original"))
+
+        Wine.reconcileDXGIForDXVK(
+            prefixRoot: prefixRoot,
+            gptkOriginalsDXGI: originalsDXGI,
+            gptkPayloadIsDeployed: true
+        )
+
+        XCTAssertTrue(exists(dxgi("system32")))
+        XCTAssertNotEqual(try markerWindow(dxgi("system32")), Data("Wine builtin DLL".utf8))
+        XCTAssertTrue(try Wine.isNativePE(dxgi("system32")))
+    }
+
+    /// The deploy replaces DXMT residue rather than leaving it behind.
+    func testDeployedPayloadReplacesExistingResidue() throws {
+        try writeOriginals(builtinFake("stored-original"))
+        try nativeFake("dxmt-64").write(to: dxgi("system32"))
+
+        Wine.reconcileDXGIForDXVK(
+            prefixRoot: prefixRoot,
+            gptkOriginalsDXGI: originalsDXGI,
+            gptkPayloadIsDeployed: true
+        )
+
+        XCTAssertTrue(try Wine.isNativePE(dxgi("system32")))
+        XCTAssertNotEqual(try Data(contentsOf: dxgi("system32")), nativeFake("dxmt-64"))
+    }
+
+    /// GPTK deploys forwarders into `x86_64-windows` only, so the 32-bit
+    /// builtin is still wine's own and the stored 64-bit original must not be
+    /// written into syswow64.
+    func testDeployedPayloadLeavesSysWOW64Alone() throws {
+        try writeOriginals(builtinFake("stored-original"))
+
+        Wine.reconcileDXGIForDXVK(
+            prefixRoot: prefixRoot,
+            gptkOriginalsDXGI: originalsDXGI,
+            gptkPayloadIsDeployed: true
+        )
+
+        XCTAssertFalse(exists(dxgi("syswow64")))
+    }
+
+    /// The stale-store case: `originals/` survives from a previous engine but
+    /// the payload is gone, so the builtin is wine's own again and residue in
+    /// *both* arches has to go. A store-keyed predicate would misread this as
+    /// "GPTK active" and leave the 32-bit bad pairing in place.
+    func testStaleStoreRemovesResidueFromBothArches() throws {
+        try writeOriginals(builtinFake("stale-original"))
+        try nativeFake("dxmt-64").write(to: dxgi("system32"))
+        try nativeFake("dxmt-32").write(to: dxgi("syswow64"))
+
+        Wine.reconcileDXGIForDXVK(
+            prefixRoot: prefixRoot,
+            gptkOriginalsDXGI: originalsDXGI,
+            gptkPayloadIsDeployed: false
+        )
+
+        XCTAssertFalse(exists(dxgi("system32")))
+        XCTAssertFalse(exists(dxgi("syswow64")))
+    }
+
+    /// Without the payload, wine's builtin-marked placeholder must survive a
+    /// DXVK launch: deleting it is a per-launch prefix mutation wineboot only
+    /// has to undo.
+    func testNotDeployedKeepsBuiltinPlaceholder() throws {
+        try builtinFake("wine-fake").write(to: dxgi("system32"))
+
+        Wine.reconcileDXGIForDXVK(
+            prefixRoot: prefixRoot,
+            gptkOriginalsDXGI: originalsDXGI,
+            gptkPayloadIsDeployed: false
+        )
+
+        XCTAssertTrue(exists(dxgi("system32")))
+        XCTAssertEqual(try Data(contentsOf: dxgi("system32")), builtinFake("wine-fake"))
+    }
+
+    /// A deployed payload with no stored dxgi backup has nothing to install;
+    /// the prefix is left as-is rather than emptied.
+    func testDeployedPayloadWithoutStoredOriginalIsANoOp() throws {
+        try builtinFake("wine-fake").write(to: dxgi("system32"))
+
+        Wine.reconcileDXGIForDXVK(
+            prefixRoot: prefixRoot,
+            gptkOriginalsDXGI: originalsDXGI,
+            gptkPayloadIsDeployed: true
+        )
+
+        XCTAssertEqual(try Data(contentsOf: dxgi("system32")), builtinFake("wine-fake"))
     }
 }


### PR DESCRIPTION
builds on #253. #248 was already closed by that merge, so this does not carry a fixes line; it finishes the gptk half of the same dxgi problem (#163).

### problem
dxvk-macos ships no `dxgi.dll` and relies on wine's dxgi implementation. when d3dmetal is deployed into the wine runtime, the builtin `dxgi.dll` becomes apple's forwarder. steam's cef gpu process under dxvk then pairs dxvk's native `d3d11.dll` with that forwarder, swapchain creation fails, and the client crash-loops into a black window.

copying wine's clean `dxgi.dll` into `system32` does not help on its own: it still carries the 16-byte `"Wine builtin DLL"` marker at `0x40`, so the loader treats it as a builtin and redirects back to the forwarder.

#253 handles the other direction (payload absent, dxmt residue in the prefix). before this pr the two were stacked: a blind `removeItem` on system32 followed by a deploy, which deleted wine's builtin-marked placeholder on every dxvk launch and never touched syswow64.

### fix
`enableDXVK` now runs one step, `reconcileDXGIForDXVK(prefixRoot:gptkOriginalsDXGI:gptkPayloadIsDeployed:)`, keyed on whether the gptk payload is deployed:

- deployed: install the backed-up original from `originals/` into `system32` and strip the marker at `0x40` so wine loads it as a true native pe under `n,b`. only system32 is written; gptk deploys forwarders into `x86_64-windows` only, so the 32-bit builtin is still wine's own.
- not deployed: call #253's `removeStaleNativeDXGI(prefixRoot:)`, which sweeps both arches and skips anything builtin-marked, then put the runtime's own marked `dxgi.dll` back into the slot it emptied. wine's loader only reaches a builtin through its system32 placeholder (`find_builtin_without_file` in `ntdll/loader.c` refuses every non-16-bit dll that has no file outside prefix bootstrap), so an empty slot makes `LoadLibrary("dxgi.dll")` fail in every process. that is the black store, community and profile on v4.6.4 in #163: chromium's gpu process cannot bring up d3d11 and crash-loops into software. the copy is what wineboot installs, so `n,b` still defers to the builtin, and a marked file already in place is left alone.

the predicate is the payload, not the store. `originals/` outlives an engine install and the payload does not, so a stale store from a previous engine would otherwise read as "gptk active" and deploy a dxgi the current runtime never shipped. the store path and payload predicate are injectable parameters with production defaults; `removeStaleNativeDXGI` loses its store guard and parameter since the caller owns that decision now.

`removeCleanDXGIForDXVK` is dropped. it had no caller, and the next dxvk launch reconciles the prefix anyway.

### also in this pr
`disablingNVAPI` now clears `nvapi` and `nvngx` alongside `nvapi64`, so launcher helper processes get every nvidia bridge dll disabled rather than just the 64-bit nvapi one. `NVAPIBridgeTests` updated to match.

### tests
eight cases in `WineDXVKResidueTests` drive `reconcileDXGIForDXVK` and `removeStaleNativeDXGI` directly: deployed installs the stripped original, deployed replaces existing residue, deployed leaves syswow64 alone, stale store replaces residue with the builtin in both arches, not-deployed keeps the builtin placeholder, deployed without a stored original is a no-op, removed residue is replaced by the builtin placeholder, and an existing placeholder is not rewritten. the removal tests inject a runtime folder rather than reading the installed one. the old `testNativeDXGIIsKeptWhenGPTKOriginalsExist` is replaced by the stale-store case, since that state now takes the removal path by design.
