### PR TITLE
fix(dxvk): remove stale native dxgi.dll left by a DXMT launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Enabling DXVK now removes a stale native dxgi.dll that a previous DXMT
+  launch left in the bottle's system directories. The leftover paired
+  DXVK's d3d11 with DXMT's dxgi, which cannot create window swapchains,
+  leaving Chromium-based launchers such as Steam running with no window
+  after a switch from DXMT to DXVK (#163).
+
 ## [3.7.0] - 2026-08-29 (App)
 
 ### Added

--- a/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
+++ b/WhiskyKit/Sources/WhiskyKit/Wine/Wine.swift
@@ -693,6 +693,47 @@ public class Wine {
             in: bottle.url.appending(path: "drive_c").appending(path: "windows").appending(path: "syswow64"),
             withContentsIn: Wine.dxvkFolder.appending(path: "x32")
         )
+        removeStaleNativeDXGI(prefixRoot: bottle.url)
+    }
+
+    /// Removes a stale native `dxgi.dll` that a DXMT deploy left in the prefix.
+    ///
+    /// DXVK-macOS ships no `dxgi.dll`, so ``enableDXVK(bottle:)`` never
+    /// overwrites one. After a bottle has launched under DXMT, its system
+    /// directories hold DXMT's *native* dxgi, and a DXVK launch then pairs
+    /// DXVK's `d3d11` with DXMT's `dxgi` under the `n,b` override. That mix
+    /// cannot create window swapchains: Chromium clients fail with
+    /// `DXGI_ERROR_UNSUPPORTED` and run with no window at all. Removing the
+    /// leftover lets the `,b` half of the override load the builtin, which is
+    /// the pairing DXVK is written against.
+    ///
+    /// Only the GPTK-less case is handled here: when the importer's
+    /// `originals/` backup exists, the builtin behind `,b` is Apple's
+    /// forwarder and the prefix needs a clean native copy instead, which is
+    /// its own change. A builtin-marked file is never touched: that is wine's
+    /// own fake DLL, exactly what DXVK expects to defer to.
+    static func removeStaleNativeDXGI(
+        prefixRoot: URL,
+        gptkOriginalsDXGI: URL = GPTKImporter.storeFolder
+            .appending(path: "originals").appending(path: "dxgi.dll")
+    ) {
+        let fileManager = FileManager.default
+        guard !fileManager.fileExists(atPath: gptkOriginalsDXGI.path(percentEncoded: false)) else { return }
+        for dir in ["system32", "syswow64"] {
+            let dxgi = prefixRoot.appending(path: "drive_c").appending(path: "windows")
+                .appending(path: dir).appending(path: "dxgi.dll")
+            guard fileManager.fileExists(atPath: dxgi.path(percentEncoded: false)),
+                  (try? isNativePE(dxgi)) == true
+            else { continue }
+            do {
+                try fileManager.removeItem(at: dxgi)
+                Logger.wineKit.info("Removed stale native dxgi.dll from \(dir, privacy: .public)")
+            } catch {
+                Logger.wineKit.warning(
+                    "Could not remove stale native dxgi.dll: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
     }
 
     /// Errors thrown by ``enableDXMT(bottle:)``.

--- a/WhiskyKit/Tests/WhiskyKitTests/WineDXVKResidueTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WineDXVKResidueTests.swift
@@ -1,0 +1,122 @@
+//
+//  WineDXVKResidueTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+@testable import WhiskyKit
+import XCTest
+
+final class WineDXVKResidueTests: XCTestCase {
+    private var tempDir: URL!
+    private var prefixRoot: URL!
+    private var originalsDXGI: URL!
+
+    /// A markerless (native) PE stub: the 16 bytes at 0x40 are not the
+    /// builtin signature, so `Wine.isNativePE` classifies it as native.
+    private func nativeFake(_ tag: String) -> Data {
+        Data(count: 0x40) + Data(tag.utf8) + Data(count: 16)
+    }
+
+    /// A PE stub carrying winebuild's "Wine builtin DLL" signature at 0x40.
+    private func builtinFake(_ tag: String) -> Data {
+        Data(count: 0x40) + Data("Wine builtin DLL".utf8) + Data(tag.utf8)
+    }
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        prefixRoot = tempDir.appending(path: "bottle")
+        // An originals path that does not exist unless a test creates it.
+        originalsDXGI = tempDir.appending(path: "store/originals/dxgi.dll")
+        for dir in ["system32", "syswow64"] {
+            try FileManager.default.createDirectory(
+                at: prefixRoot.appending(path: "drive_c/windows/\(dir)"),
+                withIntermediateDirectories: true
+            )
+        }
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func dxgi(_ dir: String) -> URL {
+        prefixRoot.appending(path: "drive_c/windows/\(dir)/dxgi.dll")
+    }
+
+    private func exists(_ url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path(percentEncoded: false))
+    }
+
+    /// The regression this guards: a DXMT launch leaves its native dxgi in
+    /// both system directories, and the next DXVK launch must clear them.
+    func testNativeResidueIsRemovedFromBothArches() throws {
+        try nativeFake("dxmt-64").write(to: dxgi("system32"))
+        try nativeFake("dxmt-32").write(to: dxgi("syswow64"))
+        let bystander = prefixRoot.appending(path: "drive_c/windows/system32/d3d11.dll")
+        try nativeFake("dxvk-d3d11").write(to: bystander)
+
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, gptkOriginalsDXGI: originalsDXGI)
+
+        XCTAssertFalse(exists(dxgi("system32")))
+        XCTAssertFalse(exists(dxgi("syswow64")))
+        XCTAssertTrue(exists(bystander), "only dxgi.dll may be touched")
+    }
+
+    /// Wine's own fake DLL carries the builtin marker and must stay: it is
+    /// what redirects the loader to the builtin DXVK pairs with.
+    func testBuiltinMarkedDXGIIsKept() throws {
+        try builtinFake("wine-fake").write(to: dxgi("system32"))
+
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, gptkOriginalsDXGI: originalsDXGI)
+
+        XCTAssertTrue(exists(dxgi("system32")))
+    }
+
+    /// With GPTK originals present the builtin behind `,b` is Apple's
+    /// forwarder, so the removal must stand down and leave the prefix to the
+    /// originals-aware path.
+    func testNativeDXGIIsKeptWhenGPTKOriginalsExist() throws {
+        try FileManager.default.createDirectory(
+            at: originalsDXGI.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try builtinFake("backed-up-original").write(to: originalsDXGI)
+        try nativeFake("dxmt-64").write(to: dxgi("system32"))
+
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, gptkOriginalsDXGI: originalsDXGI)
+
+        XCTAssertTrue(exists(dxgi("system32")))
+    }
+
+    /// A prefix that never saw DXMT has no dxgi.dll of its own; the removal
+    /// must be a silent no-op.
+    func testMissingDXGIIsANoOp() {
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, gptkOriginalsDXGI: originalsDXGI)
+
+        XCTAssertFalse(exists(dxgi("system32")))
+        XCTAssertFalse(exists(dxgi("syswow64")))
+    }
+
+    /// A file too short to hold the marker window is not classified native
+    /// (`isNativePE` fails closed), so a truncated stray survives rather than
+    /// being mistaken for DXMT residue.
+    func testTruncatedFileIsLeftAlone() throws {
+        try Data("stub".utf8).write(to: dxgi("system32"))
+
+        Wine.removeStaleNativeDXGI(prefixRoot: prefixRoot, gptkOriginalsDXGI: originalsDXGI)
+
+        XCTAssertTrue(exists(dxgi("system32")))
+    }
+}


