### PR TITLE
fix(graphics): resolve launchers to DXVK on every runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- The Recommended graphics backend now resolves launchers (Steam and other
+  Chromium-based clients) to DXVK on every runtime. Previously a runtime
+  without the D3DMetal payload resolved launchers to DXMT, whose Direct3D
+  layer launcher UIs cannot render on, leaving the client running with no
+  window (#163).
 - Enabling DXVK now removes a stale native dxgi.dll that a previous DXMT
   launch left in the bottle's system directories. The leftover paired
   DXVK's d3d11 with DXMT's dxgi, which cannot create window swapchains,

--- a/WhiskyKit/Sources/WhiskyKit/Wine/GraphicsBackendResolver.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/GraphicsBackendResolver.swift
@@ -35,6 +35,8 @@ public enum GraphicsBackendResolver {
     /// the runtime bundles it, otherwise DXVK, which ships with every runtime.
     ///
     /// - Parameters:
+    ///   - launcher: The launcher this launch targets, if any. Launchers always
+    ///     resolve to DXVK: their Chromium UIs cannot render on D3DMetal or DXMT.
     ///   - macOSVersion: The macOS version to consider. Defaults to the running system.
     ///   - runtimeInfo: The runtime record to consider. Defaults to the installed
     ///     runtime's version plist.
@@ -50,13 +52,15 @@ public enum GraphicsBackendResolver {
         d3dMetalInstalled: Bool = WhiskyWineInstaller.isD3DMetalInstalled(),
         dxmtRuntimeNative: Bool = Wine.isDXMTRuntimeNative()
     ) -> GraphicsBackend {
+        // Launcher clients are Chromium and cannot render on D3DMetal or DXMT:
+        // the CEF gpu process fails to create its window swapchain and the
+        // client shows no window (or a black one). DXVK is the one backend
+        // their UIs render on, so a launcher gets it regardless of what else
+        // is installed. Games a launcher starts still resolve below.
+        if launcher != nil {
+            return .dxvk
+        }
         if d3dMetalInstalled {
-            // Launcher clients are Chromium and cannot render on D3DMetal:
-            // the window comes up and never paints. Games they start still get
-            // D3DMetal.
-            if launcher != nil {
-                return .dxvk
-            }
             return .d3dMetal
         }
         // The same gate the backend picker applies, not the version record

--- a/WhiskyKit/Tests/WhiskyKitTests/BackendResolverLauncherTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/BackendResolverLauncherTests.swift
@@ -16,6 +16,7 @@
 //  If not, see https://www.gnu.org/licenses/.
 //
 
+import SemanticVersion
 @testable import WhiskyKit
 import XCTest
 
@@ -39,11 +40,37 @@ final class BackendResolverLauncherTests: XCTestCase {
         }
     }
 
-    /// Without D3DMetal there is nothing to steer around, so a launcher
-    /// resolves exactly like anything else.
-    func testLauncherIsNotSpecialWithoutD3DMetal() {
-        let game = GraphicsBackendResolver.resolve(for: nil, d3dMetalInstalled: false)
-        let launcher = GraphicsBackendResolver.resolve(for: .steam, d3dMetalInstalled: false)
+    /// DXMT is just as unrenderable for Chromium as D3DMetal, so on a runtime
+    /// that would recommend DXMT a launcher still gets DXVK. This is the
+    /// payload-less default install: without the steer, the first Steam launch
+    /// deploys DXMT and the client never shows a window.
+    func testLauncherGetsDXVKWhenDXMTWouldBeRecommended() {
+        let runtime = WhiskyWineVersion(version: SemanticVersion(3, 1, 1), dxmtVersion: "0.80")
+        XCTAssertEqual(
+            GraphicsBackendResolver.resolve(
+                for: nil, runtimeInfo: runtime, d3dMetalInstalled: false, dxmtRuntimeNative: true
+            ),
+            .dxmt
+        )
+        XCTAssertEqual(
+            GraphicsBackendResolver.resolve(
+                for: .steam, runtimeInfo: runtime, d3dMetalInstalled: false, dxmtRuntimeNative: true
+            ),
+            .dxvk
+        )
+    }
+
+    /// With neither D3DMetal nor DXMT the answer is DXVK for everyone, so the
+    /// steer changes nothing there.
+    func testLauncherAndGameAgreeWhenOnlyDXVKExists() {
+        let runtime = WhiskyWineVersion(version: SemanticVersion(3, 0, 0))
+        let game = GraphicsBackendResolver.resolve(
+            for: nil, runtimeInfo: runtime, d3dMetalInstalled: false
+        )
+        let launcher = GraphicsBackendResolver.resolve(
+            for: .steam, runtimeInfo: runtime, d3dMetalInstalled: false
+        )
+        XCTAssertEqual(game, .dxvk)
         XCTAssertEqual(game, launcher)
     }
 


### PR DESCRIPTION
### Problem
`GraphicsBackendResolver.resolve(for:)` only diverted launchers to DXVK inside the `d3dMetalInstalled` branch. On a runtime without the D3DMetal payload (every default install of the new engine line), a Steam launch resolved to DXMT. Chromium cannot render on DXMT any more than on D3DMetal: the CEF gpu process fails to create its window swapchain (`SwapChain11.cpp:636`, `HRESULT: 0x80004005`, `eglCreateWindowSurface: EGL_BAD_ALLOC`) and the client runs headless with no window. Confirmed twice on clean bottle clones against `v4.6.4-beta.1`; full investigation on #163.

The DXMT launch also deploys a native `dxgi.dll` into the prefix that later poisons DXVK launches; that residue is a separate fix in the follow-up PR.

### Fix
The launcher check moves to the top of `resolve(for:)`: a launcher always gets DXVK, regardless of what else is installed. Games a launcher starts are unaffected (the steer keys on the launched executable).

### Tests
`testLauncherIsNotSpecialWithoutD3DMetal` asserted the buggy behavior and is replaced by `testLauncherGetsDXVKWhenDXMTWouldBeRecommended` (game resolves DXMT, launcher resolves DXVK on the same runtime) and `testLauncherAndGameAgreeWhenOnlyDXVKExists`. Full kit suite passes.

Part of #163.