### PR DESCRIPTION
### Problem
`enableDXMT` deploys a native `dxgi.dll` into the bottle's system directories. DXVK ships no `dxgi.dll`, so `enableDXVK` never replaces it, and after a switch from DXMT to DXVK the bottle pairs DXVK's `d3d11` with DXMT's `dxgi` under the `n,b` override. That mix cannot create window swapchains: Chromium clients log `SwapChain11.cpp:636 ... HRESULT: 0x887A0004` and `eglCreateWindowSurface: EGL_BAD_ALLOC`, and the Steam client runs with no window at all. Combined with the resolver gap fixed in #252 (first launch of a launcher auto-picks DXMT on payload-less runtimes), this is why a default-install Steam bottle on the new engine line looked completely dead.

Verified bidirectionally on real bottle clones against `v4.6.4-beta.1`: a clean clone works, planting DXMT's `dxgi.dll` into `system32` reproduces the failure on the very next launch, and restoring the builtin-marked file brings the main window back. Reproduced twice on independent clones; full investigation on #163.

### Fix
`enableDXVK` now ends by removing a markerless (native) `dxgi.dll` from `system32` and `syswow64`, letting the `,b` half of the override load wine's builtin, which is the pairing DXVK is written against. Two deliberate stand-downs: builtin-marked files are never touched (wine's own fake DLL), and the removal is skipped entirely when the GPTK importer's `originals/` backup exists, because the builtin is then Apple's forwarder and the prefix needs a clean native copy instead; #251 owns that case and the two changes compose.

### Tests
`WineDXVKResidueTests`: residue removed from both arches with bystanders untouched, builtin-marked file kept, native file kept when GPTK originals exist, missing file no-op, truncated stray left alone (`isNativePE` fails closed). Full kit suite passes.

Part of #163.
